### PR TITLE
feat(submodule): show branch and warn when a pinned commit needs merging to the default branch

### DIFF
--- a/src/components/file_list.rs
+++ b/src/components/file_list.rs
@@ -12,7 +12,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::action::Action;
 use crate::components::Component;
-use crate::git::status::{FileEntry, FileStatus, SubmoduleState, SubmoduleWarn};
+use crate::git::status::{FileEntry, FileStatus, SubmoduleHead, SubmoduleState, SubmoduleWarn};
 use crate::repo_id::RepoId;
 use crate::theme::{FileListTheme, Theme};
 
@@ -188,6 +188,7 @@ impl FileList {
                 if entry.is_submodule {
                     spans.extend(submodule_tag_spans(
                         &entry.submodule_state,
+                        &entry.submodule_head,
                         &entry.submodule_warn,
                         t,
                     ));
@@ -255,16 +256,19 @@ impl FileList {
     }
 }
 
-/// Build the `[sub: …]` tag spans for a submodule file row.
-/// `state` is independent from `warn` — both can be present and compose.
+/// Build the `[sub: …]` tag spans for a submodule file row. `state`, `head`,
+/// and `warn` are independent and compose, e.g. `[sub: +commit @feature ↑3 ↛main]`.
 fn submodule_tag_spans(
     state: &Option<SubmoduleState>,
+    head: &Option<SubmoduleHead>,
     warn: &SubmoduleWarn,
     theme: &FileListTheme,
 ) -> Vec<Span<'static>> {
     let bracket_style = Style::default().fg(theme.submodule_bracket);
+    let branch_style = Style::default().fg(theme.submodule_branch);
     let unpushed_style = Style::default().fg(theme.submodule_unpushed);
     let unreach_style = Style::default().fg(theme.submodule_unreachable);
+    let merge_style = Style::default().fg(theme.submodule_needs_merge);
 
     let mut inner: Vec<Span<'static>> = Vec::new();
 
@@ -275,28 +279,50 @@ fn submodule_tag_spans(
         None => None,
     };
 
-    // Uninitialized takes precedence: never compose with warn — `sub.open()`
-    // can't introspect the inner repo, so warn fields are zero anyway.
+    // Uninitialized takes precedence: never compose with branch/warn —
+    // `sub.open()` can't introspect the inner repo, so those fields are empty.
     let suppress_warn = matches!(state, Some(SubmoduleState::Uninitialized));
 
     if let Some(label) = state_label {
         inner.push(Span::styled(label, bracket_style));
     }
 
+    // Push a separating space when the tag already has content.
+    fn sep(inner: &mut Vec<Span<'static>>, style: Style) {
+        if !inner.is_empty() {
+            inner.push(Span::styled(" ", style));
+        }
+    }
+
     if !suppress_warn {
+        // Branch indicator: `@feature`, or `@detached` for a detached HEAD.
+        if let Some(h) = head {
+            let label = match h {
+                SubmoduleHead::Branch(name) => format!("@{name}"),
+                SubmoduleHead::Detached => "@detached".to_string(),
+            };
+            sep(&mut inner, bracket_style);
+            inner.push(Span::styled(label, branch_style));
+        }
+
+        // Push/merge warnings. `⚠unreach` (on no remote) dominates; otherwise
+        // `↑N` (ahead of upstream) and `↛main` (not on the default branch)
+        // compose additively.
         if warn.pointer_unreachable {
-            if !inner.is_empty() {
-                inner.push(Span::styled(" ", bracket_style));
-            }
+            sep(&mut inner, bracket_style);
             inner.push(Span::styled("\u{26a0}unreach", unreach_style));
-        } else if warn.unpushed_commits > 0 {
-            if !inner.is_empty() {
-                inner.push(Span::styled(" ", bracket_style));
+        } else {
+            if warn.unpushed_commits > 0 {
+                sep(&mut inner, bracket_style);
+                inner.push(Span::styled(
+                    format!("\u{2191}{}", warn.unpushed_commits),
+                    unpushed_style,
+                ));
             }
-            inner.push(Span::styled(
-                format!("\u{2191}{}", warn.unpushed_commits),
-                unpushed_style,
-            ));
+            if warn.needs_merge_to_default {
+                sep(&mut inner, bracket_style);
+                inner.push(Span::styled("\u{219b}main", merge_style));
+            }
         }
     }
 
@@ -443,9 +469,13 @@ impl Component for FileList {
 mod tag_tests {
     use super::*;
 
-    fn rendered(state: Option<SubmoduleState>, warn: SubmoduleWarn) -> String {
+    fn rendered(
+        state: Option<SubmoduleState>,
+        head: Option<SubmoduleHead>,
+        warn: SubmoduleWarn,
+    ) -> String {
         let theme = FileListTheme::default();
-        submodule_tag_spans(&state, &warn, &theme)
+        submodule_tag_spans(&state, &head, &warn, &theme)
             .iter()
             .map(|s| s.content.as_ref())
             .collect::<String>()
@@ -454,7 +484,11 @@ mod tag_tests {
     #[test]
     fn modified_clean() {
         assert_eq!(
-            rendered(Some(SubmoduleState::Modified), SubmoduleWarn::default()),
+            rendered(
+                Some(SubmoduleState::Modified),
+                None,
+                SubmoduleWarn::default()
+            ),
             "[sub: +commit] "
         );
     }
@@ -467,7 +501,7 @@ mod tag_tests {
             needs_merge_to_default: false,
         };
         assert_eq!(
-            rendered(Some(SubmoduleState::Modified), warn),
+            rendered(Some(SubmoduleState::Modified), None, warn),
             "[sub: +commit \u{2191}3] "
         );
     }
@@ -480,7 +514,7 @@ mod tag_tests {
             needs_merge_to_default: false,
         };
         assert_eq!(
-            rendered(Some(SubmoduleState::Modified), warn),
+            rendered(Some(SubmoduleState::Modified), None, warn),
             "[sub: +commit \u{26a0}unreach] "
         );
     }
@@ -488,7 +522,7 @@ mod tag_tests {
     #[test]
     fn dirty_clean() {
         assert_eq!(
-            rendered(Some(SubmoduleState::Dirty), SubmoduleWarn::default()),
+            rendered(Some(SubmoduleState::Dirty), None, SubmoduleWarn::default()),
             "[sub: ~dirty] "
         );
     }
@@ -501,7 +535,7 @@ mod tag_tests {
             needs_merge_to_default: false,
         };
         assert_eq!(
-            rendered(Some(SubmoduleState::Dirty), warn),
+            rendered(Some(SubmoduleState::Dirty), None, warn),
             "[sub: ~dirty \u{2191}1] "
         );
     }
@@ -514,7 +548,7 @@ mod tag_tests {
             needs_merge_to_default: false,
         };
         assert_eq!(
-            rendered(Some(SubmoduleState::Dirty), warn),
+            rendered(Some(SubmoduleState::Dirty), None, warn),
             "[sub: ~dirty \u{26a0}unreach] "
         );
     }
@@ -528,7 +562,7 @@ mod tag_tests {
             needs_merge_to_default: false,
         };
         assert_eq!(
-            rendered(Some(SubmoduleState::Uninitialized), warn),
+            rendered(Some(SubmoduleState::Uninitialized), None, warn),
             "[sub: -uninit] "
         );
     }
@@ -540,7 +574,7 @@ mod tag_tests {
             pointer_unreachable: true,
             needs_merge_to_default: false,
         };
-        assert_eq!(rendered(None, warn), "[sub: \u{26a0}unreach] ");
+        assert_eq!(rendered(None, None, warn), "[sub: \u{26a0}unreach] ");
     }
 
     #[test]
@@ -550,11 +584,99 @@ mod tag_tests {
             pointer_unreachable: false,
             needs_merge_to_default: false,
         };
-        assert_eq!(rendered(None, warn), "[sub: \u{2191}4] ");
+        assert_eq!(rendered(None, None, warn), "[sub: \u{2191}4] ");
     }
 
     #[test]
     fn no_state_no_warn_falls_back_to_plain_tag() {
-        assert_eq!(rendered(None, SubmoduleWarn::default()), "[submodule] ");
+        assert_eq!(
+            rendered(None, None, SubmoduleWarn::default()),
+            "[submodule] "
+        );
+    }
+
+    #[test]
+    fn modified_with_branch() {
+        assert_eq!(
+            rendered(
+                Some(SubmoduleState::Modified),
+                Some(SubmoduleHead::Branch("feature".to_string())),
+                SubmoduleWarn::default(),
+            ),
+            "[sub: +commit @feature] "
+        );
+    }
+
+    #[test]
+    fn dirty_detached() {
+        assert_eq!(
+            rendered(
+                Some(SubmoduleState::Dirty),
+                Some(SubmoduleHead::Detached),
+                SubmoduleWarn::default(),
+            ),
+            "[sub: ~dirty @detached] "
+        );
+    }
+
+    #[test]
+    fn modified_needs_merge_to_default() {
+        let warn = SubmoduleWarn {
+            unpushed_commits: 0,
+            pointer_unreachable: false,
+            needs_merge_to_default: true,
+        };
+        assert_eq!(
+            rendered(Some(SubmoduleState::Modified), None, warn),
+            "[sub: +commit \u{219b}main] "
+        );
+    }
+
+    #[test]
+    fn composed_branch_unpushed_and_needs_merge() {
+        let warn = SubmoduleWarn {
+            unpushed_commits: 3,
+            pointer_unreachable: false,
+            needs_merge_to_default: true,
+        };
+        assert_eq!(
+            rendered(
+                Some(SubmoduleState::Modified),
+                Some(SubmoduleHead::Branch("feature".to_string())),
+                warn,
+            ),
+            "[sub: +commit @feature \u{2191}3 \u{219b}main] "
+        );
+    }
+
+    #[test]
+    fn unreachable_dominates_needs_merge() {
+        // On no remote at all: only `⚠unreach`, never `↛main`.
+        let warn = SubmoduleWarn {
+            unpushed_commits: 0,
+            pointer_unreachable: true,
+            needs_merge_to_default: true,
+        };
+        assert_eq!(
+            rendered(Some(SubmoduleState::Modified), None, warn),
+            "[sub: +commit \u{26a0}unreach] "
+        );
+    }
+
+    #[test]
+    fn uninitialized_suppresses_branch_and_merge() {
+        let warn = SubmoduleWarn {
+            unpushed_commits: 0,
+            pointer_unreachable: false,
+            needs_merge_to_default: true,
+        };
+        assert_eq!(
+            rendered(
+                Some(SubmoduleState::Uninitialized),
+                Some(SubmoduleHead::Branch("x".to_string())),
+                warn,
+            ),
+            "[sub: -uninit] "
+        );
     }
 }

