### PR TITLE
Add the abilty to overwrite the version during the build and print version cli options

### DIFF
--- a/src/components/status_bar.rs
+++ b/src/components/status_bar.rs
@@ -43,7 +43,7 @@ impl Component for StatusBar {
     fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
         let s = &self.theme.status_bar;
         let r = &self.theme.repo_list;
-        let version_text = format!("v{} ", env!("CARGO_PKG_VERSION"));
+        let version_text = format!("v{} ", gitpane::VERSION);
         let version_len = version_text.len() as u16;
         let chunks =
             Layout::horizontal([Constraint::Fill(1), Constraint::Length(version_len)]).split(area);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,5 +16,12 @@
 //!
 //! The public library surface is intentionally small.
 
-/// The crate version from `Cargo.toml`.
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+/// The current gitpane version.
+///
+/// Uses `GITPANE_BUILD_OVERWRITE_VERSION` when set at build time,
+/// otherwise falls back to `CARGO_PKG_VERSION`.
+pub const VERSION: &str = match option_env!("GITPANE_BUILD_OVERWRITE_VERSION") {
+    Some(v) => v,
+    None => env!("CARGO_PKG_VERSION"),
+};
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,13 @@
 /// Uses `GITPANE_BUILD_OVERWRITE_VERSION` when set at build time,
 /// otherwise falls back to `CARGO_PKG_VERSION`.
 pub const VERSION: &str = match option_env!("GITPANE_BUILD_OVERWRITE_VERSION") {
-    Some(v) => v,
+    Some(v) => {
+        if v.is_empty() {
+            // fallback to the `CARGO_PKG_VERSION`
+            env!("CARGO_PKG_VERSION")
+        } else {
+            v
+        }
+    }
     None => env!("CARGO_PKG_VERSION"),
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,4 +24,3 @@ pub const VERSION: &str = match option_env!("GITPANE_BUILD_OVERWRITE_VERSION") {
     Some(v) => v,
     None => env!("CARGO_PKG_VERSION"),
 };
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,15 +148,23 @@ fn run_diagnostic(root: Option<PathBuf>, theme_override: Option<&str>) -> Result
     let report = diagnostic::render(
         &config,
         &repos,
-        diagnostic::RuntimeInfo::current(env!("CARGO_PKG_VERSION")),
+        diagnostic::RuntimeInfo::current(gitpane::VERSION),
     );
     print!("{report}");
     Ok(())
 }
 
 fn self_update() -> Result<()> {
-    let current = env!("CARGO_PKG_VERSION");
-    println!("gitpane v{current} — checking for updates...");
+    let base = env!("CARGO_PKG_VERSION");
+    println!("gitpane v{} — checking for updates...", gitpane::VERSION);
+    if gitpane::VERSION != base {
+        println!(
+            "note: this build sets a custom version; update checks use the base version {base}"
+        );
+        println!(
+            "note: `gitpane update` runs `cargo install gitpane` and may replace a package-managed binary"
+        );
+    }
 
     if let Some(latest) = update_checker::check_latest() {
         println!("New version available: v{latest}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use color_eyre::Result;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
-#[command(name = "gitpane", about = "Multi-repo Git workspace dashboard")]
+#[command(name = "gitpane", about = "Multi-repo Git workspace dashboard", version = gitpane::VERSION)]
 struct Cli {
     /// Root directory to scan for repos
     #[arg(long)]


### PR DESCRIPTION
Hi,
In some cases you may want to append a custom string to the version that cargo would normally reject. e.g. git hash

a simple solution is that we allow the builder from setting an environment variable (`GITPANE_BUILD_OVERWRITE_VERSION`) and use it when available and use `CARGO_PKG_VERSION` otherwise

something a package like [1] could make use of, and provide a more accurate build that outputs the version+commit of the build.

Also added `-V` and `--version`  to the command-line options to print the version

[1]: https://aur.archlinux.org/packages/gitpane-git