### PR TITLE
chore(dependabot): tighten grouping to one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,16 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     groups:
       cargo:
         patterns:
           - '*'
-        update-types:
-          - minor
-          - patch
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     groups:
       actions:
         patterns:


### PR DESCRIPTION
Follow-up to #14. The cargo group only covered minor/patch updates, so every major bump would open its own PR (a weekly flood once a few crates go major).

Changes:
- Drop `update-types: [minor, patch]` from the cargo group so majors group in too.
- Lower cargo `open-pull-requests-limit` from 10 to 5.
- Add an explicit limit of 5 to the github-actions block for symmetry.

Result: at most one grouped cargo PR plus one grouped actions PR per week. Security updates still come through separately, as intended.

Tradeoff: a grouped PR that includes a breaking major can be blocked as a whole until resolved. Acceptable given the goal of avoiding PR sprawl.