--- a/src/components/file_list.rs
+++ b/src/components/file_list.rs
@@ -464,6 +464,7 @@ mod tag_tests {
         let warn = SubmoduleWarn {
             unpushed_commits: 3,
             pointer_unreachable: false,
+            needs_merge_to_default: false,
         };
         assert_eq!(
             rendered(Some(SubmoduleState::Modified), warn),
@@ -476,6 +477,7 @@ mod tag_tests {
         let warn = SubmoduleWarn {
             unpushed_commits: 5,
             pointer_unreachable: true,
+            needs_merge_to_default: false,
         };
         assert_eq!(
             rendered(Some(SubmoduleState::Modified), warn),
@@ -496,6 +498,7 @@ mod tag_tests {
         let warn = SubmoduleWarn {
             unpushed_commits: 1,
             pointer_unreachable: false,
+            needs_merge_to_default: false,
         };
         assert_eq!(
             rendered(Some(SubmoduleState::Dirty), warn),
@@ -508,6 +511,7 @@ mod tag_tests {
         let warn = SubmoduleWarn {
             unpushed_commits: 0,
             pointer_unreachable: true,
+            needs_merge_to_default: false,
         };
         assert_eq!(
             rendered(Some(SubmoduleState::Dirty), warn),
@@ -521,6 +525,7 @@ mod tag_tests {
         let warn = SubmoduleWarn {
             unpushed_commits: 7,
             pointer_unreachable: true,
+            needs_merge_to_default: false,
         };
         assert_eq!(
             rendered(Some(SubmoduleState::Uninitialized), warn),
@@ -533,6 +538,7 @@ mod tag_tests {
         let warn = SubmoduleWarn {
             unpushed_commits: 0,
             pointer_unreachable: true,
+            needs_merge_to_default: false,
         };
         assert_eq!(rendered(None, warn), "[sub: \u{26a0}unreach] ");
     }
@@ -542,6 +548,7 @@ mod tag_tests {
         let warn = SubmoduleWarn {
             unpushed_commits: 4,
             pointer_unreachable: false,
+            needs_merge_to_default: false,
         };
         assert_eq!(rendered(None, warn), "[sub: \u{2191}4] ");
     }

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -1544,6 +1544,77 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_needs_merge_to_default_when_pinned_on_side_branch() {
+        // The parent pins a submodule commit that lives on a remote *side*
+        // branch (origin/feature) but is not reachable from the default branch
+        // (origin/main). The commit is fetchable, so it is not "unreachable",
+        // yet it still needs merging to main → `needs_merge_to_default`.
+        let (tmp, _sub_source, _sub_repo) = init_repo_with_submodule();
+
+        let sub_dir = tmp.path().join("my-sub");
+        let inner = Repository::open(&sub_dir).unwrap();
+
+        // A: the initial cloned commit. Anchor the default branch here.
+        let a = inner.head().unwrap().peel_to_commit().unwrap().id();
+        inner
+            .reference("refs/remotes/origin/main", a, true, "test setup")
+            .unwrap();
+
+        // B: a new commit (child of A) now checked out in the submodule,
+        // published only on origin/feature.
+        let b = add_commit_on_head(&inner, "feature.rs", "fn f() {}");
+        inner
+            .reference("refs/remotes/origin/feature", b, true, "test setup")
+            .unwrap();
+
+        // Stage the parent's pointer at B (the submodule's current HEAD).
+        stage_submodule_pointer(tmp.path(), "my-sub");
+
+        let status = query_status(tmp.path(), &SubmoduleConfig::default()).unwrap();
+        let sub = status
+            .submodules
+            .iter()
+            .find(|s| s.path == Path::new("my-sub"))
+            .expect("submodule entry expected");
+
+        assert!(
+            sub.warn.needs_merge_to_default,
+            "pinned commit is on origin/feature, not origin/main: {:?}",
+            sub.warn
+        );
+        assert!(
+            !sub.warn.pointer_unreachable,
+            "commit is on a remote, so it is reachable: {:?}",
+            sub.warn
+        );
+        assert!(!sub.warn.is_clean());
+        assert!(status.has_unpushed_submodules);
+    }
+
+    /// A pinned commit that IS on the default branch must not warn.
+    #[test]
+    fn test_no_merge_warning_when_pinned_on_default_branch() {
+        let (tmp, _sub_source, _sub_repo) = init_repo_with_submodule();
+
+        let sub_dir = tmp.path().join("my-sub");
+        let inner = Repository::open(&sub_dir).unwrap();
+        let a = inner.head().unwrap().peel_to_commit().unwrap().id();
+        // Default branch points at the very commit the parent pins.
+        inner
+            .reference("refs/remotes/origin/main", a, true, "test setup")
+            .unwrap();
+
+        let status = query_status(tmp.path(), &SubmoduleConfig::default()).unwrap();
+        for sub in &status.submodules {
+            assert!(
+                !sub.warn.needs_merge_to_default,
+                "pinned commit is on origin/main: {:?}",
+                sub.warn
+            );
+        }
+    }
+
     fn add_commit_on_head(repo: &Repository, file: &str, contents: &str) -> git2::Oid {
         let workdir = repo.workdir().unwrap().to_path_buf();
         fs::write(workdir.join(file), contents).unwrap();

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -126,6 +126,9 @@ pub(crate) struct FileEntry {
     pub is_submodule: bool,
     pub submodule_state: Option<SubmoduleState>,
     pub submodule_warn: SubmoduleWarn,
+    /// Checked-out branch of the submodule (or detached). `None` for non
+    /// submodule rows and for submodules that could not be opened.
+    pub submodule_head: Option<SubmoduleHead>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -145,6 +148,15 @@ pub(crate) enum SubmoduleState {
     Dirty,
 }
 
+/// The submodule's currently checked-out HEAD. After `git submodule update`
+/// a submodule sits on a detached HEAD by default, so `Detached` is common and
+/// itself a useful signal: a modification there is not on any tracked branch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SubmoduleHead {
+    Branch(String),
+    Detached,
+}
+
 /// "You owe a push" warnings for a submodule. Orthogonal to `SubmoduleState`.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct SubmoduleWarn {
@@ -154,11 +166,16 @@ pub(crate) struct SubmoduleWarn {
     /// `refs/remotes/*` refs — committing the parent would pin a sha nobody
     /// else can fetch.
     pub pointer_unreachable: bool,
+    /// Parent's recorded oid IS on a remote, but not on the submodule's default
+    /// branch (`origin/HEAD`, falling back to `origin/main`/`origin/master`),
+    /// so it still needs a merge/PR there. Stays `false` when no default branch
+    /// resolves, so it never fires on a false positive.
+    pub needs_merge_to_default: bool,
 }
 
 impl SubmoduleWarn {
     pub fn is_clean(&self) -> bool {
-        self.unpushed_commits == 0 && !self.pointer_unreachable
+        self.unpushed_commits == 0 && !self.pointer_unreachable && !self.needs_merge_to_default
     }
 }
 
@@ -182,6 +199,7 @@ pub(crate) struct SubmoduleInfo {
     pub name: String,
     pub path: PathBuf,
     pub state: Option<SubmoduleState>,
+    pub head: Option<SubmoduleHead>,
     pub head_oid: Option<String>,
     pub workdir_oid: Option<String>,
     pub warn: SubmoduleWarn,
@@ -336,6 +354,7 @@ fn collect_change_summary(
             is_submodule: false,
             submodule_state: None,
             submodule_warn: SubmoduleWarn::default(),
+            submodule_head: None,
         });
     }
 
@@ -382,12 +401,16 @@ fn collect_change_summary(
                 }
             };
 
-            // Warn-state computation (gated on warn_unpushed). Skipped for
-            // uninitialized submodules — `sub.open()` would fail anyway.
-            let warn = if sub_cfg.warn_unpushed && state != Some(SubmoduleState::Uninitialized) {
-                compute_submodule_warn(sub)
+            // Open the submodule (once) to read its checked-out branch and,
+            // when enabled, compute push/merge warnings. Skip for uninitialized
+            // submodules (`sub.open()` fails) and when there is nothing to show
+            // (clean working tree with warnings disabled): branch is only worth
+            // reading for a submodule that will render a row.
+            let is_uninit = state == Some(SubmoduleState::Uninitialized);
+            let (head, warn) = if !is_uninit && (state.is_some() || sub_cfg.warn_unpushed) {
+                compute_submodule_head_and_warn(sub, sub_cfg.warn_unpushed)
             } else {
-                SubmoduleWarn::default()
+                (None, SubmoduleWarn::default())
             };
 
             let has_dirty_signal = state.is_some();
@@ -404,6 +427,7 @@ fn collect_change_summary(
                 name: name.clone(),
                 path: sub_path.clone(),
                 state: state.clone(),
+                head: head.clone(),
                 head_oid,
                 workdir_oid,
                 warn,
@@ -414,6 +438,7 @@ fn collect_change_summary(
                 file_entry.is_submodule = true;
                 file_entry.submodule_state = state.clone();
                 file_entry.submodule_warn = warn;
+                file_entry.submodule_head = head;
             } else {
                 // Synthetic FileEntry for any submodule with a dirty or warn signal.
                 // FileStatus::Modified keeps the leading `M` "needs attention" cue;
@@ -424,6 +449,7 @@ fn collect_change_summary(
                     is_submodule: true,
                     submodule_state: state,
                     submodule_warn: warn,
+                    submodule_head: head,
                 });
             }
 
@@ -446,47 +472,123 @@ fn collect_change_summary(
     })
 }
 
-/// Compute "you owe a push" warnings for a submodule.
-/// Uses `index_id()` (parent's *staged* pointer, not committed) so the warning
-/// fires *before* the parent commit ships, while the user can still amend or reset.
-fn compute_submodule_warn(sub: &git2::Submodule) -> SubmoduleWarn {
+/// Open the submodule once to read its checked-out branch and, when
+/// `warn_enabled`, compute its push/merge warnings. Returns `(head, warn)`;
+/// `head` is `None` only when the submodule cannot be opened.
+fn compute_submodule_head_and_warn(
+    sub: &git2::Submodule,
+    warn_enabled: bool,
+) -> (Option<SubmoduleHead>, SubmoduleWarn) {
+    let inner = match sub.open() {
+        Ok(r) => r,
+        Err(_) => return (None, SubmoduleWarn::default()),
+    };
+
+    let head = Some(read_submodule_head(&inner));
+    let warn = if warn_enabled {
+        compute_submodule_warn(sub, &inner)
+    } else {
+        SubmoduleWarn::default()
+    };
+    (head, warn)
+}
+
+/// Read the submodule's current branch, or `Detached` when it sits on a
+/// detached HEAD (git's default after `submodule update`) or has no branch.
+fn read_submodule_head(inner: &Repository) -> SubmoduleHead {
+    if inner.head_detached().unwrap_or(true) {
+        return SubmoduleHead::Detached;
+    }
+    match inner.head() {
+        Ok(head) => SubmoduleHead::Branch(head.shorthand().unwrap_or("HEAD").to_string()),
+        Err(_) => SubmoduleHead::Detached,
+    }
+}
+
+/// Compute "you owe a push/merge" warnings for a submodule, given an already
+/// open handle to it. Uses `index_id()` (parent's *staged* pointer, not
+/// committed) so the warning fires *before* the parent commit ships, while the
+/// user can still amend or reset.
+fn compute_submodule_warn(sub: &git2::Submodule, inner: &Repository) -> SubmoduleWarn {
     let recorded = match sub.index_id() {
         Some(o) => o,
         None => return SubmoduleWarn::default(),
     };
-    let inner = match sub.open() {
-        Ok(r) => r,
-        Err(_) => return SubmoduleWarn::default(),
-    };
 
-    let unpushed_commits = compute_ahead_behind(&inner).0;
+    let unpushed_commits = compute_ahead_behind(inner).0;
 
     // If the recorded oid isn't even in local objects, no remote can possibly hold it.
     if inner.find_object(recorded, None).is_err() {
         return SubmoduleWarn {
             unpushed_commits,
             pointer_unreachable: true,
+            needs_merge_to_default: false,
         };
     }
 
-    if let Ok(branches) = inner.branches(Some(git2::BranchType::Remote)) {
-        for (b, _) in branches.flatten() {
-            if let Some(tip) = b.get().target()
-                && (tip == recorded || inner.graph_descendant_of(tip, recorded).unwrap_or(false))
-            {
-                return SubmoduleWarn {
-                    unpushed_commits,
-                    pointer_unreachable: false,
-                };
-            }
-        }
+    if !remote_reaches(inner, recorded) {
+        // No remote tip reaches `recorded` (or no remotes configured) → must push.
+        return SubmoduleWarn {
+            unpushed_commits,
+            pointer_unreachable: true,
+            needs_merge_to_default: false,
+        };
     }
 
-    // No remote tip reaches `recorded` (or no remotes configured) → unreachable.
+    // Reachable from some remote. If we can resolve the default branch and it
+    // does NOT reach `recorded`, the commit lives on a side branch and still
+    // needs a merge there. When no default branch resolves, stay silent.
+    let needs_merge_to_default = match default_branch_tip(inner) {
+        Some(tip) => !reaches(inner, tip, recorded),
+        None => false,
+    };
+
     SubmoduleWarn {
         unpushed_commits,
-        pointer_unreachable: true,
+        pointer_unreachable: false,
+        needs_merge_to_default,
     }
+}
+
+/// Whether `recorded` is reachable from `tip` (equal, or an ancestor of it).
+fn reaches(inner: &Repository, tip: git2::Oid, recorded: git2::Oid) -> bool {
+    tip == recorded || inner.graph_descendant_of(tip, recorded).unwrap_or(false)
+}
+
+/// Whether `recorded` is reachable from any `refs/remotes/*` branch tip.
+fn remote_reaches(inner: &Repository, recorded: git2::Oid) -> bool {
+    let Ok(branches) = inner.branches(Some(git2::BranchType::Remote)) else {
+        return false;
+    };
+    for (b, _) in branches.flatten() {
+        if let Some(tip) = b.get().target()
+            && reaches(inner, tip, recorded)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Resolve the submodule's default-branch tip: `origin/HEAD`'s symbolic target
+/// first, then `origin/main`, then `origin/master`. `None` when none resolve —
+/// common in submodule clones, where `origin/HEAD` is often absent.
+fn default_branch_tip(inner: &Repository) -> Option<git2::Oid> {
+    if let Ok(head_ref) = inner.find_reference("refs/remotes/origin/HEAD")
+        && let Ok(Some(target_name)) = head_ref.symbolic_target()
+        && let Ok(target_ref) = inner.find_reference(target_name)
+        && let Some(oid) = target_ref.target()
+    {
+        return Some(oid);
+    }
+    for name in ["refs/remotes/origin/main", "refs/remotes/origin/master"] {
+        if let Ok(r) = inner.find_reference(name)
+            && let Some(oid) = r.target()
+        {
+            return Some(oid);
+        }
+    }
+    None
 }
 
 /// Collect details for each linked worktree using the git2 API.
@@ -886,10 +988,15 @@ mod tests {
             is_submodule: true,
             submodule_state: Some(SubmoduleState::Modified),
             submodule_warn: SubmoduleWarn::default(),
+            submodule_head: Some(SubmoduleHead::Branch("feature".to_string())),
         };
         assert!(entry.is_submodule);
         assert_eq!(entry.submodule_state, Some(SubmoduleState::Modified));
         assert!(entry.submodule_warn.is_clean());
+        assert_eq!(
+            entry.submodule_head,
+            Some(SubmoduleHead::Branch("feature".to_string()))
+        );
 
         let plain = FileEntry {
             path: PathBuf::from("src/main.rs"),
@@ -897,9 +1004,11 @@ mod tests {
             is_submodule: false,
             submodule_state: None,
             submodule_warn: SubmoduleWarn::default(),
+            submodule_head: None,
         };
         assert!(!plain.is_submodule);
         assert_eq!(plain.submodule_state, None);
+        assert_eq!(plain.submodule_head, None);
     }
 
     #[test]
@@ -1139,6 +1248,7 @@ mod tests {
             !SubmoduleWarn {
                 unpushed_commits: 1,
                 pointer_unreachable: false,
+                needs_merge_to_default: false,
             }
             .is_clean()
         );
@@ -1146,6 +1256,15 @@ mod tests {
             !SubmoduleWarn {
                 unpushed_commits: 0,
                 pointer_unreachable: true,
+                needs_merge_to_default: false,
+            }
+            .is_clean()
+        );
+        assert!(
+            !SubmoduleWarn {
+                unpushed_commits: 0,
+                pointer_unreachable: false,
+                needs_merge_to_default: true,
             }
             .is_clean()
         );

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -134,6 +134,8 @@ pub(crate) struct FileListTheme {
     pub submodule_bracket: Color,
     pub submodule_unpushed: Color,
     pub submodule_unreachable: Color,
+    pub submodule_branch: Color,
+    pub submodule_needs_merge: Color,
 }
 
 impl Default for FileListTheme {
@@ -160,6 +162,8 @@ impl Default for FileListTheme {
             submodule_bracket: Color::LightMagenta,
             submodule_unpushed: Color::Green,
             submodule_unreachable: Color::LightRed,
+            submodule_branch: Color::Cyan,
+            submodule_needs_merge: Color::Yellow,
         }
     }
 }

--- a/src/theme/presets.rs
+++ b/src/theme/presets.rs
@@ -51,6 +51,8 @@ pub(crate) fn muted() -> Theme {
     t.file_list.submodule_bracket = Color::Indexed(133);
     t.file_list.submodule_unpushed = Color::Indexed(71);
     t.file_list.submodule_unreachable = Color::Indexed(167);
+    t.file_list.submodule_branch = Color::Indexed(73);
+    t.file_list.submodule_needs_merge = Color::Indexed(178);
 
     // Graph: paragraph + commit colors muted, palettes desaturated.
     t.graph.border_focused = Color::Indexed(73);


### PR DESCRIPTION
## What this adds

For a dirty/modified submodule, the `[sub: …]` tag now shows **which branch** it is on and warns when its pinned commit still needs merging to the default branch.

- `@<branch>` / `@detached` after the state label (read from the submodule's HEAD; detached is git's default after `submodule update`).
- A third reachability tier `↛main`: the pinned commit is reachable from a remote but **not** from the default branch (`origin/HEAD`, falling back to `origin/main`/`origin/master`). Silent when no default branch resolves, so it never false-positives.

`⚠unreach` (on no remote) still dominates; `↑N` (ahead of upstream) and `↛main` compose additively. Examples:

```
[sub: +commit @feature ↑3 ↛main]
[sub: ~dirty @detached]
[sub: +commit @main]              # clean, on the default branch
```

## How

- `status.rs`: new `SubmoduleHead {Branch, Detached}`; `SubmoduleWarn.needs_merge_to_default` (folded into `is_clean()`); `head` on `FileEntry`/`SubmoduleInfo`. `compute_submodule_warn` is consolidated into `compute_submodule_head_and_warn`, which opens the submodule once to read the branch and compute the push/merge tiers. The branch is read for any dirty/warn submodule; the push/merge tiers stay gated on `warn_unpushed`.
- `file_list.rs`: `submodule_tag_spans` renders the branch and the additive `↛main` glyph.
- `theme`: two new colors (`submodule_branch`, `submodule_needs_merge`) with default + preset values.

## Tests

239 pass (+8): render-string cases for `@feature`, `@detached`, `↛main`, and the composed tag; plus integration tests that pin a submodule commit on a side branch (asserts `needs_merge_to_default` without `pointer_unreachable`) and a clean default-branch case. Clippy + fmt clean.

## Notes / tradeoffs

- `origin/HEAD` is often absent in submodule clones, so default-branch detection falls back to `origin/main`/`origin/master` and no-ops when none resolve.
- Reading the branch when `warn_unpushed` is off opens each *dirty* submodule once (it didn't before); bounded to submodules that render a row.
- Side effect: `needs_merge_to_default` feeds `has_unpushed_submodules`, so the repo-list `⇡` indicator now also lights up for a needs-merge submodule.

Closes #12
