### PR TITLE
GitHub issues & PRs panel (4th panel, via the gh CLI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/README.md
+++ b/README.md
@@ -91,22 +91,26 @@ On NetBSD, update through pkgsrc instead of `gitpane update`, which shells out t
 
 If you work across multiple repositories, such as microservices, monorepos with submodules, or a mix of projects, you know the pain of checking status one directory at a time. Existing TUI tools focus on **one repo at a time**:
 
-| Tool | Multi repo | Auto refresh | Worktrees | Mouse | Commit graph | Split diffs | Push/Pull |
-|------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| **gitpane** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** |
-| [lazygit](https://github.com/jesseduffield/lazygit) | No | No | No | Yes | Yes | Yes | Yes |
-| [gitui](https://github.com/extrawurst/gitui) | No | No | No | Yes | Yes | Yes | Yes |
-| [tig](https://github.com/jonas/tig) | No | No | No | No | Yes | No | No |
-| [git-delta](https://github.com/dandavison/delta) | No | No | No | No | No | Yes (pager) | No |
-| [grv](https://github.com/rgburke/grv) | No | No | No | Yes | Yes | No | No |
-| [git-summary](https://github.com/MircoT/git-summary) | Yes (list only) | No | No | No | No | No | No |
-| [mgitstatus](https://github.com/fboender/multi-git-status) | Yes (list only) | No | No | No | No | No | No |
-| [gita](https://github.com/nosarthur/gita) | Yes (CLI only) | No | No | No | No | No | Yes |
-| [gitbatch](https://github.com/isacikgoz/gitbatch) | Yes (TUI) | No | No | No | No | No | Yes (batch) |
-| [gwq](https://github.com/d-kuro/gwq) | Yes (CLI) | No | Yes | No | No | No | No |
-| [Canopy](https://github.com/ashmitb95/canopy) | Yes (CLI) | No | Yes | No | No | No | No |
+| Tool | Multi repo | Auto refresh | Worktrees | Mouse | Commit graph | Split diffs | Push/Pull | Issues/PRs |
+|------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **gitpane** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** |
+| [lazygit](https://github.com/jesseduffield/lazygit) | No | No | No | Yes | Yes | Yes | Yes | No |
+| [gitui](https://github.com/extrawurst/gitui) | No | No | No | Yes | Yes | Yes | Yes | No |
+| [tig](https://github.com/jonas/tig) | No | No | No | No | Yes | No | No | No |
+| [git-delta](https://github.com/dandavison/delta) | No | No | No | No | No | Yes (pager) | No | No |
+| [grv](https://github.com/rgburke/grv) | No | No | No | Yes | Yes | No | No | No |
+| [git-summary](https://github.com/MircoT/git-summary) | Yes (list only) | No | No | No | No | No | No | No |
+| [mgitstatus](https://github.com/fboender/multi-git-status) | Yes (list only) | No | No | No | No | No | No | No |
+| [gita](https://github.com/nosarthur/gita) | Yes (CLI only) | No | No | No | No | No | Yes | No |
+| [gitbatch](https://github.com/isacikgoz/gitbatch) | Yes (TUI) | No | No | No | No | No | Yes (batch) | No |
+| [gwq](https://github.com/d-kuro/gwq) | Yes (CLI) | No | Yes | No | No | No | No | No |
+| [Canopy](https://github.com/ashmitb95/canopy) | Yes (CLI) | No | Yes | No | No | No | No | No |
+| [ghpeek](https://github.com/kimusan/ghpeek) | GitHub only | No | No | Yes | No | No | No | Yes |
+| [gh-dash](https://github.com/dlvhdr/gh-dash) | GitHub only | Yes | No | No | No | No | Partial | Yes |
 
 **lazygit** and **gitui** are excellent for deep single repo work like staging hunks, interactive rebase, and conflict resolution. gitpane is the **workspace level dashboard**. It shows every repo at once, lets you drill into anything, and keeps you in the terminal. They complement each other.
+
+**ghpeek** and **gh-dash** live on the other side, they are GitHub dashboards for issues and pull requests with no view of your local working copies. gitpane folds a lightweight version of that in: select a repo and, when it has open issues or PRs on its `github.com` origin, a fourth panel appears with the list, a preview (body plus comments), and open-in-browser, fetched on demand through the `gh` CLI. It is the only tool here that pairs the local multi-repo workspace with a GitHub peek.
 
 A newer category of **worktree dashboards** has grown up around parallel AI agents, such as [gwq](https://github.com/d-kuro/gwq) (worktree status list with tmux integration), Canopy, and [git-worktree-manager](https://github.com/nanasess/git-worktree-manager). gitpane overlaps here, it expands each repo into its per worktree branch, ahead/behind, dirty, and submodule state, but pairs that with a full commit graph, split diffs, and remote ops the dashboard-only tools lack. With `o` to open any repo or worktree in a new tmux pane (or your editor), it is both the **overview** and the **launchpad**.
 
@@ -269,6 +273,9 @@ update_position = "top-right" # Update notification position ("top-right" or "to
 branches = "all"         # Branch filter: "all", "local", "remote", or "none"
 label_max_len = 24       # Max length for branch/tag labels
 show_stats = true        # Show +N/-M diff stats per commit
+
+[github]
+enabled = true           # Show the GitHub issues/PRs panel (via `gh`); opt-out, on by default
 
 [open]
 # Command run by `o` to open the selected repo/worktree. `{path}` is replaced

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Click a commit in the graph to see its files. Click a file to see the commit dif
 | `o` | Open selected repo/worktree (new tmux pane, or `[open]` command) |
 | `v` | Review selected repo/worktree's diff vs its base branch (new tmux window) |
 | `G` | Attach the live tmux session(s) for the selected repo/worktree |
+| `p` | Toggle the GitHub panel (issues/PRs) for the selected repo |
 | `a` | Add a repo (opens path input with tab completion) |
 | `d` | Remove selected repo, or worktree if a worktree row is selected (with confirmation) |
 | `s` | Cycle sort order (Alphabetical / Dirty first) |
@@ -203,6 +204,19 @@ Click a commit in the graph to see its files. Click a file to see the commit dif
 | `f` | Toggle first parent mode |
 | `c` | Collapse / expand branch |
 | `H` | Expand all collapsed branches |
+
+### GitHub panel
+
+Appears automatically when the selected repo's `github.com` origin has open issues or PRs (opt-out via `[github] enabled`); press `p` to force it open on any repo. Requires the `gh` CLI, whose auth it reuses.
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Next item / scroll preview |
+| `k` / `↑` | Previous item / scroll preview |
+| `Enter` | Open preview (body + comments); again opens in browser |
+| `Esc` / `q` | Close the preview |
+| `c` | Cycle state filter: open → all → closed |
+| `p` | Hide the panel |
 
 ### Mouse
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -64,6 +64,14 @@ label_max_len = 24
 # Show +N/-M diff stats per commit (default: true)
 show_stats = true
 
+[github]
+# Show the GitHub panel (open issues/PRs for the selected repo) via the `gh` CLI.
+# Opt-out: on by default. The 4th panel appears only for a selected repo whose
+# origin is a github.com remote and that has open issues or PRs; press `p` to
+# force it open (e.g. to browse closed items). Needs `gh` on PATH; without it
+# gitpane keeps the usual three panels and shows no error (default: true).
+enabled = true
+
 [open]
 # Command run by `o` to open the selected repo/worktree. `{path}` is its dir.
 # command = "cursor {path}"          # GUI editor (launched directly)

--- a/src/action.rs
+++ b/src/action.rs
@@ -212,6 +212,18 @@ pub(crate) enum Action {
     },
     /// Open a URL in the OS browser (an issue/PR web link).
     OpenUrl(String),
+    /// Load the body + comments of a github item into the panel's detail pane.
+    /// `generation` latches out results for a superseded selection.
+    ShowGithubItem {
+        url: String,
+        is_pr: bool,
+        generation: u64,
+    },
+    /// Result of a [`Action::ShowGithubItem`] fetch.
+    GithubItemLoaded {
+        generation: u64,
+        result: Result<crate::git::github::ItemDetail, String>,
+    },
     /// Apply a theme transiently (live preview), no persistence.
     PreviewTheme(String),
     /// Apply a theme and write `theme = "<name>"` to the active config file.

--- a/src/action.rs
+++ b/src/action.rs
@@ -200,6 +200,18 @@ pub(crate) enum Action {
     StatusQueryDone(RepoId),
     /// Open the in-app theme picker overlay.
     OpenThemePicker,
+    /// The selection settled after debouncing; fetch GitHub data for it if due.
+    /// The `u64` is the selection generation, so a stale fire is ignored.
+    GithubSelectionSettled(u64),
+    /// Result of a `gh` issue/PR fetch for `repo_id`. Applied only when
+    /// `generation` still matches the repo's latest request (staleness latch).
+    GitHubFetched {
+        repo_id: RepoId,
+        generation: u64,
+        result: Result<crate::git::github::GithubData, String>,
+    },
+    /// Open a URL in the OS browser (an issue/PR web link).
+    OpenUrl(String),
     /// Apply a theme transiently (live preview), no persistence.
     PreviewTheme(String),
     /// Apply a theme and write `theme = "<name>"` to the active config file.

--- a/src/action.rs
+++ b/src/action.rs
@@ -212,6 +212,8 @@ pub(crate) enum Action {
     },
     /// Open a URL in the OS browser (an issue/PR web link).
     OpenUrl(String),
+    /// Cycle the GitHub panel's state filter (open → all → closed) and refetch.
+    CycleGithubStateFilter,
     /// Load the body + comments of a github item into the panel's detail pane.
     /// `generation` latches out results for a superseded selection.
     ShowGithubItem {

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -37,6 +37,7 @@ impl App {
                     self.git_graph.load_repo(path, &name);
                     self.repo_list.select_repo_row(idx);
                 }
+                self.github_touch_selection();
             }
             Action::FocusRepoDetails(ref id) => {
                 // Same panel refresh as SelectRepo but without
@@ -59,6 +60,7 @@ impl App {
                     self.file_list.set_files(files, &name, repo_id);
                     self.git_graph.load_repo(path, &name);
                 }
+                self.github_touch_selection();
             }
             Action::SelectWorktree {
                 ref repo_id,
@@ -72,6 +74,7 @@ impl App {
                     .unwrap_or_default();
                 let display_name = format!("{}:{}", repo_name, worktree_branch);
                 self.activate_path_context(worktree_path.clone(), repo_id.clone(), display_name);
+                self.github_touch_selection();
             }
             Action::SelectSubmodule {
                 ref repo_id,
@@ -96,6 +99,7 @@ impl App {
                     } else {
                         let display_name = format!("{}/{}", repo_name, sub_path.display());
                         self.activate_path_context(sub_abs, repo_id.clone(), display_name);
+                        self.github_touch_selection();
                     }
                 }
             }

--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -674,6 +674,7 @@ impl App {
                         .register_action_handler(self.action_tx.clone())?;
                     // Prune per-repo state for vanished repos so HashSets
                     // don't keep growing across the session.
+                    self.prune_github_cache(&diff.removed);
                     for path in &diff.removed {
                         let id = RepoId(path.clone());
                         self.pending_status.remove(&id);
@@ -707,6 +708,25 @@ impl App {
             }
             Action::UpdateAvailable(ref version) => {
                 self.update_version = Some(version.clone());
+            }
+            Action::GithubSelectionSettled(generation) => {
+                self.github_selection_settled(generation);
+            }
+            Action::GitHubFetched {
+                repo_id,
+                generation,
+                result,
+            } => {
+                self.github_fetched(repo_id, generation, result);
+            }
+            Action::OpenUrl(ref url) => {
+                let opener = if cfg!(target_os = "macos") {
+                    "open"
+                } else {
+                    "xdg-open"
+                };
+                let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/"));
+                self.os_open(vec![opener.to_string(), url.clone()], cwd, "github");
             }
             Action::Error(ref msg) => {
                 tracing::error!("{}", msg);

--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -728,6 +728,20 @@ impl App {
                 let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/"));
                 self.os_open(vec![opener.to_string(), url.clone()], cwd, "github");
             }
+            Action::ShowGithubItem {
+                url,
+                is_pr,
+                generation,
+            } => {
+                let tx = self.action_tx.clone();
+                tokio::task::spawn_blocking(move || {
+                    let result = crate::git::github::fetch_detail(&url, is_pr);
+                    let _ = tx.send(Action::GithubItemLoaded { generation, result });
+                });
+            }
+            Action::GithubItemLoaded { generation, result } => {
+                self.github_panel.set_detail(generation, result);
+            }
             Action::Error(ref msg) => {
                 tracing::error!("{}", msg);
                 // Sanitize: single line, max 120 chars for status bar

--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -742,6 +742,9 @@ impl App {
             Action::GithubItemLoaded { generation, result } => {
                 self.github_panel.set_detail(generation, result);
             }
+            Action::CycleGithubStateFilter => {
+                self.cycle_github_state_filter();
+            }
             Action::Error(ref msg) => {
                 tracing::error!("{}", msg);
                 // Sanitize: single line, max 120 chars for status bar

--- a/src/app/github.rs
+++ b/src/app/github.rs
@@ -1,0 +1,223 @@
+use super::*;
+
+use crate::git::github::{self, GhItem};
+
+/// How long a repo's fetched issue/PR data is considered fresh. Selection
+/// changes within this window reuse the cache instead of re-spawning `gh`.
+const GITHUB_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// Debounce before a settled selection triggers a `gh` fetch, so holding `j`
+/// through the repo list doesn't spawn a `gh` process for every transient row.
+const GITHUB_SELECT_DEBOUNCE: Duration = Duration::from_millis(400);
+
+/// Cached GitHub state for one repo. Lives on `App` (not `RepoStatus`, which is
+/// rebuilt on every 5s poll, nor `RepoEntry`, which is recreated on rescan) so
+/// it survives polls and rescans; `RepoId` is path-stable.
+#[derive(Default)]
+pub(super) struct GithubState {
+    /// `origin` parsed to `(owner, repo)`; `None` = not a github.com repo.
+    owner_repo: Option<(String, String)>,
+    /// A `gh` fetch is currently in flight.
+    loading: bool,
+    /// Bumped per request so a late result for a superseded request is dropped.
+    generation: u64,
+    /// When the last fetch attempt completed (drives the freshness cooldown).
+    fetched_at: Option<Instant>,
+    issues: Vec<GhItem>,
+    prs: Vec<GhItem>,
+    /// First stderr line of the last failed fetch, if any.
+    error: Option<String>,
+}
+
+impl App {
+    /// The repo whose issues/PRs the panel targets: the parent repo of the
+    /// current selection (worktrees and submodules share the parent's origin).
+    /// Returns `(id, path, display_name)`.
+    fn github_target(&self) -> Option<(RepoId, std::path::PathBuf, String)> {
+        if let Some(aw) = &self.active_worktree {
+            let idx = self.repo_list.resolve_index(&aw.repo_id)?;
+            let entry = &self.repo_list.repos[idx];
+            return Some((aw.repo_id.clone(), entry.path.clone(), entry.name.clone()));
+        }
+        let entry = self.repo_list.selected_repo()?;
+        Some((
+            RepoId(entry.path.clone()),
+            entry.path.clone(),
+            entry.name.clone(),
+        ))
+    }
+
+    /// Open-item count for the selected repo, from the cache. Drives auto-show.
+    fn selected_github_open_count(&self) -> usize {
+        self.github_target()
+            .and_then(|(id, _, _)| self.github_cache.get(&id))
+            .map(|s| s.issues.len() + s.prs.len())
+            .unwrap_or(0)
+    }
+
+    /// Whether the 4th panel should be visible this frame. Off entirely when the
+    /// feature is disabled; otherwise a manual `p` override wins, and the default
+    /// auto-shows only when the selected repo has open issues or PRs.
+    pub(super) fn show_github_panel(&self) -> bool {
+        if !self.config.github.enabled {
+            return false;
+        }
+        match self.github_forced {
+            Some(forced) => forced,
+            None => self.selected_github_open_count() > 0,
+        }
+    }
+
+    /// Selection changed: reset any manual override and schedule a debounced
+    /// fetch for the newly selected repo.
+    pub(super) fn github_touch_selection(&mut self) {
+        if !self.config.github.enabled {
+            return;
+        }
+        self.github_forced = None;
+        self.github_select_gen = self.github_select_gen.wrapping_add(1);
+        let generation = self.github_select_gen;
+        let tx = self.action_tx.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(GITHUB_SELECT_DEBOUNCE).await;
+            let _ = tx.send(Action::GithubSelectionSettled(generation));
+        });
+    }
+
+    /// Fired after the selection debounce: fetch the current repo and refresh
+    /// the view, unless a newer selection has superseded this one.
+    pub(super) fn github_selection_settled(&mut self, generation: u64) {
+        if generation != self.github_select_gen {
+            return;
+        }
+        self.request_github(false);
+        self.refresh_github_panel();
+    }
+
+    /// Manual `p` toggle: flip the panel's forced visibility. Forcing it open on
+    /// a repo with no cached data kicks off a fetch.
+    pub(super) fn toggle_github_panel(&mut self) {
+        if !self.config.github.enabled {
+            self.error_message = Some((
+                "GitHub panel disabled ([github] enabled = false)".to_string(),
+                Instant::now(),
+            ));
+            return;
+        }
+        let now_visible = self.show_github_panel();
+        self.github_forced = Some(!now_visible);
+        if self.github_forced == Some(true) {
+            self.request_github(true);
+            self.refresh_github_panel();
+        }
+    }
+
+    /// Spawn a `gh` fetch for the selected repo when due. `force` bypasses the
+    /// freshness cooldown (used by the manual toggle and refresh). No-op when the
+    /// feature is off, `gh` is absent, a fetch is already in flight, the data is
+    /// still fresh, or the repo has no github.com origin.
+    pub(super) fn request_github(&mut self, force: bool) {
+        if !self.config.github.enabled || !github::gh_available() {
+            return;
+        }
+        let Some((id, path, _)) = self.github_target() else {
+            return;
+        };
+        let now = Instant::now();
+        let entry = self.github_cache.entry(id.clone()).or_default();
+        if entry.loading {
+            return;
+        }
+        if !force
+            && let Some(at) = entry.fetched_at
+            && now.saturating_duration_since(at) < GITHUB_COOLDOWN
+        {
+            return;
+        }
+        if entry.owner_repo.is_none() {
+            entry.owner_repo = github::origin_owner_repo(&path);
+        }
+        let Some((owner, repo)) = entry.owner_repo.clone() else {
+            // Not a github.com repo: record the attempt so we don't re-probe the
+            // remote on every settle, and never spawn `gh`.
+            entry.fetched_at = Some(now);
+            return;
+        };
+        entry.loading = true;
+        entry.generation = entry.generation.wrapping_add(1);
+        let generation = entry.generation;
+        let tx = self.action_tx.clone();
+        tokio::task::spawn_blocking(move || {
+            let result = github::fetch(&owner, &repo, "open");
+            let _ = tx.send(Action::GitHubFetched {
+                repo_id: id,
+                generation,
+                result,
+            });
+        });
+    }
+
+    /// Apply a completed fetch to the cache and, if it is for the repo on screen,
+    /// refresh the panel view. Stale results (superseded generation) are dropped.
+    pub(super) fn github_fetched(
+        &mut self,
+        repo_id: RepoId,
+        generation: u64,
+        result: Result<github::GithubData, String>,
+    ) {
+        if let Some(entry) = self.github_cache.get_mut(&repo_id) {
+            if entry.generation != generation {
+                return;
+            }
+            entry.loading = false;
+            entry.fetched_at = Some(Instant::now());
+            match result {
+                Ok(data) => {
+                    entry.issues = data.issues;
+                    entry.prs = data.prs;
+                    entry.error = None;
+                }
+                Err(e) => entry.error = Some(e),
+            }
+        }
+        if self.github_target().map(|t| t.0) == Some(repo_id) {
+            self.refresh_github_panel();
+        }
+    }
+
+    /// Push the selected repo's cached state into the panel component.
+    pub(super) fn refresh_github_panel(&mut self) {
+        let Some((id, _, name)) = self.github_target() else {
+            return;
+        };
+        // No `gh` means no fetch will ever populate the cache; say so plainly
+        // instead of a "Loading…" that never resolves (only visible if the user
+        // force-opens the panel, since auto-show needs a non-zero count).
+        if !github::gh_available() {
+            self.github_panel
+                .set_error(&name, "gh CLI not found on PATH".to_string());
+            return;
+        }
+        match self.github_cache.get(&id) {
+            None => self.github_panel.set_loading(&name),
+            Some(s) if s.loading && s.fetched_at.is_none() => self.github_panel.set_loading(&name),
+            Some(s) if s.owner_repo.is_none() && s.fetched_at.is_some() => {
+                self.github_panel.set_not_github(&name)
+            }
+            Some(s) if s.error.is_some() => self
+                .github_panel
+                .set_error(&name, s.error.clone().unwrap_or_default()),
+            Some(s) => self
+                .github_panel
+                .set_data(s.issues.clone(), s.prs.clone(), &name),
+        }
+    }
+
+    /// Drop cached GitHub state for repos that vanished from the list, mirroring
+    /// how `DiscoverNewRepos` prunes the other per-repo maps.
+    pub(super) fn prune_github_cache(&mut self, removed: &[std::path::PathBuf]) {
+        for path in removed {
+            self.github_cache.remove(&RepoId(path.clone()));
+        }
+    }
+}

--- a/src/app/github.rs
+++ b/src/app/github.rs
@@ -10,6 +10,43 @@ const GITHUB_COOLDOWN: Duration = Duration::from_secs(60);
 /// through the repo list doesn't spawn a `gh` process for every transient row.
 const GITHUB_SELECT_DEBOUNCE: Duration = Duration::from_millis(400);
 
+/// Which issues/PRs the panel lists. Cycled with `c`; reset to `Open` on nav.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub(super) enum GithubStateFilter {
+    #[default]
+    Open,
+    All,
+    Closed,
+}
+
+impl GithubStateFilter {
+    fn next(self) -> Self {
+        match self {
+            Self::Open => Self::All,
+            Self::All => Self::Closed,
+            Self::Closed => Self::Open,
+        }
+    }
+
+    /// The `--state` argument passed to `gh`.
+    fn gh_state(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::All => "all",
+            Self::Closed => "closed",
+        }
+    }
+
+    /// Short label shown in the panel title.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::All => "all",
+            Self::Closed => "closed",
+        }
+    }
+}
+
 /// Cached GitHub state for one repo. Lives on `App` (not `RepoStatus`, which is
 /// rebuilt on every 5s poll, nor `RepoEntry`, which is recreated on rescan) so
 /// it survives polls and rescans; `RepoId` is path-stable.
@@ -25,6 +62,9 @@ pub(super) struct GithubState {
     fetched_at: Option<Instant>,
     issues: Vec<GhItem>,
     prs: Vec<GhItem>,
+    /// Open-item count from the last `open`-filter fetch. Drives auto-show, and
+    /// stays put while the user browses closed/all so the panel doesn't collapse.
+    open_count: usize,
     /// First stderr line of the last failed fetch, if any.
     error: Option<String>,
 }
@@ -48,10 +88,12 @@ impl App {
     }
 
     /// Open-item count for the selected repo, from the cache. Drives auto-show.
+    /// Uses the cached open count (not the displayed rows) so viewing closed/all
+    /// items never changes whether the panel auto-shows.
     fn selected_github_open_count(&self) -> usize {
         self.github_target()
             .and_then(|(id, _, _)| self.github_cache.get(&id))
-            .map(|s| s.issues.len() + s.prs.len())
+            .map(|s| s.open_count)
             .unwrap_or(0)
     }
 
@@ -75,6 +117,7 @@ impl App {
             return;
         }
         self.github_forced = None;
+        self.github_state_filter = GithubStateFilter::Open;
         self.github_select_gen = self.github_select_gen.wrapping_add(1);
         let generation = self.github_select_gen;
         let tx = self.action_tx.clone();
@@ -123,6 +166,7 @@ impl App {
         let Some((id, path, _)) = self.github_target() else {
             return;
         };
+        let state = self.github_state_filter.gh_state();
         let now = Instant::now();
         let entry = self.github_cache.entry(id.clone()).or_default();
         if entry.loading {
@@ -148,7 +192,7 @@ impl App {
         let generation = entry.generation;
         let tx = self.action_tx.clone();
         tokio::task::spawn_blocking(move || {
-            let result = github::fetch(&owner, &repo, "open");
+            let result = github::fetch(&owner, &repo, state);
             let _ = tx.send(Action::GitHubFetched {
                 repo_id: id,
                 generation,
@@ -165,6 +209,9 @@ impl App {
         generation: u64,
         result: Result<github::GithubData, String>,
     ) {
+        // Only an `open` fetch refreshes the auto-show count, so browsing
+        // closed/all leaves it untouched and the panel stays put.
+        let is_open_filter = self.github_state_filter == GithubStateFilter::Open;
         if let Some(entry) = self.github_cache.get_mut(&repo_id) {
             if entry.generation != generation {
                 return;
@@ -173,6 +220,9 @@ impl App {
             entry.fetched_at = Some(Instant::now());
             match result {
                 Ok(data) => {
+                    if is_open_filter {
+                        entry.open_count = data.issues.len() + data.prs.len();
+                    }
                     entry.issues = data.issues;
                     entry.prs = data.prs;
                     entry.error = None;
@@ -198,6 +248,7 @@ impl App {
                 .set_error(&name, "gh CLI not found on PATH".to_string());
             return;
         }
+        let label = self.github_state_filter.label();
         match self.github_cache.get(&id) {
             None => self.github_panel.set_loading(&name),
             Some(s) if s.loading && s.fetched_at.is_none() => self.github_panel.set_loading(&name),
@@ -209,8 +260,19 @@ impl App {
                 .set_error(&name, s.error.clone().unwrap_or_default()),
             Some(s) => self
                 .github_panel
-                .set_data(s.issues.clone(), s.prs.clone(), &name),
+                .set_data(s.issues.clone(), s.prs.clone(), &name, label),
         }
+    }
+
+    /// Cycle the panel's state filter (open → all → closed) and refetch. Sent by
+    /// `c` in the panel. The auto-show count is unaffected (see `github_fetched`).
+    pub(super) fn cycle_github_state_filter(&mut self) {
+        if !self.config.github.enabled {
+            return;
+        }
+        self.github_state_filter = self.github_state_filter.next();
+        self.request_github(true);
+        self.refresh_github_panel();
     }
 
     /// Drop cached GitHub state for repos that vanished from the list, mirroring

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -84,6 +84,7 @@ impl App {
                     self.git_graph.handle_key_event(key)?;
                 } else {
                     match self.focus {
+                        FocusPanel::GitHub => self.focus = FocusPanel::Graph,
                         FocusPanel::Graph => self.focus = FocusPanel::Changes,
                         FocusPanel::Changes => self.focus = FocusPanel::Repos,
                         FocusPanel::Repos => self.action_tx.send(Action::Quit)?,
@@ -91,19 +92,23 @@ impl App {
                 }
             }
             KeyCode::Tab => {
-                // Cycle focus right
+                // Cycle focus right, skipping the GitHub panel when it's hidden.
                 self.focus = match self.focus {
                     FocusPanel::Repos => FocusPanel::Changes,
                     FocusPanel::Changes => FocusPanel::Graph,
+                    FocusPanel::Graph if self.github_visible => FocusPanel::GitHub,
                     FocusPanel::Graph => FocusPanel::Repos,
+                    FocusPanel::GitHub => FocusPanel::Repos,
                 };
             }
             KeyCode::BackTab => {
-                // Cycle focus left
+                // Cycle focus left, skipping the GitHub panel when it's hidden.
                 self.focus = match self.focus {
+                    FocusPanel::Repos if self.github_visible => FocusPanel::GitHub,
                     FocusPanel::Repos => FocusPanel::Graph,
                     FocusPanel::Changes => FocusPanel::Repos,
                     FocusPanel::Graph => FocusPanel::Changes,
+                    FocusPanel::GitHub => FocusPanel::Graph,
                 };
             }
             KeyCode::Char('r') => {
@@ -117,6 +122,9 @@ impl App {
             }
             KeyCode::Char('g') => {
                 self.action_tx.send(Action::ShowGitGraph)?;
+            }
+            KeyCode::Char('p') => {
+                self.toggle_github_panel();
             }
             KeyCode::Char('G') => {
                 self.action_tx.send(Action::GotoSessionSelected)?;
@@ -155,6 +163,7 @@ impl App {
                         .map(|e| e.path.to_string_lossy().to_string()),
                     FocusPanel::Changes => self.file_list.selected_path(),
                     FocusPanel::Graph => self.git_graph.selected_text(),
+                    FocusPanel::GitHub => self.github_panel.selected_url(),
                 };
                 if let Some(text) = text {
                     use std::io::Write;
@@ -178,6 +187,11 @@ impl App {
                     }
                     FocusPanel::Graph => {
                         if let Some(action) = self.git_graph.handle_key_event(key)? {
+                            self.action_tx.send(action)?;
+                        }
+                    }
+                    FocusPanel::GitHub => {
+                        if let Some(action) = self.github_panel.handle_key_event(key)? {
                             self.action_tx.send(action)?;
                         }
                     }
@@ -219,7 +233,10 @@ impl App {
                     self.repo_area.x + self.repo_area.width,
                     self.changes_area.x + self.changes_area.width,
                     mouse.column,
-                    self.repo_area.width + self.changes_area.width + self.graph_area.width,
+                    self.repo_area.width
+                        + self.changes_area.width
+                        + self.graph_area.width
+                        + self.github_area.width,
                     self.repo_area.x,
                 )
             } else {
@@ -227,7 +244,10 @@ impl App {
                     self.repo_area.y + self.repo_area.height,
                     self.changes_area.y + self.changes_area.height,
                     mouse.row,
-                    self.repo_area.height + self.changes_area.height + self.graph_area.height,
+                    self.repo_area.height
+                        + self.changes_area.height
+                        + self.graph_area.height
+                        + self.github_area.height,
                     self.repo_area.y,
                 )
             };
@@ -278,6 +298,8 @@ impl App {
                 self.focus = FocusPanel::Changes;
             } else if self.graph_area.contains(pos) {
                 self.focus = FocusPanel::Graph;
+            } else if self.github_visible && self.github_area.contains(pos) {
+                self.focus = FocusPanel::GitHub;
             }
         }
 
@@ -290,8 +312,13 @@ impl App {
             if let Some(action) = self.file_list.handle_mouse_event(mouse)? {
                 self.action_tx.send(action)?;
             }
-        } else if self.graph_area.contains(pos)
-            && let Some(action) = self.git_graph.handle_mouse_event(mouse)?
+        } else if self.graph_area.contains(pos) {
+            if let Some(action) = self.git_graph.handle_mouse_event(mouse)? {
+                self.action_tx.send(action)?;
+            }
+        } else if self.github_visible
+            && self.github_area.contains(pos)
+            && let Some(action) = self.github_panel.handle_mouse_event(mouse)?
         {
             self.action_tx.send(action)?;
         }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -233,11 +233,13 @@ impl App {
 
         // Border dragging for panel resize (works in both orientations)
         if self.repo_area.width > 0 {
-            // Compute border positions and mouse coordinate along the layout axis
-            let (border1, border2, mouse_pos, total, origin) = if self.horizontal_layout {
+            // Compute border positions and mouse coordinate along the layout
+            // axis. border3 (graph|github) only exists while the panel is shown.
+            let (border1, border2, border3, mouse_pos, total, origin) = if self.horizontal_layout {
                 (
                     self.repo_area.x + self.repo_area.width,
                     self.changes_area.x + self.changes_area.width,
+                    self.graph_area.x + self.graph_area.width,
                     mouse.column,
                     self.repo_area.width
                         + self.changes_area.width
@@ -249,6 +251,7 @@ impl App {
                 (
                     self.repo_area.y + self.repo_area.height,
                     self.changes_area.y + self.changes_area.height,
+                    self.graph_area.y + self.graph_area.height,
                     mouse.row,
                     self.repo_area.height
                         + self.changes_area.height
@@ -260,15 +263,19 @@ impl App {
 
             match mouse.kind {
                 MouseEventKind::Down(MouseButton::Left) => {
-                    let d1 = mouse_pos.abs_diff(border1);
-                    let d2 = mouse_pos.abs_diff(border2);
-                    if d1 <= GRAB_ZONE && (d1 <= d2 || d2 > GRAB_ZONE) {
-                        self.dragging_border = Some(0);
-                    } else if d2 <= GRAB_ZONE {
-                        self.dragging_border = Some(1);
-                    } else {
-                        self.dragging_border = None;
+                    // Grab the nearest border within the hit zone.
+                    let mut candidates = vec![
+                        (0u8, mouse_pos.abs_diff(border1)),
+                        (1, mouse_pos.abs_diff(border2)),
+                    ];
+                    if self.github_visible {
+                        candidates.push((2, mouse_pos.abs_diff(border3)));
                     }
+                    self.dragging_border = candidates
+                        .into_iter()
+                        .filter(|(_, d)| *d <= GRAB_ZONE)
+                        .min_by_key(|(_, d)| *d)
+                        .map(|(id, _)| id);
                     // Don't return — let the click propagate to panels
                     // so items near borders remain clickable. The drag
                     // will only engage on MouseEventKind::Drag.
@@ -281,8 +288,17 @@ impl App {
                             self.border_frac[0] = rel.clamp(min_f, self.border_frac[1] - min_f);
                         }
                         Some(1) => {
-                            self.border_frac[1] =
-                                rel.clamp(self.border_frac[0] + min_f, 1.0 - min_f);
+                            // Cap at the graph/github split when the panel is shown.
+                            let upper = if self.github_visible {
+                                self.border_frac[2]
+                            } else {
+                                1.0
+                            } - min_f;
+                            self.border_frac[1] = rel.clamp(self.border_frac[0] + min_f, upper);
+                        }
+                        Some(2) => {
+                            self.border_frac[2] =
+                                rel.clamp(self.border_frac[1] + min_f, 1.0 - min_f);
                         }
                         _ => {}
                     }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -69,9 +69,13 @@ impl App {
 
         match key.code {
             KeyCode::Char('q') => {
-                // If viewing diff, close it instead of quitting
+                // If viewing a diff or the GitHub detail, close it instead of quitting.
                 if self.focus == FocusPanel::Changes && self.file_list.viewing_diff() {
                     self.file_list.handle_key_event(key)?;
+                    return Ok(());
+                }
+                if self.focus == FocusPanel::GitHub && self.github_panel.has_detail() {
+                    self.github_panel.handle_key_event(key)?;
                     return Ok(());
                 }
                 self.action_tx.send(Action::Quit)?;
@@ -82,6 +86,8 @@ impl App {
                     self.file_list.handle_key_event(key)?;
                 } else if self.focus == FocusPanel::Graph && self.git_graph.has_detail() {
                     self.git_graph.handle_key_event(key)?;
+                } else if self.focus == FocusPanel::GitHub && self.github_panel.has_detail() {
+                    self.github_panel.handle_key_event(key)?;
                 } else {
                     match self.focus {
                         FocusPanel::GitHub => self.focus = FocusPanel::Graph,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -173,12 +173,14 @@ pub(crate) struct App {
     github_state_filter: github::GithubStateFilter,
     error_message: Option<(String, Instant)>,
     success_message: Option<(String, Instant)>,
-    /// Which border is being dragged: 0 = repos|changes, 1 = changes|graph
+    /// Which border is being dragged: 0 = repos|changes, 1 = changes|graph,
+    /// 2 = graph|github (only when the 4th panel is shown).
     dragging_border: Option<u8>,
-    /// Fraction of the layout axis for each border (0.0..1.0).
-    /// Index 0 is the repos/changes split. Index 1 is the changes/graph split.
-    /// Applies to width in horizontal mode, height in vertical mode.
-    border_frac: [f64; 2],
+    /// Fraction of the layout axis for each border (0.0..1.0). Index 0 is the
+    /// repos/changes split, 1 the changes/graph split, and 2 the graph/github
+    /// split (live only when the GitHub panel is shown). Applies to width in
+    /// horizontal mode, height in vertical mode.
+    border_frac: [f64; 3],
     /// True when the layout is horizontal (side-by-side panels)
     horizontal_layout: bool,
     /// Newer version available (set by background update check)
@@ -351,7 +353,7 @@ impl App {
             error_message: None,
             success_message: None,
             dragging_border: None,
-            border_frac: [0.25, 0.50],
+            border_frac: [0.25, 0.50, 0.78],
             horizontal_layout: false,
             update_version: None,
             update_position,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,6 +12,7 @@ use crate::components::confirm_dialog::ConfirmDialog;
 use crate::components::context_menu::ContextMenu;
 use crate::components::file_list::FileList;
 use crate::components::git_graph::GitGraph;
+use crate::components::github_panel::GithubPanel;
 use crate::components::path_input::PathInput;
 use crate::components::picker::Picker;
 use crate::components::repo_list::RepoEntry;
@@ -32,6 +33,7 @@ use crate::watcher::RepoWatcher;
 
 mod actions;
 mod actions_extra;
+mod github;
 mod input;
 mod launch;
 mod render;
@@ -43,6 +45,7 @@ pub(crate) enum FocusPanel {
     Repos,
     Changes,
     Graph,
+    GitHub,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -138,6 +141,7 @@ pub(crate) struct App {
     repo_list: RepoList,
     file_list: FileList,
     git_graph: GitGraph,
+    github_panel: GithubPanel,
     confirm_dialog: ConfirmDialog,
     context_menu: ContextMenu,
     path_input: PathInput,
@@ -153,6 +157,18 @@ pub(crate) struct App {
     repo_area: Rect,
     changes_area: Rect,
     graph_area: Rect,
+    /// Area of the optional 4th (GitHub) panel; `Rect::default()` when hidden.
+    github_area: Rect,
+    /// Cached issue/PR data per repo (see [`github::GithubState`]).
+    github_cache: HashMap<RepoId, github::GithubState>,
+    /// Manual override for the GitHub panel: `None` auto (show when the repo has
+    /// open items), `Some(true)`/`Some(false)` force open/closed. Reset on nav.
+    github_forced: Option<bool>,
+    /// Whether the GitHub panel was drawn last frame; gates focus cycling and
+    /// mouse focus so they never land on a hidden panel.
+    github_visible: bool,
+    /// Monotonic selection counter used to debounce GitHub fetches.
+    github_select_gen: u64,
     error_message: Option<(String, Instant)>,
     success_message: Option<(String, Instant)>,
     /// Which border is being dragged: 0 = repos|changes, 1 = changes|graph
@@ -309,6 +325,7 @@ impl App {
             repo_list: RepoList::new(repo_paths, theme.clone()),
             file_list: FileList::new(theme.clone()),
             git_graph,
+            github_panel: GithubPanel::new(theme.clone()),
             confirm_dialog: ConfirmDialog::new(theme.clone()),
             context_menu: ContextMenu::new(theme.clone()),
             path_input: PathInput::new(theme.clone()),
@@ -323,6 +340,11 @@ impl App {
             repo_area: Rect::default(),
             changes_area: Rect::default(),
             graph_area: Rect::default(),
+            github_area: Rect::default(),
+            github_cache: HashMap::new(),
+            github_forced: None,
+            github_visible: false,
+            github_select_gen: 0,
             error_message: None,
             success_message: None,
             dragging_border: None,
@@ -427,6 +449,8 @@ impl App {
     }
     /// Auto-load graph + file list for the selected repo.
     fn sync_selection(&mut self) {
+        // Retarget the GitHub panel onto the (new) selection, debounced.
+        self.github_touch_selection();
         // An active worktree/submodule context owns the detail panels. A sort,
         // rescan, or discovery must refresh *that* path, not reload the selected
         // parent row over it (a submodule is opened with the parent row still
@@ -457,6 +481,7 @@ impl App {
         self.repo_list.set_theme(theme.clone());
         self.file_list.set_theme(theme.clone());
         self.git_graph.set_theme(theme.clone());
+        self.github_panel.set_theme(theme.clone());
         self.confirm_dialog.set_theme(theme.clone());
         self.context_menu.set_theme(theme.clone());
         self.path_input.set_theme(theme.clone());

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -169,6 +169,8 @@ pub(crate) struct App {
     github_visible: bool,
     /// Monotonic selection counter used to debounce GitHub fetches.
     github_select_gen: u64,
+    /// Which issues/PRs the panel lists (open/all/closed); reset on nav.
+    github_state_filter: github::GithubStateFilter,
     error_message: Option<(String, Instant)>,
     success_message: Option<(String, Instant)>,
     /// Which border is being dragged: 0 = repos|changes, 1 = changes|graph
@@ -345,6 +347,7 @@ impl App {
             github_forced: None,
             github_visible: false,
             github_select_gen: 0,
+            github_state_filter: github::GithubStateFilter::default(),
             error_message: None,
             success_message: None,
             dragging_border: None,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -113,6 +113,7 @@ impl App {
 
         self.file_list.horizontal_layout = self.horizontal_layout;
         self.git_graph.horizontal_layout = self.horizontal_layout;
+        self.github_panel.horizontal_layout = self.horizontal_layout;
 
         // Start each render from a blank buffer. Split panels can collapse,
         // logs may have written into the terminal before raw mode, and shorter
@@ -330,8 +331,12 @@ impl App {
             FocusPanel::GitHub => {
                 lines.push(Line::from(""));
                 lines.push(section("GitHub"));
-                lines.push(Line::from(vec![key("j / k"), desc("Move up / down")]));
-                lines.push(Line::from(vec![key("Enter"), desc("Open in browser")]));
+                lines.push(Line::from(vec![key("j / k"), desc("Move / scroll")]));
+                lines.push(Line::from(vec![
+                    key("Enter"),
+                    desc("Preview, then open in browser"),
+                ]));
+                lines.push(Line::from(vec![key("Esc"), desc("Close preview")]));
                 lines.push(Line::from(vec![key("p"), desc("Hide panel")]));
             }
         }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -337,6 +337,10 @@ impl App {
                     desc("Preview, then open in browser"),
                 ]));
                 lines.push(Line::from(vec![key("Esc"), desc("Close preview")]));
+                lines.push(Line::from(vec![
+                    key("c"),
+                    desc("Cycle open / all / closed"),
+                ]));
                 lines.push(Line::from(vec![key("p"), desc("Hide panel")]));
             }
         }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+/// Fixed extent (columns horizontal, rows vertical) for the GitHub panel:
+/// `desired`, shrunk so the other three panels keep at least `min_others`.
+/// Zero when there is no room, which collapses the panel away.
+fn github_extent(total: u16, desired: u16, min_others: u16) -> u16 {
+    desired.min(total.saturating_sub(min_others))
+}
+
 impl App {
     pub(super) fn clear_expired_messages(&mut self) -> bool {
         let had_error = self.error_message.is_some();
@@ -30,43 +37,79 @@ impl App {
         let main_area = outer[0];
         let status_area = outer[1];
 
-        // Three-panel layout — drag borders to resize in both orientations
+        // Three-panel layout (plus an optional 4th GitHub panel) — drag borders
+        // to resize the first three in both orientations.
         self.horizontal_layout = main_area.width >= 100;
-        let (repo_area, changes_area, graph_area) = if self.horizontal_layout {
+        let show_github = self.show_github_panel();
+        self.github_visible = show_github;
+        // Never leave focus on a panel that isn't drawn this frame.
+        if !show_github && self.focus == FocusPanel::GitHub {
+            self.focus = FocusPanel::Graph;
+        }
+
+        let (repo_area, changes_area, graph_area, github_area) = if self.horizontal_layout {
             let w = main_area.width as f64;
             let c1 = (self.border_frac[0] * w).round() as u16;
             let c2 = ((self.border_frac[1] - self.border_frac[0]) * w).round() as u16;
+            let mut constraints = vec![
+                Constraint::Length(c1),
+                Constraint::Length(c2),
+                Constraint::Min(8),
+            ];
+            // ponytail: fixed-width GitHub panel so the two draggable borders
+            // and their seam painting stay untouched. Make it draggable only if
+            // users ask for it.
+            let gh = show_github
+                .then(|| github_extent(main_area.width, 44, 80))
+                .filter(|w| *w > 0);
+            if let Some(gh) = gh {
+                constraints.push(Constraint::Length(gh));
+            }
             let chunks = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints([
-                    Constraint::Length(c1),
-                    Constraint::Length(c2),
-                    Constraint::Min(8),
-                ])
+                .constraints(constraints)
                 .split(main_area);
-            (chunks[0], chunks[1], chunks[2])
+            let github_area = gh.map(|_| chunks[3]).unwrap_or_default();
+            (chunks[0], chunks[1], chunks[2], github_area)
         } else {
             let h = main_area.height as f64;
             let r1 = (self.border_frac[0] * h).round() as u16;
             let r2 = ((self.border_frac[1] - self.border_frac[0]) * h).round() as u16;
+            let mut constraints = vec![
+                Constraint::Length(r1),
+                Constraint::Length(r2),
+                Constraint::Min(3),
+            ];
+            let gh = show_github
+                .then(|| github_extent(main_area.height, 12, 18))
+                .filter(|h| *h > 0);
+            if let Some(gh) = gh {
+                constraints.push(Constraint::Length(gh));
+            }
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints([
-                    Constraint::Length(r1),
-                    Constraint::Length(r2),
-                    Constraint::Min(3),
-                ])
+                .constraints(constraints)
                 .split(main_area);
-            (chunks[0], chunks[1], chunks[2])
+            let github_area = gh.map(|_| chunks[3]).unwrap_or_default();
+            (chunks[0], chunks[1], chunks[2], github_area)
         };
+        // Recompute: `github_extent` can return 0 on a tiny terminal even when
+        // `show_github` was true, so trust the actual rect.
+        let show_github = github_area.width > 0 && github_area.height > 0;
+        self.github_visible = show_github;
+        if !show_github && self.focus == FocusPanel::GitHub {
+            self.focus = FocusPanel::Graph;
+        }
 
         self.repo_area = repo_area;
         self.changes_area = changes_area;
         self.graph_area = graph_area;
+        self.github_area = github_area;
 
         self.repo_list.focused = self.focus == FocusPanel::Repos;
         self.file_list.focused = self.focus == FocusPanel::Changes;
         self.git_graph.focused = self.focus == FocusPanel::Graph;
+        self.github_panel.focused = self.focus == FocusPanel::GitHub;
 
         self.file_list.horizontal_layout = self.horizontal_layout;
         self.git_graph.horizontal_layout = self.horizontal_layout;
@@ -79,6 +122,9 @@ impl App {
         self.repo_list.draw(frame, repo_area)?;
         self.file_list.draw(frame, changes_area)?;
         self.git_graph.draw(frame, graph_area)?;
+        if show_github {
+            self.github_panel.draw(frame, github_area)?;
+        }
 
         // Paint thick seam borders in horizontal mode to signal "draggable".
         // Vertical mode doesn't need this — the full-width horizontal borders
@@ -234,6 +280,7 @@ impl App {
             Line::from(vec![key("o"), desc("Open repo/worktree")]),
             Line::from(vec![key("v"), desc("Review changes (tmux window)")]),
             Line::from(vec![key("G"), desc("Attach live tmux session")]),
+            Line::from(vec![key("p"), desc("Toggle GitHub panel")]),
             Line::from(vec![key("y"), desc("Copy to clipboard")]),
             Line::from(vec![key("q"), desc("Quit")]),
         ];
@@ -280,6 +327,13 @@ impl App {
                 lines.push(Line::from(vec![key("c"), desc("Collapse / expand branch")]));
                 lines.push(Line::from(vec![key("H"), desc("Expand all collapsed")]));
             }
+            FocusPanel::GitHub => {
+                lines.push(Line::from(""));
+                lines.push(section("GitHub"));
+                lines.push(Line::from(vec![key("j / k"), desc("Move up / down")]));
+                lines.push(Line::from(vec![key("Enter"), desc("Open in browser")]));
+                lines.push(Line::from(vec![key("p"), desc("Hide panel")]));
+            }
         }
 
         let height = (lines.len() as u16 + 2).min(area.height);
@@ -292,6 +346,7 @@ impl App {
             FocusPanel::Repos => "Repos",
             FocusPanel::Changes => "Changes",
             FocusPanel::Graph => "Graph",
+            FocusPanel::GitHub => "GitHub",
         };
         let block = Block::default()
             .title(format!(" Keybindings \u{2014} {panel_name} "))

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1,12 +1,5 @@
 use super::*;
 
-/// Fixed extent (columns horizontal, rows vertical) for the GitHub panel:
-/// `desired`, shrunk so the other three panels keep at least `min_others`.
-/// Zero when there is no room, which collapses the panel away.
-fn github_extent(total: u16, desired: u16, min_others: u16) -> u16 {
-    desired.min(total.saturating_sub(min_others))
-}
-
 impl App {
     pub(super) fn clear_expired_messages(&mut self) -> bool {
         let had_error = self.error_message.is_some();
@@ -37,8 +30,8 @@ impl App {
         let main_area = outer[0];
         let status_area = outer[1];
 
-        // Three-panel layout (plus an optional 4th GitHub panel) — drag borders
-        // to resize the first three in both orientations.
+        // Three-panel layout (plus an optional 4th GitHub panel). Every border
+        // drags to resize in both orientations.
         self.horizontal_layout = main_area.width >= 100;
         let show_github = self.show_github_panel();
         self.github_visible = show_github;
@@ -47,59 +40,78 @@ impl App {
             self.focus = FocusPanel::Graph;
         }
 
+        // Keep the graph/github split right of the changes/graph split so the
+        // panel never inverts if the first two borders were dragged while the
+        // GitHub panel was hidden.
+        if show_github {
+            let axis = if self.horizontal_layout {
+                main_area.width
+            } else {
+                main_area.height
+            };
+            let min_gap = 3.0 / (axis.max(1) as f64);
+            self.border_frac[2] =
+                self.border_frac[2].clamp(self.border_frac[1] + min_gap, 1.0 - min_gap);
+        }
+
         let (repo_area, changes_area, graph_area, github_area) = if self.horizontal_layout {
             let w = main_area.width as f64;
             let c1 = (self.border_frac[0] * w).round() as u16;
             let c2 = ((self.border_frac[1] - self.border_frac[0]) * w).round() as u16;
-            let mut constraints = vec![
-                Constraint::Length(c1),
-                Constraint::Length(c2),
-                Constraint::Min(8),
-            ];
-            // ponytail: fixed-width GitHub panel so the two draggable borders
-            // and their seam painting stay untouched. Make it draggable only if
-            // users ask for it.
-            let gh = show_github
-                .then(|| github_extent(main_area.width, 44, 80))
-                .filter(|w| *w > 0);
-            if let Some(gh) = gh {
-                constraints.push(Constraint::Length(gh));
+            if show_github {
+                // graph is fraction-sized; github takes the remainder, so
+                // dragging the graph/github border resizes them together (as the
+                // changes/graph border does for changes + graph).
+                let c3 = ((self.border_frac[2] - self.border_frac[1]) * w).round() as u16;
+                let chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([
+                        Constraint::Length(c1),
+                        Constraint::Length(c2),
+                        Constraint::Length(c3),
+                        Constraint::Min(8),
+                    ])
+                    .split(main_area);
+                (chunks[0], chunks[1], chunks[2], chunks[3])
+            } else {
+                let chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([
+                        Constraint::Length(c1),
+                        Constraint::Length(c2),
+                        Constraint::Min(8),
+                    ])
+                    .split(main_area);
+                (chunks[0], chunks[1], chunks[2], Rect::default())
             }
-            let chunks = Layout::default()
-                .direction(Direction::Horizontal)
-                .constraints(constraints)
-                .split(main_area);
-            let github_area = gh.map(|_| chunks[3]).unwrap_or_default();
-            (chunks[0], chunks[1], chunks[2], github_area)
         } else {
             let h = main_area.height as f64;
             let r1 = (self.border_frac[0] * h).round() as u16;
             let r2 = ((self.border_frac[1] - self.border_frac[0]) * h).round() as u16;
-            let mut constraints = vec![
-                Constraint::Length(r1),
-                Constraint::Length(r2),
-                Constraint::Min(3),
-            ];
-            let gh = show_github
-                .then(|| github_extent(main_area.height, 12, 18))
-                .filter(|h| *h > 0);
-            if let Some(gh) = gh {
-                constraints.push(Constraint::Length(gh));
+            if show_github {
+                let r3 = ((self.border_frac[2] - self.border_frac[1]) * h).round() as u16;
+                let chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(r1),
+                        Constraint::Length(r2),
+                        Constraint::Length(r3),
+                        Constraint::Min(3),
+                    ])
+                    .split(main_area);
+                (chunks[0], chunks[1], chunks[2], chunks[3])
+            } else {
+                let chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(r1),
+                        Constraint::Length(r2),
+                        Constraint::Min(3),
+                    ])
+                    .split(main_area);
+                (chunks[0], chunks[1], chunks[2], Rect::default())
             }
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints(constraints)
-                .split(main_area);
-            let github_area = gh.map(|_| chunks[3]).unwrap_or_default();
-            (chunks[0], chunks[1], chunks[2], github_area)
         };
-        // Recompute: `github_extent` can return 0 on a tiny terminal even when
-        // `show_github` was true, so trust the actual rect.
-        let show_github = github_area.width > 0 && github_area.height > 0;
-        self.github_visible = show_github;
-        if !show_github && self.focus == FocusPanel::GitHub {
-            self.focus = FocusPanel::Graph;
-        }
 
         self.repo_area = repo_area;
         self.changes_area = changes_area;
@@ -134,7 +146,7 @@ impl App {
             use ratatui::style::Style;
 
             let buf = frame.buffer_mut();
-            for (dragging, x_a, x_b) in [
+            let mut seams = vec![
                 (
                     self.dragging_border == Some(0),
                     repo_area.x + repo_area.width.saturating_sub(1),
@@ -145,7 +157,15 @@ impl App {
                     changes_area.x + changes_area.width.saturating_sub(1),
                     graph_area.x,
                 ),
-            ] {
+            ];
+            if show_github {
+                seams.push((
+                    self.dragging_border == Some(2),
+                    graph_area.x + graph_area.width.saturating_sub(1),
+                    github_area.x,
+                ));
+            }
+            for (dragging, x_a, x_b) in seams {
                 let color = if dragging {
                     self.theme.overlay.border_drag_active
                 } else {
@@ -165,10 +185,14 @@ impl App {
             use ratatui::style::Style;
             let style = Style::default().fg(self.theme.overlay.border_drag_active);
             let buf = frame.buffer_mut();
-            for (dragging, y) in [
+            let mut seams = vec![
                 (self.dragging_border == Some(0), changes_area.y),
                 (self.dragging_border == Some(1), graph_area.y),
-            ] {
+            ];
+            if show_github {
+                seams.push((self.dragging_border == Some(2), github_area.y));
+            }
+            for (dragging, y) in seams {
                 if !dragging {
                     continue;
                 }

--- a/src/components/github_panel.rs
+++ b/src/components/github_panel.rs
@@ -612,4 +612,33 @@ mod tests {
         p.close_detail();
         assert!(!p.has_detail(), "closing clears the pane");
     }
+
+    #[test]
+    fn renders_title_and_rows_to_a_buffer() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut p = panel();
+        p.set_data(vec![item(1)], vec![item(2)], "myrepo", "open");
+        let mut terminal = Terminal::new(TestBackend::new(80, 8)).unwrap();
+        terminal
+            .draw(|f| {
+                p.draw(f, f.area()).unwrap();
+            })
+            .unwrap();
+
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+
+        for needle in ["GitHub", "myrepo", "open", "#1", "issue", "#2", "PR"] {
+            assert!(
+                text.contains(needle),
+                "expected {needle:?} in render: {text:?}"
+            );
+        }
+    }
 }

--- a/src/components/github_panel.rs
+++ b/src/components/github_panel.rs
@@ -400,8 +400,41 @@ impl GithubPanel {
                 )));
             }
         }
+        // PR file changes (unified diff), colored like the changes-panel diff.
+        if let Some(diff) = &d.diff {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "\u{2500}\u{2500} Files changed \u{2500}\u{2500}",
+                Style::default()
+                    .fg(f.diff_border)
+                    .add_modifier(Modifier::BOLD),
+            )));
+            for line in diff.lines() {
+                lines.push(diff_line(line, f));
+            }
+        }
         lines
     }
+}
+
+/// Style one unified-diff line by its prefix (matches the changes panel).
+fn diff_line(line: &str, f: &crate::theme::FileListTheme) -> Line<'static> {
+    let color = if line.starts_with("+++")
+        || line.starts_with("---")
+        || line.starts_with("diff ")
+        || line.starts_with("index ")
+    {
+        f.diff_meta
+    } else if line.starts_with('+') {
+        f.diff_added
+    } else if line.starts_with('-') {
+        f.diff_removed
+    } else if line.starts_with("@@") {
+        f.diff_hunk
+    } else {
+        f.diff_context
+    };
+    Line::from(Span::styled(line.to_string(), Style::default().fg(color)))
 }
 
 impl Component for GithubPanel {
@@ -583,7 +616,21 @@ mod tests {
             author: "alice".into(),
             body: "body".into(),
             comments: vec![],
+            diff: None,
         }
+    }
+
+    #[test]
+    fn diff_line_colors_by_prefix() {
+        let f = crate::theme::FileListTheme::default();
+        // File headers are meta, not additions/removals, despite the +/- prefix.
+        let meta = |l: &str| diff_line(l, &f).spans[0].style.fg.unwrap();
+        assert_eq!(meta("+++ b/x"), f.diff_meta);
+        assert_eq!(meta("--- a/x"), f.diff_meta);
+        assert_eq!(meta("+added"), f.diff_added);
+        assert_eq!(meta("-removed"), f.diff_removed);
+        assert_eq!(meta("@@ -1 +1 @@"), f.diff_hunk);
+        assert_eq!(meta(" context"), f.diff_context);
     }
 
     #[test]

--- a/src/components/github_panel.rs
+++ b/src/components/github_panel.rs
@@ -1,0 +1,356 @@
+use color_eyre::Result;
+use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+use std::sync::Arc;
+
+use crate::action::Action;
+use crate::components::Component;
+use crate::git::github::GhItem;
+use crate::theme::Theme;
+
+/// One selectable row: either an issue or a pull request.
+struct PanelRow {
+    is_pr: bool,
+    item: GhItem,
+}
+
+/// What the panel shows when it has no rows to list.
+enum PanelStatus {
+    /// Rows are authoritative (may still be empty = "no open items").
+    Ready,
+    /// A fetch is in flight and there is nothing cached yet.
+    Loading,
+    /// The selected repo has no github.com `origin`.
+    NotGithub,
+    /// A `gh` invocation failed; the message is its first stderr line.
+    Error(String),
+}
+
+/// The 4th panel: open issues and pull requests for the selected repo, fetched
+/// through the `gh` CLI. It is a pure view — [`crate::app::App`] owns the cache
+/// and feeds this component on selection change and when a fetch completes.
+pub(crate) struct GithubPanel {
+    rows: Vec<PanelRow>,
+    issue_count: usize,
+    pr_count: usize,
+    state: ListState,
+    repo_name: String,
+    status: PanelStatus,
+    pub focused: bool,
+    render_area: Rect,
+    theme: Arc<Theme>,
+}
+
+impl GithubPanel {
+    pub fn new(theme: Arc<Theme>) -> Self {
+        Self {
+            rows: Vec::new(),
+            issue_count: 0,
+            pr_count: 0,
+            state: ListState::default(),
+            repo_name: String::new(),
+            status: PanelStatus::Loading,
+            focused: false,
+            render_area: Rect::default(),
+            theme,
+        }
+    }
+
+    pub fn set_theme(&mut self, theme: Arc<Theme>) {
+        self.theme = theme;
+    }
+
+    /// Replace the panel's data. Selection is preserved when the repo is
+    /// unchanged (a refetch of the same repo), reset to the top otherwise.
+    pub fn set_data(&mut self, issues: Vec<GhItem>, prs: Vec<GhItem>, repo_name: &str) {
+        let same_repo = self.repo_name == repo_name;
+        let prev = self.state.selected();
+        self.issue_count = issues.len();
+        self.pr_count = prs.len();
+        self.rows = issues
+            .into_iter()
+            .map(|item| PanelRow { is_pr: false, item })
+            .chain(prs.into_iter().map(|item| PanelRow { is_pr: true, item }))
+            .collect();
+        self.repo_name = repo_name.to_string();
+        self.status = PanelStatus::Ready;
+
+        if self.rows.is_empty() {
+            self.state.select(None);
+        } else if same_repo {
+            let idx = prev.map(|i| i.min(self.rows.len() - 1)).unwrap_or(0);
+            self.state.select(Some(idx));
+        } else {
+            self.state.select(Some(0));
+        }
+    }
+
+    pub fn set_loading(&mut self, repo_name: &str) {
+        self.reset_if_new(repo_name);
+        self.status = PanelStatus::Loading;
+    }
+
+    pub fn set_not_github(&mut self, repo_name: &str) {
+        self.reset_if_new(repo_name);
+        self.status = PanelStatus::NotGithub;
+    }
+
+    pub fn set_error(&mut self, repo_name: &str, message: String) {
+        self.reset_if_new(repo_name);
+        self.status = PanelStatus::Error(message);
+    }
+
+    /// Drop stale rows when the panel retargets a different repo. On a same-repo
+    /// status change (e.g. a refetch) the rows stay put so the list doesn't
+    /// flicker while new data loads.
+    fn reset_if_new(&mut self, repo_name: &str) {
+        if self.repo_name != repo_name {
+            self.rows.clear();
+            self.issue_count = 0;
+            self.pr_count = 0;
+            self.state.select(None);
+        }
+        self.repo_name = repo_name.to_string();
+    }
+
+    /// Web URL of the selected row, for opening in the browser.
+    pub fn selected_url(&self) -> Option<String> {
+        let idx = self.state.selected()?;
+        self.rows.get(idx).map(|r| r.item.url.clone())
+    }
+
+    fn select_next(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        let i = match self.state.selected() {
+            Some(i) => (i + 1).min(self.rows.len() - 1),
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
+
+    fn select_prev(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        let i = match self.state.selected() {
+            Some(i) => i.saturating_sub(1),
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
+
+    fn row_line(&self, row: &PanelRow) -> Line<'static> {
+        let f = &self.theme.file_list;
+        let g = &self.theme.graph;
+        let r = &self.theme.repo_list;
+
+        let (tag, tag_color) = if row.is_pr {
+            if row.item.is_draft {
+                ("PR draft", f.empty_text)
+            } else {
+                ("PR", r.ahead)
+            }
+        } else {
+            ("issue", f.status_modified)
+        };
+
+        let date = row
+            .item
+            .updated_at
+            .get(..10)
+            .unwrap_or(&row.item.updated_at)
+            .to_string();
+
+        Line::from(vec![
+            Span::styled(
+                format!("#{} ", row.item.number),
+                Style::default()
+                    .fg(g.commit_id)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(format!("{tag} "), Style::default().fg(tag_color)),
+            Span::styled(row.item.title.clone(), Style::default().fg(f.regular_path)),
+            Span::styled(
+                format!("  {} \u{00b7} {}", row.item.author, date),
+                Style::default().fg(g.time),
+            ),
+        ])
+    }
+}
+
+impl Component for GithubPanel {
+    fn handle_key_event(&mut self, key: KeyEvent) -> Result<Option<Action>> {
+        match key.code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.select_next();
+                Ok(None)
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.select_prev();
+                Ok(None)
+            }
+            KeyCode::Enter => Ok(self.selected_url().map(Action::OpenUrl)),
+            _ => Ok(None),
+        }
+    }
+
+    fn handle_mouse_event(&mut self, mouse: MouseEvent) -> Result<Option<Action>> {
+        match mouse.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                let pos = ratatui::layout::Position::new(mouse.column, mouse.row);
+                if self.render_area.contains(pos) {
+                    let content_y = self.render_area.y + 1; // +1 for border
+                    if mouse.row >= content_y {
+                        let idx = (mouse.row - content_y) as usize + self.state.offset();
+                        if idx < self.rows.len() {
+                            if self.state.selected() == Some(idx) {
+                                return Ok(self
+                                    .rows
+                                    .get(idx)
+                                    .map(|r| Action::OpenUrl(r.item.url.clone())));
+                            }
+                            self.state.select(Some(idx));
+                        }
+                    }
+                }
+                Ok(None)
+            }
+            MouseEventKind::ScrollUp => {
+                self.select_prev();
+                Ok(None)
+            }
+            MouseEventKind::ScrollDown => {
+                self.select_next();
+                Ok(None)
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        self.render_area = area;
+        let f = &self.theme.file_list;
+        let border_color = if self.focused {
+            f.border_focused
+        } else {
+            f.border_unfocused
+        };
+
+        let title = if self.repo_name.is_empty() {
+            " GitHub ".to_string()
+        } else {
+            format!(
+                " GitHub \u{2014} {} ({} issues, {} PRs) ",
+                self.repo_name, self.issue_count, self.pr_count
+            )
+        };
+
+        let block = Block::default()
+            .title(title)
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(border_color));
+
+        if self.rows.is_empty() {
+            let msg = match &self.status {
+                PanelStatus::Loading => "Loading\u{2026}",
+                PanelStatus::NotGithub => "No github.com remote",
+                PanelStatus::Error(e) => e.as_str(),
+                PanelStatus::Ready => "No open issues or PRs",
+            };
+            let paragraph = Paragraph::new(msg)
+                .style(Style::default().fg(f.empty_text))
+                .block(block);
+            frame.render_widget(paragraph, area);
+            return Ok(());
+        }
+
+        let items: Vec<ListItem> = self
+            .rows
+            .iter()
+            .map(|row| ListItem::new(self.row_line(row)))
+            .collect();
+
+        let list = List::new(items).block(block).highlight_style(
+            Style::default()
+                .bg(f.selection_bg)
+                .add_modifier(Modifier::BOLD),
+        );
+
+        frame.render_stateful_widget(list, area, &mut self.state);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(n: u64) -> GhItem {
+        GhItem {
+            number: n,
+            title: format!("title {n}"),
+            is_draft: false,
+            author: "octocat".into(),
+            updated_at: "2026-01-02T03:04:05Z".into(),
+            url: format!("https://github.com/o/r/issues/{n}"),
+        }
+    }
+
+    fn panel() -> GithubPanel {
+        GithubPanel::new(Arc::new(Theme::default()))
+    }
+
+    #[test]
+    fn set_data_orders_issues_before_prs_and_counts_each() {
+        let mut p = panel();
+        p.set_data(vec![item(1), item(2)], vec![item(3)], "repo");
+        assert_eq!(p.issue_count, 2);
+        assert_eq!(p.pr_count, 1);
+        assert_eq!(p.rows.len(), 3);
+        assert!(!p.rows[0].is_pr);
+        assert!(!p.rows[1].is_pr);
+        assert!(p.rows[2].is_pr);
+        // Selection lands on the first row; its URL is what Enter would open.
+        assert_eq!(
+            p.selected_url().as_deref(),
+            Some("https://github.com/o/r/issues/1")
+        );
+    }
+
+    #[test]
+    fn selection_persists_on_same_repo_and_resets_on_a_new_one() {
+        let mut p = panel();
+        p.set_data(vec![item(1), item(2), item(3)], vec![], "repo");
+        p.state.select(Some(2));
+        p.set_data(vec![item(1), item(2), item(3)], vec![], "repo");
+        assert_eq!(p.state.selected(), Some(2), "same repo keeps selection");
+        p.set_data(vec![item(9)], vec![], "other");
+        assert_eq!(p.state.selected(), Some(0), "new repo resets selection");
+    }
+
+    #[test]
+    fn empty_result_clears_selection_and_url() {
+        let mut p = panel();
+        p.set_data(vec![], vec![], "repo");
+        assert_eq!(p.state.selected(), None);
+        assert!(p.selected_url().is_none());
+    }
+
+    #[test]
+    fn retargeting_to_a_new_repo_drops_stale_rows() {
+        let mut p = panel();
+        p.set_data(vec![item(1)], vec![item(2)], "repo");
+        p.set_loading("other");
+        assert!(p.rows.is_empty(), "loading a new repo clears old rows");
+        assert_eq!(p.issue_count, 0);
+        assert_eq!(p.pr_count, 0);
+    }
+}

--- a/src/components/github_panel.rs
+++ b/src/components/github_panel.rs
@@ -2,16 +2,16 @@ use color_eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::{
     Frame,
-    layout::Rect,
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
 };
 use std::sync::Arc;
 
 use crate::action::Action;
 use crate::components::Component;
-use crate::git::github::GhItem;
+use crate::git::github::{GhItem, ItemDetail};
 use crate::theme::Theme;
 
 /// One selectable row: either an issue or a pull request.
@@ -43,7 +43,20 @@ pub(crate) struct GithubPanel {
     repo_name: String,
     status: PanelStatus,
     pub focused: bool,
+    /// Fed by `App` each frame: split direction follows the main layout.
+    pub horizontal_layout: bool,
     render_area: Rect,
+    list_area: Rect,
+    detail_area: Rect,
+    /// Loaded body + comments for the selected item; `Some` opens the detail
+    /// pane. `None` with `detail_loading`/`detail_error` covers the in-flight
+    /// and failed states.
+    detail: Option<ItemDetail>,
+    detail_loading: bool,
+    detail_error: Option<String>,
+    detail_scroll: u16,
+    /// Bumped per detail request so a late `gh view` result is discarded.
+    detail_generation: u64,
     theme: Arc<Theme>,
 }
 
@@ -57,7 +70,15 @@ impl GithubPanel {
             repo_name: String::new(),
             status: PanelStatus::Loading,
             focused: false,
+            horizontal_layout: false,
             render_area: Rect::default(),
+            list_area: Rect::default(),
+            detail_area: Rect::default(),
+            detail: None,
+            detail_loading: false,
+            detail_error: None,
+            detail_scroll: 0,
+            detail_generation: 0,
             theme,
         }
     }
@@ -115,6 +136,7 @@ impl GithubPanel {
             self.issue_count = 0;
             self.pr_count = 0;
             self.state.select(None);
+            self.close_detail();
         }
         self.repo_name = repo_name.to_string();
     }
@@ -123,6 +145,56 @@ impl GithubPanel {
     pub fn selected_url(&self) -> Option<String> {
         let idx = self.state.selected()?;
         self.rows.get(idx).map(|r| r.item.url.clone())
+    }
+
+    /// Whether the detail (body + comments) pane is open — loading, loaded, or
+    /// showing a fetch error.
+    pub fn has_detail(&self) -> bool {
+        self.detail_loading || self.detail.is_some() || self.detail_error.is_some()
+    }
+
+    /// Close the detail pane and reset its scroll.
+    pub fn close_detail(&mut self) {
+        self.detail = None;
+        self.detail_loading = false;
+        self.detail_error = None;
+        self.detail_scroll = 0;
+    }
+
+    /// Apply a detail fetch result, discarding it if a newer request superseded
+    /// this one (generation mismatch).
+    pub fn set_detail(&mut self, generation: u64, result: Result<ItemDetail, String>) {
+        if generation != self.detail_generation {
+            return;
+        }
+        self.detail_loading = false;
+        match result {
+            Ok(detail) => {
+                self.detail = Some(detail);
+                self.detail_error = None;
+            }
+            Err(e) => {
+                self.detail = None;
+                self.detail_error = Some(e);
+            }
+        }
+    }
+
+    /// Begin loading the selected item's detail: bump the generation, mark the
+    /// pane loading, and return the fetch action for `App` to run.
+    fn open_selected_detail(&mut self) -> Option<Action> {
+        let idx = self.state.selected()?;
+        let row = self.rows.get(idx)?;
+        self.detail_generation = self.detail_generation.wrapping_add(1);
+        self.detail_loading = true;
+        self.detail = None;
+        self.detail_error = None;
+        self.detail_scroll = 0;
+        Some(Action::ShowGithubItem {
+            url: row.item.url.clone(),
+            is_pr: row.is_pr,
+            generation: self.detail_generation,
+        })
     }
 
     fn select_next(&mut self) {
@@ -184,61 +256,11 @@ impl GithubPanel {
             ),
         ])
     }
-}
 
-impl Component for GithubPanel {
-    fn handle_key_event(&mut self, key: KeyEvent) -> Result<Option<Action>> {
-        match key.code {
-            KeyCode::Char('j') | KeyCode::Down => {
-                self.select_next();
-                Ok(None)
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.select_prev();
-                Ok(None)
-            }
-            KeyCode::Enter => Ok(self.selected_url().map(Action::OpenUrl)),
-            _ => Ok(None),
-        }
-    }
-
-    fn handle_mouse_event(&mut self, mouse: MouseEvent) -> Result<Option<Action>> {
-        match mouse.kind {
-            MouseEventKind::Down(MouseButton::Left) => {
-                let pos = ratatui::layout::Position::new(mouse.column, mouse.row);
-                if self.render_area.contains(pos) {
-                    let content_y = self.render_area.y + 1; // +1 for border
-                    if mouse.row >= content_y {
-                        let idx = (mouse.row - content_y) as usize + self.state.offset();
-                        if idx < self.rows.len() {
-                            if self.state.selected() == Some(idx) {
-                                return Ok(self
-                                    .rows
-                                    .get(idx)
-                                    .map(|r| Action::OpenUrl(r.item.url.clone())));
-                            }
-                            self.state.select(Some(idx));
-                        }
-                    }
-                }
-                Ok(None)
-            }
-            MouseEventKind::ScrollUp => {
-                self.select_prev();
-                Ok(None)
-            }
-            MouseEventKind::ScrollDown => {
-                self.select_next();
-                Ok(None)
-            }
-            _ => Ok(None),
-        }
-    }
-
-    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        self.render_area = area;
+    fn draw_list(&mut self, frame: &mut Frame, area: Rect) {
+        self.list_area = area;
         let f = &self.theme.file_list;
-        let border_color = if self.focused {
+        let border_color = if self.focused && !self.has_detail() {
             f.border_focused
         } else {
             f.border_unfocused
@@ -269,7 +291,7 @@ impl Component for GithubPanel {
                 .style(Style::default().fg(f.empty_text))
                 .block(block);
             frame.render_widget(paragraph, area);
-            return Ok(());
+            return;
         }
 
         let items: Vec<ListItem> = self
@@ -285,6 +307,181 @@ impl Component for GithubPanel {
         );
 
         frame.render_stateful_widget(list, area, &mut self.state);
+    }
+
+    fn draw_detail(&mut self, frame: &mut Frame, area: Rect) {
+        self.detail_area = area;
+        let f = &self.theme.file_list;
+        let g = &self.theme.graph;
+
+        let title = match &self.detail {
+            Some(d) => format!(" #{} \u{2014} {} (Esc to close) ", d.number, d.title),
+            None => " GitHub item (Esc to close) ".to_string(),
+        };
+        let block = Block::default()
+            .title(title)
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(f.diff_border));
+
+        let lines: Vec<Line> = if self.detail_loading {
+            vec![Line::from(Span::styled(
+                "Loading\u{2026}",
+                Style::default().fg(f.empty_text),
+            ))]
+        } else if let Some(e) = &self.detail_error {
+            vec![Line::from(Span::styled(
+                e.clone(),
+                Style::default().fg(g.error_text),
+            ))]
+        } else if let Some(d) = &self.detail {
+            self.detail_lines(d)
+        } else {
+            Vec::new()
+        };
+
+        let paragraph = Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false })
+            .scroll((self.detail_scroll, 0));
+        frame.render_widget(paragraph, area);
+    }
+
+    /// Body + comment thread of an item as styled, wrappable lines.
+    fn detail_lines(&self, d: &ItemDetail) -> Vec<Line<'static>> {
+        let f = &self.theme.file_list;
+        let g = &self.theme.graph;
+        let mut lines: Vec<Line> = vec![
+            Line::from(Span::styled(
+                format!("@{}", d.author),
+                Style::default().fg(g.time),
+            )),
+            Line::from(""),
+        ];
+        for line in d.body.lines() {
+            lines.push(Line::from(Span::styled(
+                line.to_string(),
+                Style::default().fg(f.regular_path),
+            )));
+        }
+        for c in &d.comments {
+            lines.push(Line::from(""));
+            let date = c.created_at.get(..10).unwrap_or(&c.created_at);
+            lines.push(Line::from(Span::styled(
+                format!("\u{2500}\u{2500} @{} \u{00b7} {}", c.author, date),
+                Style::default().fg(g.commit_id),
+            )));
+            for line in c.body.lines() {
+                lines.push(Line::from(Span::styled(
+                    line.to_string(),
+                    Style::default().fg(f.regular_path),
+                )));
+            }
+        }
+        lines
+    }
+}
+
+impl Component for GithubPanel {
+    fn handle_key_event(&mut self, key: KeyEvent) -> Result<Option<Action>> {
+        // Detail pane open: keys scroll or close it, or open the item in the
+        // browser. ghpeek-style: Enter in the list previews, Enter again opens.
+        if self.has_detail() {
+            match key.code {
+                KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('h') | KeyCode::Left => {
+                    self.close_detail();
+                }
+                KeyCode::Char('j') | KeyCode::Down => {
+                    self.detail_scroll = self.detail_scroll.saturating_add(1);
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    self.detail_scroll = self.detail_scroll.saturating_sub(1);
+                }
+                KeyCode::Enter => return Ok(self.selected_url().map(Action::OpenUrl)),
+                _ => {}
+            }
+            return Ok(None);
+        }
+
+        match key.code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.select_next();
+                Ok(None)
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.select_prev();
+                Ok(None)
+            }
+            KeyCode::Enter => Ok(self.open_selected_detail()),
+            _ => Ok(None),
+        }
+    }
+
+    fn handle_mouse_event(&mut self, mouse: MouseEvent) -> Result<Option<Action>> {
+        match mouse.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                let pos = ratatui::layout::Position::new(mouse.column, mouse.row);
+                // When split, only the list half selects rows.
+                let click_area = if self.has_detail() {
+                    self.list_area
+                } else {
+                    self.render_area
+                };
+                if click_area.contains(pos) {
+                    let content_y = click_area.y + 1; // +1 for border
+                    if mouse.row >= content_y {
+                        let idx = (mouse.row - content_y) as usize + self.state.offset();
+                        if idx < self.rows.len() {
+                            // Click the already-selected row to open its detail.
+                            if self.state.selected() == Some(idx) {
+                                return Ok(self.open_selected_detail());
+                            }
+                            self.state.select(Some(idx));
+                        }
+                    }
+                }
+                Ok(None)
+            }
+            MouseEventKind::ScrollUp => {
+                if self.has_detail() {
+                    self.detail_scroll = self.detail_scroll.saturating_sub(1);
+                } else {
+                    self.select_prev();
+                }
+                Ok(None)
+            }
+            MouseEventKind::ScrollDown => {
+                if self.has_detail() {
+                    self.detail_scroll = self.detail_scroll.saturating_add(1);
+                } else {
+                    self.select_next();
+                }
+                Ok(None)
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        self.render_area = area;
+        if self.has_detail() {
+            // A narrow column (horizontal main layout) stacks list over detail;
+            // a wide short row splits them side by side. Mirrors the changes
+            // panel's diff split.
+            let dir = if self.horizontal_layout {
+                Direction::Vertical
+            } else {
+                Direction::Horizontal
+            };
+            let chunks = Layout::default()
+                .direction(dir)
+                .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+                .split(area);
+            self.draw_list(frame, chunks[0]);
+            self.draw_detail(frame, chunks[1]);
+        } else {
+            self.detail_area = Rect::default();
+            self.draw_list(frame, area);
+        }
         Ok(())
     }
 }
@@ -352,5 +549,42 @@ mod tests {
         assert!(p.rows.is_empty(), "loading a new repo clears old rows");
         assert_eq!(p.issue_count, 0);
         assert_eq!(p.pr_count, 0);
+    }
+
+    fn detail(n: u64) -> ItemDetail {
+        ItemDetail {
+            number: n,
+            title: format!("title {n}"),
+            author: "alice".into(),
+            body: "body".into(),
+            comments: vec![],
+        }
+    }
+
+    #[test]
+    fn detail_opens_loads_and_discards_stale_results() {
+        let mut p = panel();
+        p.set_data(vec![item(1)], vec![], "repo");
+        let generation = match p.open_selected_detail().expect("enter yields an action") {
+            Action::ShowGithubItem {
+                generation, is_pr, ..
+            } => {
+                assert!(!is_pr, "issue, not PR");
+                generation
+            }
+            other => panic!("expected ShowGithubItem, got {other:?}"),
+        };
+        assert!(p.has_detail(), "pane is open (loading) once requested");
+
+        // A result from a superseded request is dropped.
+        p.set_detail(generation.wrapping_sub(1), Ok(detail(99)));
+        assert!(p.detail.is_none(), "stale generation ignored");
+
+        // The current-generation result lands.
+        p.set_detail(generation, Ok(detail(1)));
+        assert_eq!(p.detail.as_ref().unwrap().number, 1);
+
+        p.close_detail();
+        assert!(!p.has_detail(), "closing clears the pane");
     }
 }

--- a/src/components/github_panel.rs
+++ b/src/components/github_panel.rs
@@ -41,6 +41,8 @@ pub(crate) struct GithubPanel {
     pr_count: usize,
     state: ListState,
     repo_name: String,
+    /// Filter label shown in the title ("open" / "all" / "closed").
+    state_label: String,
     status: PanelStatus,
     pub focused: bool,
     /// Fed by `App` each frame: split direction follows the main layout.
@@ -68,6 +70,7 @@ impl GithubPanel {
             pr_count: 0,
             state: ListState::default(),
             repo_name: String::new(),
+            state_label: "open".to_string(),
             status: PanelStatus::Loading,
             focused: false,
             horizontal_layout: false,
@@ -89,9 +92,16 @@ impl GithubPanel {
 
     /// Replace the panel's data. Selection is preserved when the repo is
     /// unchanged (a refetch of the same repo), reset to the top otherwise.
-    pub fn set_data(&mut self, issues: Vec<GhItem>, prs: Vec<GhItem>, repo_name: &str) {
+    pub fn set_data(
+        &mut self,
+        issues: Vec<GhItem>,
+        prs: Vec<GhItem>,
+        repo_name: &str,
+        state_label: &str,
+    ) {
         let same_repo = self.repo_name == repo_name;
         let prev = self.state.selected();
+        self.state_label = state_label.to_string();
         self.issue_count = issues.len();
         self.pr_count = prs.len();
         self.rows = issues
@@ -241,7 +251,7 @@ impl GithubPanel {
             .unwrap_or(&row.item.updated_at)
             .to_string();
 
-        Line::from(vec![
+        let mut spans = vec![
             Span::styled(
                 format!("#{} ", row.item.number),
                 Style::default()
@@ -249,12 +259,25 @@ impl GithubPanel {
                     .add_modifier(Modifier::BOLD),
             ),
             Span::styled(format!("{tag} "), Style::default().fg(tag_color)),
-            Span::styled(row.item.title.clone(), Style::default().fg(f.regular_path)),
-            Span::styled(
-                format!("  {} \u{00b7} {}", row.item.author, date),
-                Style::default().fg(g.time),
-            ),
-        ])
+        ];
+        // Mark non-open rows, visible under the closed/all filter.
+        if !row.item.state.eq_ignore_ascii_case("open") {
+            let (label, color) = if row.item.state.eq_ignore_ascii_case("merged") {
+                ("merged ", f.submodule_path)
+            } else {
+                ("closed ", r.behind)
+            };
+            spans.push(Span::styled(label, Style::default().fg(color)));
+        }
+        spans.push(Span::styled(
+            row.item.title.clone(),
+            Style::default().fg(f.regular_path),
+        ));
+        spans.push(Span::styled(
+            format!("  {} \u{00b7} {}", row.item.author, date),
+            Style::default().fg(g.time),
+        ));
+        Line::from(spans)
     }
 
     fn draw_list(&mut self, frame: &mut Frame, area: Rect) {
@@ -270,8 +293,8 @@ impl GithubPanel {
             " GitHub ".to_string()
         } else {
             format!(
-                " GitHub \u{2014} {} ({} issues, {} PRs) ",
-                self.repo_name, self.issue_count, self.pr_count
+                " GitHub \u{2014} {} \u{00b7} {} ({} issues, {} PRs) ",
+                self.repo_name, self.state_label, self.issue_count, self.pr_count
             )
         };
 
@@ -411,6 +434,7 @@ impl Component for GithubPanel {
                 self.select_prev();
                 Ok(None)
             }
+            KeyCode::Char('c') => Ok(Some(Action::CycleGithubStateFilter)),
             KeyCode::Enter => Ok(self.open_selected_detail()),
             _ => Ok(None),
         }
@@ -494,6 +518,7 @@ mod tests {
         GhItem {
             number: n,
             title: format!("title {n}"),
+            state: "OPEN".into(),
             is_draft: false,
             author: "octocat".into(),
             updated_at: "2026-01-02T03:04:05Z".into(),
@@ -508,7 +533,7 @@ mod tests {
     #[test]
     fn set_data_orders_issues_before_prs_and_counts_each() {
         let mut p = panel();
-        p.set_data(vec![item(1), item(2)], vec![item(3)], "repo");
+        p.set_data(vec![item(1), item(2)], vec![item(3)], "repo", "open");
         assert_eq!(p.issue_count, 2);
         assert_eq!(p.pr_count, 1);
         assert_eq!(p.rows.len(), 3);
@@ -525,18 +550,18 @@ mod tests {
     #[test]
     fn selection_persists_on_same_repo_and_resets_on_a_new_one() {
         let mut p = panel();
-        p.set_data(vec![item(1), item(2), item(3)], vec![], "repo");
+        p.set_data(vec![item(1), item(2), item(3)], vec![], "repo", "open");
         p.state.select(Some(2));
-        p.set_data(vec![item(1), item(2), item(3)], vec![], "repo");
+        p.set_data(vec![item(1), item(2), item(3)], vec![], "repo", "open");
         assert_eq!(p.state.selected(), Some(2), "same repo keeps selection");
-        p.set_data(vec![item(9)], vec![], "other");
+        p.set_data(vec![item(9)], vec![], "other", "open");
         assert_eq!(p.state.selected(), Some(0), "new repo resets selection");
     }
 
     #[test]
     fn empty_result_clears_selection_and_url() {
         let mut p = panel();
-        p.set_data(vec![], vec![], "repo");
+        p.set_data(vec![], vec![], "repo", "open");
         assert_eq!(p.state.selected(), None);
         assert!(p.selected_url().is_none());
     }
@@ -544,7 +569,7 @@ mod tests {
     #[test]
     fn retargeting_to_a_new_repo_drops_stale_rows() {
         let mut p = panel();
-        p.set_data(vec![item(1)], vec![item(2)], "repo");
+        p.set_data(vec![item(1)], vec![item(2)], "repo", "open");
         p.set_loading("other");
         assert!(p.rows.is_empty(), "loading a new repo clears old rows");
         assert_eq!(p.issue_count, 0);
@@ -564,7 +589,7 @@ mod tests {
     #[test]
     fn detail_opens_loads_and_discards_stale_results() {
         let mut p = panel();
-        p.set_data(vec![item(1)], vec![], "repo");
+        p.set_data(vec![item(1)], vec![], "repo", "open");
         let generation = match p.open_selected_detail().expect("enter yields an action") {
             Action::ShowGithubItem {
                 generation, is_pr, ..

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod confirm_dialog;
 pub(crate) mod context_menu;
 pub(crate) mod file_list;
 pub(crate) mod git_graph;
+pub(crate) mod github_panel;
 pub(crate) mod path_input;
 pub(crate) mod picker;
 pub(crate) mod repo_list;

--- a/src/components/status_bar.rs
+++ b/src/components/status_bar.rs
@@ -142,6 +142,7 @@ impl Component for StatusBar {
                 FocusPanel::Repos => "Repos",
                 FocusPanel::Changes => "Changes",
                 FocusPanel::Graph => "Graph",
+                FocusPanel::GitHub => "GitHub",
             };
             vec![
                 Span::styled(
@@ -158,6 +159,8 @@ impl Component for StatusBar {
                 Span::raw(" Diff  "),
                 key_span("g", s),
                 Span::raw(" Graph  "),
+                key_span("p", s),
+                Span::raw(" GitHub  "),
                 key_span("r", s),
                 Span::raw(" Refresh  "),
                 key_span("R", s),

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -10,6 +10,18 @@ impl Default for SubmoduleConfig {
     }
 }
 
+impl Default for GithubConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_github_enabled(),
+        }
+    }
+}
+
+pub(super) fn default_github_enabled() -> bool {
+    true
+}
+
 impl Default for OpenConfig {
     fn default() -> Self {
         Self {
@@ -175,6 +187,7 @@ impl Default for Config {
             ui: UiConfig::default(),
             graph: GraphConfig::default(),
             submodules: SubmoduleConfig::default(),
+            github: GithubConfig::default(),
             open: OpenConfig::default(),
             review: ReviewConfig::default(),
             worktree: WorktreeConfig::default(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -38,6 +38,8 @@ pub(crate) struct Config {
     #[serde(default)]
     pub submodules: SubmoduleConfig,
     #[serde(default)]
+    pub github: GithubConfig,
+    #[serde(default)]
     pub open: OpenConfig,
     #[serde(default)]
     pub review: ReviewConfig,
@@ -142,6 +144,17 @@ pub(crate) struct SubmoduleConfig {
     pub ignore_dirty: bool,
     #[serde(default = "default_warn_unpushed")]
     pub warn_unpushed: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct GithubConfig {
+    /// Show the GitHub panel (open issues/PRs for the selected repo, fetched via
+    /// the `gh` CLI). Opt-out: enabled by default. The panel only appears for a
+    /// selected repo whose `origin` is a github.com remote and only when it has
+    /// open issues or PRs (press `p` to force it open otherwise). Requires `gh`
+    /// on PATH; absent, gitpane keeps the usual three panels with no error.
+    #[serde(default = "default_github_enabled")]
+    pub enabled: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -482,6 +482,32 @@ fn test_submodule_config_parse() {
 }
 
 #[test]
+fn test_github_config_defaults() {
+    let config: Config = toml::from_str("").unwrap();
+    assert!(config.github.enabled);
+    assert!(Config::default().github.enabled);
+}
+
+#[test]
+fn test_github_config_roundtrip() {
+    let mut config = Config::default();
+    config.github.enabled = false;
+    let serialized = toml::to_string_pretty(&config).unwrap();
+    let loaded: Config = toml::from_str(&serialized).unwrap();
+    assert!(!loaded.github.enabled);
+}
+
+#[test]
+fn test_github_config_parse() {
+    let toml_str = r#"
+        [github]
+        enabled = false
+    "#;
+    let config: Config = toml::from_str(toml_str).unwrap();
+    assert!(!config.github.enabled);
+}
+
+#[test]
 fn test_open_config_defaults() {
     let config: Config = toml::from_str("").unwrap();
     assert!(config.open.command.is_none());

--- a/src/git/github.rs
+++ b/src/git/github.rs
@@ -34,6 +34,25 @@ pub(crate) struct GithubData {
     pub prs: Vec<GhItem>,
 }
 
+/// One comment on an issue or PR, for the detail pane.
+#[derive(Clone, Debug)]
+pub(crate) struct GhComment {
+    pub author: String,
+    pub body: String,
+    /// ISO-8601 timestamp; the pane shows its date part.
+    pub created_at: String,
+}
+
+/// The body and comment thread of one issue or PR, fetched on demand.
+#[derive(Clone, Debug)]
+pub(crate) struct ItemDetail {
+    pub number: u64,
+    pub title: String,
+    pub author: String,
+    pub body: String,
+    pub comments: Vec<GhComment>,
+}
+
 /// Whether the `gh` executable is available on PATH. Probed once (via
 /// `gh --version`) and cached for the process lifetime, mirroring
 /// [`crate::git::git_available`]. When absent, gitpane keeps its three panels
@@ -141,6 +160,42 @@ fn fetch_list(owner: &str, repo: &str, is_pr: bool, state: &str) -> Result<Vec<G
     Ok(raw.into_iter().map(RawItem::into_item).collect())
 }
 
+/// Fetch the body and comment thread of one issue/PR by its web URL. `is_pr`
+/// picks the `gh issue view` vs `gh pr view` subcommand; both accept the URL.
+pub(crate) fn fetch_detail(url: &str, is_pr: bool) -> Result<ItemDetail, String> {
+    let sub = if is_pr { "pr" } else { "issue" };
+    let output = Command::new("gh")
+        .args([
+            sub,
+            "view",
+            url,
+            "--json",
+            "number,title,author,body,comments",
+        ])
+        .output()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                "gh is not installed or not on PATH".to_string()
+            } else {
+                e.to_string()
+            }
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let msg = stderr
+            .lines()
+            .find(|l| !l.trim().is_empty())
+            .unwrap_or("gh failed")
+            .trim()
+            .to_string();
+        return Err(msg);
+    }
+
+    let raw: RawDetail = serde_json::from_slice(&output.stdout).map_err(|e| e.to_string())?;
+    Ok(raw.into_detail())
+}
+
 #[derive(Deserialize)]
 struct RawAuthor {
     #[serde(default)]
@@ -172,6 +227,51 @@ impl RawItem {
             author: self.author.map(|a| a.login).unwrap_or_default(),
             updated_at: self.updated_at,
             url: self.url,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawDetail {
+    number: u64,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    author: Option<RawAuthor>,
+    #[serde(default)]
+    body: String,
+    #[serde(default)]
+    comments: Vec<RawComment>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawComment {
+    #[serde(default)]
+    author: Option<RawAuthor>,
+    #[serde(default)]
+    body: String,
+    #[serde(default)]
+    created_at: String,
+}
+
+impl RawDetail {
+    fn into_detail(self) -> ItemDetail {
+        ItemDetail {
+            number: self.number,
+            title: self.title,
+            author: self.author.map(|a| a.login).unwrap_or_default(),
+            body: self.body,
+            comments: self
+                .comments
+                .into_iter()
+                .map(|c| GhComment {
+                    author: c.author.map(|a| a.login).unwrap_or_default(),
+                    body: c.body,
+                    created_at: c.created_at,
+                })
+                .collect(),
         }
     }
 }
@@ -247,5 +347,27 @@ mod tests {
         assert!(!items[0].is_draft);
         assert_eq!(items[1].author, ""); // null author → empty
         assert!(items[1].is_draft);
+    }
+
+    #[test]
+    fn deserializes_detail_shape() {
+        let json = r#"{
+            "number": 12,
+            "title": "A bug",
+            "author": {"login": "alice"},
+            "body": "It broke.",
+            "comments": [
+                {"author": {"login": "bob"}, "body": "Confirmed", "createdAt": "2026-02-01T00:00:00Z"},
+                {"author": null, "body": "ghost", "createdAt": "2026-02-02T00:00:00Z"}
+            ]
+        }"#;
+        let raw: RawDetail = serde_json::from_str(json).unwrap();
+        let detail = raw.into_detail();
+        assert_eq!(detail.number, 12);
+        assert_eq!(detail.author, "alice");
+        assert_eq!(detail.body, "It broke.");
+        assert_eq!(detail.comments.len(), 2);
+        assert_eq!(detail.comments[0].author, "bob");
+        assert_eq!(detail.comments[1].author, ""); // null author → empty
     }
 }

--- a/src/git/github.rs
+++ b/src/git/github.rs
@@ -54,6 +54,9 @@ pub(crate) struct ItemDetail {
     pub author: String,
     pub body: String,
     pub comments: Vec<GhComment>,
+    /// Unified diff of a PR's changed files (PRs only; `None` for issues or when
+    /// the diff can't be fetched).
+    pub diff: Option<String>,
 }
 
 /// Whether the `gh` executable is available on PATH. Probed once (via
@@ -196,7 +199,26 @@ pub(crate) fn fetch_detail(url: &str, is_pr: bool) -> Result<ItemDetail, String>
     }
 
     let raw: RawDetail = serde_json::from_slice(&output.stdout).map_err(|e| e.to_string())?;
-    Ok(raw.into_detail())
+    let mut detail = raw.into_detail();
+    if is_pr {
+        detail.diff = pr_diff(url);
+    }
+    Ok(detail)
+}
+
+/// Best-effort unified diff for a PR (`gh pr diff <url>`). Returns `None` on any
+/// failure — the diff is a bonus shown under the body and comments.
+fn pr_diff(url: &str) -> Option<String> {
+    let output = Command::new("gh").args(["pr", "diff", url]).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout).to_string();
+    if text.trim().is_empty() {
+        None
+    } else {
+        Some(text)
+    }
 }
 
 #[derive(Deserialize)]
@@ -269,6 +291,7 @@ impl RawDetail {
             title: self.title,
             author: self.author.map(|a| a.login).unwrap_or_default(),
             body: self.body,
+            diff: None,
             comments: self
                 .comments
                 .into_iter()

--- a/src/git/github.rs
+++ b/src/git/github.rs
@@ -18,6 +18,9 @@ use serde::Deserialize;
 pub(crate) struct GhItem {
     pub number: u64,
     pub title: String,
+    /// "OPEN" | "CLOSED" | "MERGED" as reported by `gh`. Used to mark
+    /// non-open rows when the closed/all filter is active.
+    pub state: String,
     /// Only meaningful for pull requests; always false for issues.
     pub is_draft: bool,
     pub author: String,
@@ -127,9 +130,9 @@ fn fetch_list(owner: &str, repo: &str, is_pr: bool, state: &str) -> Result<Vec<G
     let sub = if is_pr { "pr" } else { "issue" };
     // PRs carry `isDraft`; issues do not, so request the field only for PRs.
     let fields = if is_pr {
-        "number,title,author,updatedAt,url,isDraft"
+        "number,title,state,author,updatedAt,url,isDraft"
     } else {
-        "number,title,author,updatedAt,url"
+        "number,title,state,author,updatedAt,url"
     };
     let repo_arg = format!("{owner}/{repo}");
     let output = Command::new("gh")
@@ -209,6 +212,8 @@ struct RawItem {
     #[serde(default)]
     title: String,
     #[serde(default)]
+    state: String,
+    #[serde(default)]
     author: Option<RawAuthor>,
     #[serde(default)]
     updated_at: String,
@@ -223,6 +228,7 @@ impl RawItem {
         GhItem {
             number: self.number,
             title: self.title,
+            state: self.state,
             is_draft: self.is_draft,
             author: self.author.map(|a| a.login).unwrap_or_default(),
             updated_at: self.updated_at,

--- a/src/git/github.rs
+++ b/src/git/github.rs
@@ -1,0 +1,251 @@
+//! GitHub issue/PR peek via the `gh` CLI.
+//!
+//! gitpane shells out to `gh` here, mirroring how the rest of the app shells out
+//! to `git`. That means `gh`'s own auth, host, and enterprise config are
+//! inherited for free: there is no token handling, no HTTP client, and no
+//! rate-limit bookkeeping in gitpane. A repo is a candidate only when its
+//! `origin` remote points at github.com; everything else returns `None` and the
+//! panel stays hidden.
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+/// One issue or pull request, in the shape the panel renders.
+#[derive(Clone, Debug)]
+pub(crate) struct GhItem {
+    pub number: u64,
+    pub title: String,
+    /// Only meaningful for pull requests; always false for issues.
+    pub is_draft: bool,
+    pub author: String,
+    /// ISO-8601 timestamp (`updatedAt`); the panel shows its date part.
+    pub updated_at: String,
+    /// Web URL, opened in the browser on Enter.
+    pub url: String,
+}
+
+/// Open issues and PRs for one repo, returned by [`fetch`].
+#[derive(Clone, Debug, Default)]
+pub(crate) struct GithubData {
+    pub issues: Vec<GhItem>,
+    pub prs: Vec<GhItem>,
+}
+
+/// Whether the `gh` executable is available on PATH. Probed once (via
+/// `gh --version`) and cached for the process lifetime, mirroring
+/// [`crate::git::git_available`]. When absent, gitpane keeps its three panels
+/// and never spawns `gh`.
+pub(crate) fn gh_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        Command::new("gh")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    })
+}
+
+/// Resolve a repo's `origin` remote to `(owner, repo)` when it is a github.com
+/// remote, else `None`. Reads the remote URL through git2 (already a dep) and
+/// parses the common SSH/HTTPS forms.
+pub(crate) fn origin_owner_repo(path: &Path) -> Option<(String, String)> {
+    let repo = git2::Repository::open(path).ok()?;
+    let remote = repo.find_remote("origin").ok()?;
+    let url = remote.url().ok()?;
+    parse_github_owner_repo(url)
+}
+
+/// Parse `owner`/`repo` out of a github.com remote URL. Supports:
+/// `git@github.com:owner/repo(.git)`, `ssh://git@github.com/owner/repo(.git)`,
+/// `https://github.com/owner/repo(.git)`, and the `http`/`git` schemes. Any
+/// other host (GitLab, an enterprise GitHub, a bare path) returns `None`.
+fn parse_github_owner_repo(url: &str) -> Option<(String, String)> {
+    let rest = [
+        "git@github.com:",
+        "ssh://git@github.com/",
+        "https://github.com/",
+        "http://github.com/",
+        "git://github.com/",
+    ]
+    .into_iter()
+    .find_map(|prefix| url.strip_prefix(prefix))?;
+
+    let rest = rest.strip_suffix(".git").unwrap_or(rest);
+    let rest = rest.trim_end_matches('/');
+    let mut parts = rest.splitn(2, '/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim();
+    if owner.is_empty() || repo.is_empty() || repo.contains('/') {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
+}
+
+/// Fetch open issues and PRs for `owner/repo` in one call each via `gh`.
+/// `state` is passed to `--state` ("open", "closed", or "all"). A failure on one
+/// list (e.g. issues disabled on the repo) does not sink the other; only when
+/// both calls fail is an `Err` returned, carrying the first error.
+pub(crate) fn fetch(owner: &str, repo: &str, state: &str) -> Result<GithubData, String> {
+    let issues = fetch_list(owner, repo, false, state);
+    let prs = fetch_list(owner, repo, true, state);
+    match (issues, prs) {
+        (Err(e), Err(_)) => Err(e),
+        (issues, prs) => Ok(GithubData {
+            issues: issues.unwrap_or_default(),
+            prs: prs.unwrap_or_default(),
+        }),
+    }
+}
+
+/// One `gh issue list` / `gh pr list` invocation, parsed into [`GhItem`]s.
+fn fetch_list(owner: &str, repo: &str, is_pr: bool, state: &str) -> Result<Vec<GhItem>, String> {
+    let sub = if is_pr { "pr" } else { "issue" };
+    // PRs carry `isDraft`; issues do not, so request the field only for PRs.
+    let fields = if is_pr {
+        "number,title,author,updatedAt,url,isDraft"
+    } else {
+        "number,title,author,updatedAt,url"
+    };
+    let repo_arg = format!("{owner}/{repo}");
+    let output = Command::new("gh")
+        .args([
+            sub, "list", "-R", &repo_arg, "--state", state, "--limit", "50", "--json", fields,
+        ])
+        .output()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                "gh is not installed or not on PATH".to_string()
+            } else {
+                e.to_string()
+            }
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let msg = stderr
+            .lines()
+            .find(|l| !l.trim().is_empty())
+            .unwrap_or("gh failed")
+            .trim()
+            .to_string();
+        return Err(msg);
+    }
+
+    let raw: Vec<RawItem> = serde_json::from_slice(&output.stdout).map_err(|e| e.to_string())?;
+    Ok(raw.into_iter().map(RawItem::into_item).collect())
+}
+
+#[derive(Deserialize)]
+struct RawAuthor {
+    #[serde(default)]
+    login: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawItem {
+    number: u64,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    author: Option<RawAuthor>,
+    #[serde(default)]
+    updated_at: String,
+    #[serde(default)]
+    url: String,
+    #[serde(default)]
+    is_draft: bool,
+}
+
+impl RawItem {
+    fn into_item(self) -> GhItem {
+        GhItem {
+            number: self.number,
+            title: self.title,
+            is_draft: self.is_draft,
+            author: self.author.map(|a| a.login).unwrap_or_default(),
+            updated_at: self.updated_at,
+            url: self.url,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_ssh_scp_form() {
+        assert_eq!(
+            parse_github_owner_repo("git@github.com:affromero/gitpane.git"),
+            Some(("affromero".into(), "gitpane".into()))
+        );
+    }
+
+    #[test]
+    fn parses_ssh_url_form() {
+        assert_eq!(
+            parse_github_owner_repo("ssh://git@github.com/affromero/gitpane.git"),
+            Some(("affromero".into(), "gitpane".into()))
+        );
+    }
+
+    #[test]
+    fn parses_https_with_and_without_git_suffix() {
+        assert_eq!(
+            parse_github_owner_repo("https://github.com/affromero/gitpane.git"),
+            Some(("affromero".into(), "gitpane".into()))
+        );
+        assert_eq!(
+            parse_github_owner_repo("https://github.com/affromero/gitpane"),
+            Some(("affromero".into(), "gitpane".into()))
+        );
+    }
+
+    #[test]
+    fn rejects_non_github_hosts() {
+        assert_eq!(
+            parse_github_owner_repo("git@gitlab.com:owner/repo.git"),
+            None
+        );
+        assert_eq!(
+            parse_github_owner_repo("https://bitbucket.org/owner/repo"),
+            None
+        );
+        assert_eq!(
+            parse_github_owner_repo("https://github.enterprise.io/owner/repo"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_incomplete_paths() {
+        assert_eq!(parse_github_owner_repo("https://github.com/owner"), None);
+        assert_eq!(parse_github_owner_repo("git@github.com:"), None);
+        assert_eq!(
+            parse_github_owner_repo("https://github.com/owner/repo/extra"),
+            None
+        );
+    }
+
+    #[test]
+    fn deserializes_gh_json_shape() {
+        let json = r#"[
+            {"number":7,"title":"Bug","state":"OPEN","author":{"login":"alice"},"updatedAt":"2026-01-02T03:04:05Z","url":"https://github.com/o/r/issues/7"},
+            {"number":8,"title":"Feature","state":"OPEN","author":null,"updatedAt":"2026-01-03T00:00:00Z","url":"https://github.com/o/r/pull/8","isDraft":true}
+        ]"#;
+        let raw: Vec<RawItem> = serde_json::from_str(json).unwrap();
+        let items: Vec<GhItem> = raw.into_iter().map(RawItem::into_item).collect();
+        assert_eq!(items[0].number, 7);
+        assert_eq!(items[0].author, "alice");
+        assert!(!items[0].is_draft);
+        assert_eq!(items[1].author, ""); // null author → empty
+        assert!(items[1].is_draft);
+    }
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod commit_files;
+pub(crate) mod github;
 pub(crate) mod graph;
 pub(crate) mod graph_render;
 pub(crate) mod scanner;

--- a/src/git/status/tests_refs.rs
+++ b/src/git/status/tests_refs.rs
@@ -3,6 +3,24 @@ use super::*;
 use std::{fs, path::Path};
 use tempfile::TempDir;
 
+/// Strip the git environment a hook injects (`GIT_DIR`, `GIT_INDEX_FILE`, …).
+/// This suite runs under the pre-push hook, whose env would otherwise redirect
+/// a spawned `git` at the outer repo instead of the test's temp repo.
+fn clear_inherited_git_env(cmd: &mut std::process::Command) {
+    for var in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_PREFIX",
+        "GIT_COMMON_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_NAMESPACE",
+    ] {
+        cmd.env_remove(var);
+    }
+}
+
 #[test]
 fn test_ahead_count_when_no_upstream_with_remote_ref() {
     // Local branch with no configured upstream but with a remote-tracking
@@ -185,16 +203,17 @@ fn query_status_detects_commit_in_linked_worktree() {
     fs::create_dir_all(&root).unwrap();
 
     let git = |args: &[&str], cwd: &Path| -> bool {
-        std::process::Command::new("git")
-            .args(args)
+        let mut cmd = std::process::Command::new("git");
+        cmd.args(args)
             .current_dir(cwd)
             .env("GIT_AUTHOR_NAME", "Test")
             .env("GIT_AUTHOR_EMAIL", "t@t")
             .env("GIT_COMMITTER_NAME", "Test")
-            .env("GIT_COMMITTER_EMAIL", "t@t")
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
+            .env("GIT_COMMITTER_EMAIL", "t@t");
+        // Clear the git env a hook injects (this suite runs under the pre-push
+        // hook), so operations target `cwd`'s repo and not the outer one.
+        clear_inherited_git_env(&mut cmd);
+        cmd.status().map(|s| s.success()).unwrap_or(false)
     };
 
     if !git(&["init", "-q"], &root) {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -69,7 +69,7 @@ impl Default for RepoListTheme {
             live: Color::Indexed(48),
             border_focused: Color::Cyan,
             border_unfocused: Color::DarkGray,
-            selection_bg: Color::DarkGray,
+            selection_bg: Color::Indexed(237),
         }
     }
 }
@@ -156,7 +156,7 @@ impl Default for FileListTheme {
             status_conflicted: Color::LightRed,
             submodule_path: Color::LightMagenta,
             regular_path: Color::White,
-            selection_bg: Color::DarkGray,
+            selection_bg: Color::Indexed(237),
             diff_border: Color::Cyan,
             diff_added: Color::Green,
             diff_removed: Color::Red,
@@ -236,7 +236,7 @@ impl Default for GraphTheme {
             time: Color::DarkGray,
             addition: Color::Green,
             deletion: Color::Red,
-            selection_bg: Color::DarkGray,
+            selection_bg: Color::Indexed(237),
             commit_msg_border: Color::Cyan,
             commit_msg_text: Color::White,
             commit_files_border: Color::Cyan,

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -512,12 +512,25 @@ mod tests {
         // defaults to true), so we actually `git init` rather than fake `.git`.
         let tmp = tempfile::TempDir::new().unwrap();
         let root = tmp.path();
-        let initialized = std::process::Command::new("git")
-            .args(["init", "-q"])
-            .current_dir(root)
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
+        let mut init_cmd = std::process::Command::new("git");
+        init_cmd.args(["init", "-q"]).current_dir(root);
+        // This suite can run under the pre-push hook, whose injected git env
+        // (GIT_DIR, GIT_INDEX_FILE, …) would make `git init` target the outer
+        // repo instead of the temp dir, leaving it a non-repo where `ignore`
+        // then skips .gitignore. Strip that env.
+        for var in [
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_PREFIX",
+            "GIT_COMMON_DIR",
+            "GIT_OBJECT_DIRECTORY",
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            "GIT_NAMESPACE",
+        ] {
+            init_cmd.env_remove(var);
+        }
+        let initialized = init_cmd.status().map(|s| s.success()).unwrap_or(false);
         if !initialized {
             eprintln!("skipping watch_dirs_respects_gitignore: git is not available");
             return;


### PR DESCRIPTION
Adds an optional fourth panel showing the selected repo's open GitHub issues and pull requests, inspired by ghpeek — but scoped to the selected repo only, so it stays cheap and never fans network calls out across the whole repo list.

## What it does

- A GitHub panel appears automatically when the selected repo's `github.com` origin has open issues or PRs; a repo with none keeps the usual three panels. Opt-out via `[github] enabled` (on by default). Press `p` to force it open on any repo.
- Lists open issues and PRs. `Enter` previews an item (body + comment thread); `Enter` again opens it in the browser. For a PR the preview also shows its file changes (the unified diff).
- `c` cycles the filter open then all then closed; closed and merged rows are marked, and closed items never change whether the panel auto-shows.
- The panel resizes by dragging its border like the other panels, and supports mouse and keyboard throughout.

Data comes from shelling out to the `gh` CLI (matching how the app already shells out to `git`), so it reuses gh's auth and needs no token config or new crates. Fetches are debounced on selection and cached per repo. A missing `gh`, a non-github origin, or being offline all degrade to the three-panel layout with a clear message rather than an error.

## Keybindings (GitHub panel)

`p` toggle the panel  ·  `j`/`k` move / scroll  ·  `Enter` preview, then open in browser  ·  `Esc`/`q` close preview  ·  `c` cycle open/all/closed

## Also included

- Bumps `crossbeam-epoch` 0.9.18 to 0.9.20 to clear RUSTSEC-2026-0204, a pre-existing transitive advisory pulled in via `ignore`.
- Isolates the git environment in two tests that shell out to `git`, so they pass when the suite runs under a git hook. The pre-push coverage hook was leaking GIT_DIR / GIT_INDEX_FILE into their temp-repo `git` commands.

## Testing

- New unit tests: origin URL parsing, gh JSON parsing (list and detail), panel data/selection semantics, the detail generation latch, diff-line coloring, and a headless render assertion.
- `cargo fmt`, `clippy -D warnings`, `test`, `audit`, `doc`, and coverage all green; the full suite passes (309 tests), including under a simulated git-hook environment.

The README "Why gitpane?" table gains an Issues/PRs column (with ghpeek and gh-dash rows) and a GitHub-panel keybindings section.
