### PR TITLE
feat: clearer UX when the git binary is missing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -517,6 +517,16 @@ impl App {
             });
         }
 
+        // Warn once if the `git` binary is missing. gitpane reads repo state
+        // via libgit2, so it still runs, but fetch/pull/submodule/diff actions
+        // shell out to `git` and would otherwise fail with a cryptic OS error.
+        if !crate::git::git_available() {
+            self.action_tx.send(Action::Error(
+                "git not found on PATH: viewing works, but fetch/pull and submodule actions need git"
+                    .to_string(),
+            ))?;
+        }
+
         // Auto-select the first repo (graph loads once status arrives)
         self.sync_selection();
 
@@ -1052,7 +1062,7 @@ impl App {
                                         let _ = tx.send(Action::Error(format!(
                                             "git {} failed: {}",
                                             git_args.join(" "),
-                                            e
+                                            crate::git::describe_spawn_error(&e)
                                         )));
                                         let _ = tx.send(Action::RefreshRepo(repo_id));
                                     }
@@ -1126,7 +1136,7 @@ impl App {
                                         let _ = tx.send(Action::Error(format!(
                                             "git {} failed: {}",
                                             git_args.join(" "),
-                                            e
+                                            crate::git::describe_spawn_error(&e)
                                         )));
                                         let _ = tx.send(Action::RefreshRepo(repo_id));
                                     }
@@ -1230,7 +1240,10 @@ impl App {
                                                 }
                                             }
                                             Err(e) => {
-                                                format!("Failed to get submodule diff: {}", e)
+                                                format!(
+                                                    "Failed to get submodule diff: {}",
+                                                    crate::git::describe_spawn_error(&e)
+                                                )
                                             }
                                         };
                                         let _ = tx.send(Action::DiffLoaded {
@@ -1261,7 +1274,10 @@ impl App {
                                                     text
                                                 }
                                             }
-                                            Err(e) => format!("Failed to get submodule log: {}", e),
+                                            Err(e) => format!(
+                                                "Failed to get submodule log: {}",
+                                                crate::git::describe_spawn_error(&e)
+                                            ),
                                         };
                                         let _ = tx.send(Action::DiffLoaded {
                                             generation: diff_gen,
@@ -1317,7 +1333,10 @@ impl App {
                                         Err(e) => {
                                             let _ = tx.send(Action::DiffLoaded {
                                                 generation: diff_gen,
-                                                content: format!("Failed to get diff: {}", e),
+                                                content: format!(
+                                                    "Failed to get diff: {}",
+                                                    crate::git::describe_spawn_error(&e)
+                                                ),
                                             });
                                         }
                                     }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -3,3 +3,57 @@ pub(crate) mod graph;
 pub(crate) mod graph_render;
 pub(crate) mod scanner;
 pub(crate) mod status;
+
+use std::io;
+use std::sync::OnceLock;
+
+/// Turn a process-spawn error into a user-facing string, special-casing a
+/// missing `git` binary. Without this the status bar shows a raw
+/// `No such file or directory (os error 2)`, which gives no hint that the
+/// real problem is that `git` is not installed.
+pub(crate) fn describe_spawn_error(e: &io::Error) -> String {
+    if e.kind() == io::ErrorKind::NotFound {
+        "git is not installed or not on PATH".to_string()
+    } else {
+        e.to_string()
+    }
+}
+
+/// Whether the `git` executable is available on PATH. Probed once (via
+/// `git --version`) and cached for the process lifetime.
+///
+/// gitpane reads all repo state through libgit2, so a missing binary does not
+/// stop it from running; it only disables the CLI-backed actions (fetch,
+/// pull, submodule operations, and diffs).
+pub(crate) fn git_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        std::process::Command::new("git")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn describe_spawn_error_flags_missing_git() {
+        let err = io::Error::new(io::ErrorKind::NotFound, "No such file or directory");
+        assert_eq!(
+            describe_spawn_error(&err),
+            "git is not installed or not on PATH"
+        );
+    }
+
+    #[test]
+    fn describe_spawn_error_passes_through_other_errors() {
+        let err = io::Error::new(io::ErrorKind::PermissionDenied, "permission denied");
+        assert_eq!(describe_spawn_error(&err), "permission denied");
+    }
+}


### PR DESCRIPTION
## What

gitpane reads all repo state through libgit2, so it runs fine without the `git` binary. The CLI-backed actions (fetch, pull, submodule operations, diffs) do shell out to `git`, and previously a missing binary surfaced as a cryptic `No such file or directory (os error 2)`.

This makes the missing-`git` case clear:

- **`git::describe_spawn_error`** maps a missing-binary spawn error (`NotFound`) to `git is not installed or not on PATH`, used in every action error arm (pull/push, submodule update, submodule diff/log, file diff).
- **`git::git_available`** is a cached `git --version` probe.
- A **one-time startup toast** when `git` is absent: `git not found on PATH: viewing works, but fetch/pull and submodule actions need git`.

## Why

Follow-up to the git-dependency discussion in #5. The test that hard-required `git` is already fixed on `main` (it now skips cleanly without `git`); this improves the *runtime* experience for the same git-less environments.

## Testing

- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-targets --all-features` all pass (218 tests).
- New unit tests for `describe_spawn_error` (NotFound maps to the friendly message, other errors pass through) run without `git` installed.

Relates to #5.
