### PR TITLE
feat: discover and display Google repo-managed workspaces

### DIFF
--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -630,9 +630,14 @@ impl App {
                         tracing::error!("Failed to save config: {}", e);
                     }
                     let repo_id = RepoId(path.clone());
+                    let display = crate::components::repo_list::display_path(
+                        &path,
+                        &self.config.root_dirs,
+                    );
                     self.repo_list.repos.push(RepoEntry {
                         path,
                         name,
+                        display,
                         status: None,
                         git_op: false,
                     });
@@ -689,7 +694,11 @@ impl App {
                     tracing::error!("Failed to save config: {}", e);
                 }
                 let repo_paths = scanner::discover_repos(&self.config);
-                self.repo_list = RepoList::new(repo_paths, self.theme.clone());
+                self.repo_list = RepoList::new(
+                    repo_paths,
+                    self.config.root_dirs.clone(),
+                    self.theme.clone(),
+                );
                 self.repo_list
                     .register_action_handler(self.action_tx.clone())?;
                 self.repo_list.init()?;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -327,11 +327,14 @@ impl App {
         let poll_semaphore = Arc::new(tokio::sync::Semaphore::new(
             config.watch.max_concurrent_polls,
         ));
+        // Roots are cloned before `config` moves into `Self` below; the repo
+        // list needs them to render each repo's relative display path.
+        let roots = config.root_dirs.clone();
 
         Self {
             config,
             should_quit: false,
-            repo_list: RepoList::new(repo_paths, theme.clone()),
+            repo_list: RepoList::new(repo_paths, roots, theme.clone()),
             file_list: FileList::new(theme.clone()),
             git_graph,
             graph_context_menu: GraphContextMenu::new(theme.clone()),
@@ -382,7 +385,7 @@ impl App {
     fn sort_repos(&mut self) {
         match self.sort_order {
             SortOrder::Alphabetical => {
-                self.repo_list.repos.sort_by_key(|r| r.name.to_lowercase());
+                self.repo_list.repos.sort_by_key(|r| r.display.to_lowercase());
             }
             SortOrder::DirtyFirst => {
                 self.repo_list.repos.sort_by(|a, b| {
@@ -390,7 +393,7 @@ impl App {
                     let b_dirty = b.status.as_ref().map(|s| s.is_dirty).unwrap_or(false);
                     b_dirty
                         .cmp(&a_dirty)
-                        .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+                        .then_with(|| a.display.to_lowercase().cmp(&b.display.to_lowercase()))
                 });
             }
         }

--- a/src/components/repo_list/mod.rs
+++ b/src/components/repo_list/mod.rs
@@ -412,7 +412,13 @@ impl RepoList {
 
         let mut next: Vec<RepoEntry> = Vec::with_capacity(new_paths.len());
         let mut added: Vec<PathBuf> = Vec::new();
+        let mut seen_paths = HashSet::new();
         for path in &new_paths {
+            // A path can't appear twice in the list; discovery regressions or
+            // overlapping roots would otherwise render it as duplicate rows.
+            if !seen_paths.insert(path.clone()) {
+                continue;
+            }
             if let Some(existing) = by_path.remove(path) {
                 next.push(existing);
             } else {

--- a/src/components/repo_list/mod.rs
+++ b/src/components/repo_list/mod.rs
@@ -5,7 +5,7 @@ use ratatui::{
     widgets::{ListItem, ListState},
 };
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -36,7 +36,13 @@ impl SyncDiff {
 #[derive(Clone, Debug)]
 pub(crate) struct RepoEntry {
     pub path: PathBuf,
+    /// Basename of the repo directory (used by titles / menus / sort).
     pub name: String,
+    /// Breadcrumb label shown in the repo list: the repo's path relative to
+    /// its workspace root (basename when it lives outside every root). Keeps
+    /// same-named repos distinguishable and makes the list read like the
+    /// workspace tree.
+    pub display: String,
     pub status: Option<RepoStatus>,
     /// True only during push/pull/rebase — shows animated spinner
     pub git_op: bool,
@@ -66,6 +72,9 @@ enum DisplayRow {
 
 pub(crate) struct RepoList {
     pub repos: Vec<RepoEntry>,
+    /// Workspace roots used to compute each repo's relative display path
+    /// (`display_path`). Needed at rescan time too, for repos added later.
+    roots: Vec<PathBuf>,
     pub state: ListState,
     pub render_area: Rect,
     pub focused: bool,
@@ -82,8 +91,104 @@ pub(crate) struct RepoList {
     theme: Arc<Theme>,
 }
 
+/// The label shown for a repo in the list: its path relative to the first
+/// workspace root that contains it, falling back to the basename for repos
+/// outside every root (e.g. pinned paths). The relative path instead of the
+/// bare basename keeps same-named repos distinguishable and makes the list
+/// read like the workspace tree.
+pub(crate) fn display_path(path: &Path, roots: &[PathBuf]) -> String {
+    for root in roots {
+        if let Ok(rel) = path.strip_prefix(root) {
+            return rel.to_string_lossy().to_string();
+        }
+    }
+    path.file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_string_lossy().to_string())
+}
+
+/// Width of the fixed status block rendered to the right of the repo display
+/// name (branch, ahead/behind, stash/worktree toggles, submodule markers,
+/// fetch warning, file count). Mirrors `render_repo_item`; used to budget the
+/// name column so a long path never pushes the status indicators off-screen.
+fn status_block_width(entry: &RepoEntry) -> u16 {
+    let mut w: u16 = 0;
+    // The dirty/git-op marker is rendered before the name, so it isn't part
+    // of the trailing block; everything from the branch onward is.
+    let Some(status) = entry.status.as_ref() else {
+        return w;
+    };
+    // Branch is left-padded to a minimum of 12 columns, then a space.
+    w += status.branch.chars().count().max(12) as u16 + 1;
+    if status.ahead > 0 {
+        w += 2 + status.ahead.to_string().len() as u16;
+    }
+    if status.behind > 0 {
+        w += 2 + status.behind.to_string().len() as u16;
+    }
+    if !status.stashes.is_empty() {
+        w += 3 + status.stash_count().to_string().len() as u16;
+    }
+    if !status.worktree_info.is_empty() {
+        w += 2 + status.worktree_info.len().to_string().len() as u16;
+    }
+    if status.has_dirty_submodules {
+        w += 3;
+    }
+    if status.has_unpushed_submodules {
+        w += 3;
+    }
+    if status.fetch_failed {
+        w += 3;
+    }
+    if !status.files.is_empty() {
+        // "[N] "
+        w += 2 + status.files.len().to_string().len() as u16 + 1;
+    }
+    w
+}
+
+/// The repo's display label for the list row, middle-ellipsized to fit the
+/// panel. Reserves the leading dirty/git-op marker, a trailing liveness
+/// marker, and the fixed status block so the row never clips its indicators.
+fn rendered_name(entry: &RepoEntry, inner_width: u16) -> String {
+    let max = inner_width
+        .saturating_sub(2) // dirty/git-op marker
+        .saturating_sub(2) // liveness marker
+        .saturating_sub(1) // space after the name
+        .saturating_sub(status_block_width(entry))
+        .max(1);
+    middle_ellipsize(&entry.display, max as usize)
+}
+
+/// Collapse an over-long path to "head/…/tail", keeping the top-level group
+/// and the repo basename visible while hiding the middle of deep paths.
+/// Falls back to "…/tail" / "head/…" and finally a hard tail-truncation.
+fn middle_ellipsize(s: &str, max: usize) -> String {
+    if max == 0 {
+        return String::new();
+    }
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let parts: Vec<&str> = s.split('/').collect();
+    let head = parts.first().copied().unwrap_or(s);
+    let tail = parts.last().copied().unwrap_or(s);
+    let head_tail = format!("{head}/…/{tail}");
+    if head_tail.chars().count() <= max {
+        return head_tail;
+    }
+    let tail_only = format!("…/{tail}");
+    if tail_only.chars().count() <= max {
+        return tail_only;
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
 impl RepoList {
-    pub fn new(repo_paths: Vec<PathBuf>, theme: Arc<Theme>) -> Self {
+    pub fn new(repo_paths: Vec<PathBuf>, roots: Vec<PathBuf>, theme: Arc<Theme>) -> Self {
         let repos: Vec<RepoEntry> = repo_paths
             .into_iter()
             .map(|path| {
@@ -91,9 +196,11 @@ impl RepoList {
                     .file_name()
                     .map(|n| n.to_string_lossy().to_string())
                     .unwrap_or_else(|| path.to_string_lossy().to_string());
+                let display = display_path(&path, &roots);
                 RepoEntry {
                     path,
                     name,
+                    display,
                     status: None,
                     git_op: false,
                 }
@@ -107,6 +214,7 @@ impl RepoList {
 
         let mut list = Self {
             repos,
+            roots,
             state,
             render_area: Rect::default(),
             focused: true,
@@ -312,9 +420,11 @@ impl RepoList {
                     .file_name()
                     .map(|n| n.to_string_lossy().to_string())
                     .unwrap_or_else(|| path.to_string_lossy().to_string());
+                let display = display_path(path, &self.roots);
                 next.push(RepoEntry {
                     path: path.clone(),
                     name,
+                    display,
                     status: None,
                     git_op: false,
                 });
@@ -473,6 +583,16 @@ impl RepoList {
             spans.push(Span::raw("  "));
         }
 
+        // The repo's display name anchors the left of the row: its path
+        // relative to the workspace root, middle-ellipsized so deep paths
+        // can't push the status indicators off-screen.
+        let inner_width = self.render_area.width.saturating_sub(2);
+        spans.push(Span::styled(
+            rendered_name(entry, inner_width),
+            Style::default().fg(t.repo_name),
+        ));
+        spans.push(Span::raw(" "));
+
         if let Some(status) = &entry.status {
             spans.push(Span::styled(
                 format!("{:<12} ", status.branch),
@@ -541,13 +661,8 @@ impl RepoList {
             }
         }
 
-        spans.push(Span::styled(
-            entry.name.clone(),
-            Style::default().fg(t.repo_name),
-        ));
-
-        // Liveness marker (bare symbol; the session names are in the context
-        // menu), after the repo name so it doesn't shift the name.
+        // Liveness marker at the end of the row so it never shifts the name
+        // column (bare symbol; the session names are in the context menu).
         if crate::session::liveness::is_live(&entry.path, &self.live_panes) {
             spans.push(Span::styled(" \u{25c9}", Style::default().fg(t.live)));
         }

--- a/src/components/repo_list/render.rs
+++ b/src/components/repo_list/render.rs
@@ -26,16 +26,22 @@ pub(super) struct IndicatorColumns {
 /// Compute the column ranges of the stash and worktree indicators for a repo
 /// row, given the leftmost content column. Mirrors the layout in
 /// [`RepoList::render_repo_item`] — keep the two in sync.
-pub(super) fn indicator_columns(entry: &RepoEntry, base_x: u16) -> IndicatorColumns {
+pub(super) fn indicator_columns(
+    entry: &RepoEntry,
+    base_x: u16,
+    name_width: u16,
+) -> IndicatorColumns {
     let mut col = base_x;
     // Dirty/git_op marker: always 2 columns ("* ", "~ ", or "  ").
     col = col.saturating_add(2);
+    // The repo display name (path relative to the workspace root) sits
+    // between the marker and the branch; it is variable width.
+    col = col.saturating_add(name_width);
 
     let mut out = IndicatorColumns::default();
     let Some(status) = entry.status.as_ref() else {
         return out;
     };
-
     // Branch field is left-padded to a minimum of 12 columns, then a space.
     let branch_width = status.branch.chars().count().max(12).saturating_add(1);
     col = col.saturating_add(branch_width as u16);
@@ -119,7 +125,10 @@ impl Component for RepoList {
                             && let Some(status) = self.repos[*i].status.as_ref()
                         {
                             let base_x = self.render_area.x + 1;
-                            let cols = indicator_columns(&self.repos[*i], base_x);
+                            let inner_width = self.render_area.width.saturating_sub(2);
+                            let name_width =
+                                rendered_name(&self.repos[*i], inner_width).chars().count() as u16;
+                            let cols = indicator_columns(&self.repos[*i], base_x, name_width);
                             let clicked_stash = cols
                                 .stash
                                 .is_some_and(|(s, e)| mouse.column >= s && mouse.column < e);

--- a/src/components/repo_list/tests.rs
+++ b/src/components/repo_list/tests.rs
@@ -49,6 +49,7 @@ fn entry_with_status(path: &str, status: RepoStatus) -> RepoEntry {
     RepoEntry {
         path: PathBuf::from(path),
         name: path.trim_start_matches('/').to_string(),
+        display: path.trim_start_matches('/').to_string(),
         status: Some(status),
         git_op: false,
     }
@@ -56,7 +57,11 @@ fn entry_with_status(path: &str, status: RepoStatus) -> RepoEntry {
 
 fn make_list(paths: &[&str]) -> RepoList {
     let theme = Arc::new(Theme::default());
-    RepoList::new(paths.iter().map(PathBuf::from).collect(), theme)
+    RepoList::new(
+        paths.iter().map(PathBuf::from).collect(),
+        vec![], // no roots: display falls back to the basename
+        theme,
+    )
 }
 
 #[test]
@@ -117,7 +122,7 @@ fn sync_paths_preserves_existing_entry_status() {
 #[test]
 fn indicator_columns_returns_none_when_neither_subtree_present() {
     let entry = entry_with_status("/r", empty_status("main"));
-    let cols = indicator_columns(&entry, 0);
+    let cols = indicator_columns(&entry, 0, 1);
     assert_eq!(cols.stash, None);
     assert_eq!(cols.worktree, None);
 }
@@ -129,17 +134,18 @@ fn indicator_columns_locates_stash_then_worktree() {
     status.worktree_info.push(worktree_entry("wt"));
     let entry = entry_with_status("/r", status);
 
-    let cols = indicator_columns(&entry, 0);
-    // 2 (dirty marker) + 12 (branch pad for "main") + 1 (space) = 15 → stash start.
+    let cols = indicator_columns(&entry, 0, 1);
+    // 2 (dirty marker) + 1 (name "r") + 12 (branch pad for "main") + 1 (space)
+    // = 16 → stash start.
     let (s_start, s_end) = cols.stash.expect("stash range");
     let (w_start, w_end) = cols.worktree.expect("worktree range");
-    assert_eq!(s_start, 15);
+    assert_eq!(s_start, 16);
     // "▶$1 " = 4 columns.
-    assert_eq!(s_end, 19);
+    assert_eq!(s_end, 20);
     // Worktree starts immediately after stash.
-    assert_eq!(w_start, 19);
+    assert_eq!(w_start, 20);
     // "▶1 " = 3 columns.
-    assert_eq!(w_end, 22);
+    assert_eq!(w_end, 23);
 }
 
 #[test]
@@ -150,10 +156,10 @@ fn indicator_columns_accounts_for_ahead_behind() {
     status.stashes.push(stash_entry(0));
     let entry = entry_with_status("/r", status);
 
-    let cols = indicator_columns(&entry, 0);
-    // 2 + 13 (branch) + 3 ("↑3 ") + 4 ("↓22 ") = 22 → stash start.
+    let cols = indicator_columns(&entry, 0, 1);
+    // 2 + 1 (name) + 13 (branch) + 3 ("↑3 ") + 4 ("↓22 ") = 23 → stash start.
     let (s_start, _) = cols.stash.expect("stash range");
-    assert_eq!(s_start, 22);
+    assert_eq!(s_start, 23);
 }
 
 #[test]
@@ -162,10 +168,10 @@ fn indicator_columns_respects_long_branch_name() {
     status.worktree_info.push(worktree_entry("wt"));
     let entry = entry_with_status("/r", status);
 
-    let cols = indicator_columns(&entry, 0);
-    // 2 + 24 (branch chars) + 1 (space) = 27 → worktree start.
+    let cols = indicator_columns(&entry, 0, 1);
+    // 2 + 1 (name) + 24 (branch chars) + 1 (space) = 28 → worktree start.
     let (w_start, _) = cols.worktree.expect("worktree range");
-    assert_eq!(w_start, 27);
+    assert_eq!(w_start, 28);
 }
 
 /// One repo with a linked worktree, expanded so the worktree row is
@@ -283,3 +289,74 @@ fn selected_worktree_reports_worktree_when_worktree_row_is_selected() {
     list.state.select(Some(0));
     assert!(list.selected_worktree().is_none());
 }
+
+#[test]
+fn display_path_uses_relative_path_under_a_root() {
+    let roots = vec![PathBuf::from("/ws")];
+    assert_eq!(display_path(&PathBuf::from("/ws/hbre/libmm"), &roots), "hbre/libmm");
+    // Outside every root → basename.
+    assert_eq!(display_path(&PathBuf::from("/elsewhere/pinned"), &roots), "pinned");
+}
+
+#[test]
+fn display_path_keeps_basename_for_top_level_repo() {
+    let roots = vec![PathBuf::from("/ws")];
+    assert_eq!(display_path(&PathBuf::from("/ws/kernel-6.12"), &roots), "kernel-6.12");
+}
+
+#[test]
+fn middle_ellipsize_keeps_head_and_tail() {
+    assert_eq!(middle_ellipsize("hbre/camsys", 30), "hbre/camsys");
+    let deep = "kernel-6.12/drivers/media/platform/horizon/camsys";
+    assert_eq!(middle_ellipsize(deep, 20), "kernel-6.12/…/camsys");
+    // Tight budget: prefer the disambiguating tail, then hard-truncate.
+    assert_eq!(middle_ellipsize(deep, 12), "…/camsys");
+    assert_eq!(middle_ellipsize(deep, 5), "kern…");
+    assert_eq!(middle_ellipsize(deep, 0), "");
+}
+
+/// Headless render check: the list shows each repo's path relative to the
+/// workspace root, so same-basename repos (e.g. three `camsys`) stay
+/// distinguishable, and deep paths are middle-ellipsized to the panel width.
+#[test]
+fn renders_breadcrumb_paths_and_ellipsizes_deep_ones() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    let theme = Arc::new(Theme::default());
+    let roots = vec![PathBuf::from("/ws")];
+    let mut list = RepoList::new(
+        vec![
+            PathBuf::from("/ws/hbre/camsys"),
+            PathBuf::from("/ws/kernel-6.1/drivers/media/platform/horizon/camsys"),
+            PathBuf::from("/ws/kernel-6.12/drivers/media/platform/horizon/camsys"),
+            PathBuf::from("/ws/build"),
+        ],
+        roots,
+        theme,
+    );
+    // Narrow enough that the deep kernel paths must be ellipsized.
+    list.render_area = Rect::new(0, 0, 40, 8);
+
+    let mut terminal = Terminal::new(TestBackend::new(40, 8)).unwrap();
+    terminal
+        .draw(|f| {
+            list.draw(f, f.area()).unwrap();
+        })
+        .unwrap();
+
+    let text: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|c| c.symbol())
+        .collect();
+
+    // Breadcrumb paths, not bare basenames — the three same-named repos are
+    // told apart by their parent path.
+    assert!(text.contains("hbre/camsys"), "got: {text}");
+    assert!(text.contains("kernel-6.1/…/camsys"), "got: {text}");
+    assert!(text.contains("kernel-6.12/…/camsys"), "got: {text}");
+    assert!(text.contains("build"), "got: {text}");
+}
+

--- a/src/git/scanner.rs
+++ b/src/git/scanner.rs
@@ -77,14 +77,19 @@ fn discover_repo_workspace_projects(
         if !repo_path.starts_with(root) {
             continue;
         }
+        // Canonicalize so a symlinked root (e.g. `~/work` -> `/real/path`)
+        // produces the same string as the tree walk's canonicalized paths.
+        // Without this, the same top-level repo would be added twice — once
+        // by the walk, once here — and `seen` couldn't tell them apart.
+        let canonical = repo_path.canonicalize().unwrap_or(repo_path.clone());
         // The working copy's `.git` may be a symlink or a `gitdir:` file;
         // is_real_git_dir handles both and rejects empty/phantom dirs. A
         // project whose working tree hasn't been synced yet is skipped.
-        if is_real_git_dir(&repo_path.join(".git"))
-            && !is_excluded(&repo_path, config)
-            && seen.insert(repo_path.clone())
+        if is_real_git_dir(&canonical.join(".git"))
+            && !is_excluded(&canonical, config)
+            && seen.insert(canonical.clone())
         {
-            out.push(repo_path);
+            out.push(canonical);
         }
     }
 }
@@ -538,5 +543,52 @@ mod tests {
         assert!(repos.contains(&native));
         assert!(repos.contains(&root.join("managed")));
         assert!(!repos.contains(&root.join(".repo/manifests")));
+    }
+
+    /// A repo workspace reached through a symlinked root (e.g. `~/work` ->
+    /// `/real/path`) must not double-add the top-level projects: the tree
+    /// walk canonicalizes its paths while project.list used to keep the
+    /// symlinked form, so `seen` saw two different strings for the same repo.
+    #[cfg(unix)]
+    #[test]
+    fn test_repo_workspace_symlink_root_has_no_duplicates() {
+        let tmp = TempDir::new().unwrap();
+        let real_root = tmp.path().join("real");
+        fs::create_dir_all(real_root.join(".repo/projects")).unwrap();
+        let mut worktrees = Vec::new();
+        for name in ["build", "kernel-6.12", "hbre/libmm"] {
+            let work = real_root.join(name);
+            fs::create_dir_all(&work).unwrap();
+            let gitdir = real_root.join(".repo/projects").join(format!("{name}.git"));
+            fs::create_dir_all(&gitdir).unwrap();
+            fs::write(gitdir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+            std::os::unix::fs::symlink(&gitdir, work.join(".git")).unwrap();
+            worktrees.push(work);
+        }
+        fs::write(
+            real_root.join(".repo").join("project.list"),
+            "build\nkernel-6.12\nhbre/libmm\n",
+        )
+        .unwrap();
+
+        // Access the workspace through a symlink alias, as `~/work` would be.
+        let alias = tmp.path().join("alias");
+        std::os::unix::fs::symlink(&real_root, &alias).unwrap();
+
+        let config = Config {
+            root_dirs: vec![alias],
+            scan_depth: 2,
+            ..Config::default()
+        };
+        let repos = discover_repos(&config);
+
+        let unique: HashSet<&PathBuf> = repos.iter().collect();
+        assert_eq!(repos.len(), unique.len(), "duplicates: {repos:?}");
+        assert_eq!(repos.len(), 3, "got {repos:?}");
+        // Every path is canonical (real) form, so list display is consistent.
+        assert!(
+            repos.iter().all(|p| p.starts_with(&real_root)),
+            "non-canonical paths: {repos:?}"
+        );
     }
 }

--- a/src/git/scanner.rs
+++ b/src/git/scanner.rs
@@ -9,8 +9,12 @@ use walkdir::WalkDir;
 /// query, so we treat such paths as not-a-repo at discovery time. Anything
 /// produced by `git init` will have a `HEAD` file; that is what we look for.
 ///
-/// Two layouts are accepted:
+/// Three layouts are accepted:
 /// - A standard checkout, where `.git` is a directory containing `HEAD`.
+/// - A *symlink* to such a git directory. This is exactly what Google's
+///   `repo` tool writes for every project working copy (`.git ->`
+///   `.repo/projects/<name>.git`), and `Path::join("HEAD").is_file()`
+///   resolves the symlink transparently.
 /// - A submodule or linked worktree, where `.git` is a *file* of the form
 ///   `gitdir: <path>` pointing at the real git directory (e.g.
 ///   `<superproject>/.git/modules/<name>`). Without this branch, pinning a
@@ -26,6 +30,63 @@ fn is_real_git_dir(dot_git: &Path) -> bool {
         return gitdir.join("HEAD").is_file();
     }
     false
+}
+
+/// Whether a candidate repo path matches an `excluded_repos` pattern.
+/// Patterns match the repo's directory name or any path component.
+fn is_excluded(repo_path: &Path, config: &Config) -> bool {
+    let repo_name = repo_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let path_str = repo_path.to_string_lossy();
+    config
+        .excluded_repos
+        .iter()
+        .any(|pattern| repo_name == *pattern || path_str.contains(pattern))
+}
+
+/// Google `repo` (git-repo) managed workspace discovery.
+///
+/// In such a workspace every project's working copy carries a `.git` that is
+/// a *symlink* (or `gitdir:` file) pointing into `.repo/projects/`, so the
+/// tree walk never sees them as directories. The authoritative list of
+/// managed projects is `.repo/project.list` — one relative path per line —
+/// which we enumerate instead. This is exact (matches what `repo sync`
+/// manages), scales to hundreds of projects, and automatically picks up
+/// projects added or removed by later `repo sync` runs because the file is
+/// re-read on every discovery pass. Workspaces not managed by `repo` (no
+/// `.repo/project.list`) are left untouched.
+fn discover_repo_workspace_projects(
+    root: &Path,
+    config: &Config,
+    seen: &mut HashSet<PathBuf>,
+    out: &mut Vec<PathBuf>,
+) {
+    let contents = match std::fs::read_to_string(root.join(".repo").join("project.list")) {
+        Ok(c) => c,
+        Err(_) => return, // not a repo-managed workspace (or not synced yet)
+    };
+    for line in contents.lines() {
+        let rel = line.trim();
+        if rel.is_empty() {
+            continue;
+        }
+        // Never let a listed path escape the workspace root.
+        let repo_path = root.join(rel);
+        if !repo_path.starts_with(root) {
+            continue;
+        }
+        // The working copy's `.git` may be a symlink or a `gitdir:` file;
+        // is_real_git_dir handles both and rejects empty/phantom dirs. A
+        // project whose working tree hasn't been synced yet is skipped.
+        if is_real_git_dir(&repo_path.join(".git"))
+            && !is_excluded(&repo_path, config)
+            && seen.insert(repo_path.clone())
+        {
+            out.push(repo_path);
+        }
+    }
 }
 
 /// Resolve a `gitdir: <path>` pointer file (used by submodules and linked
@@ -62,12 +123,16 @@ pub(crate) fn discover_repos(config: &Config) -> Vec<PathBuf> {
             .max_depth(config.scan_depth)
             .follow_links(false)
             .into_iter()
+            // Don't descend into the repo tool's own metadata (`<root>/.repo`).
+            // Its gitdirs under `.repo/projects/` are not `.git` entries, but
+            // `.repo/manifests/.git` is a symlink that would otherwise match.
+            .filter_entry(|e| e.file_name() != ".repo")
             .filter_map(|e| e.ok())
         {
-            if entry.file_name() == ".git"
-                && entry.file_type().is_dir()
-                && is_real_git_dir(entry.path())
-            {
+            // Accept any real gitdir: a `.git` directory with a `HEAD`, a
+            // `.git` symlink to one (Google `repo` working copies), or a
+            // `gitdir:` pointer file (submodules / linked worktrees).
+            if entry.file_name() == ".git" && is_real_git_dir(entry.path()) {
                 let repo_path = entry
                     .path()
                     .parent()
@@ -75,23 +140,15 @@ pub(crate) fn discover_repos(config: &Config) -> Vec<PathBuf> {
                     .canonicalize()
                     .unwrap_or_else(|_| entry.path().parent().unwrap().to_path_buf());
 
-                // Check exclusions
-                let repo_name = repo_path
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_default();
-
-                let path_str = repo_path.to_string_lossy();
-                let excluded = config
-                    .excluded_repos
-                    .iter()
-                    .any(|pattern| repo_name == *pattern || path_str.contains(pattern));
-
-                if !excluded && seen.insert(repo_path.clone()) {
+                if !is_excluded(&repo_path, config) && seen.insert(repo_path.clone()) {
                     repos.push(repo_path);
                 }
             }
         }
+
+        // Google `repo` (git-repo) managed workspace: enumerate
+        // `.repo/project.list` for the projects the tree walk cannot see.
+        discover_repo_workspace_projects(root, config, &mut seen, &mut repos);
     }
 
     repos.sort_by(|a, b| {
@@ -334,5 +391,152 @@ mod tests {
         let repos = discover_repos(&config);
         assert_eq!(repos.len(), 2);
         assert!(repos[0].ends_with("z-repo"));
+    }
+
+    /// Build a Google `repo`-style workspace fixture under `root`:
+    /// - `.repo/project.list` lists `projects` (one relative path per line),
+    /// - each project's gitdir lives at `.repo/projects/<name>.git` with a HEAD,
+    /// - the working copy at `<root>/<name>` gets its `.git` linked by `link`
+    ///   (a symlink on unix — the layout real `repo sync` writes — or a
+    ///   `gitdir:` pointer file, the portable equivalent).
+    fn make_repo_workspace(
+        root: &Path,
+        projects: &[&str],
+        link: impl Fn(&Path, &Path),
+    ) -> Vec<PathBuf> {
+        fs::create_dir_all(root.join(".repo/projects")).unwrap();
+        let mut worktrees = Vec::new();
+        for name in projects {
+            let work = root.join(name);
+            fs::create_dir_all(&work).unwrap();
+            let gitdir = root.join(".repo/projects").join(format!("{name}.git"));
+            fs::create_dir_all(&gitdir).unwrap();
+            fs::write(gitdir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+            link(&work, &gitdir);
+            worktrees.push(work);
+        }
+        fs::write(
+            root.join(".repo").join("project.list"),
+            format!("{}\n", projects.join("\n")),
+        )
+        .unwrap();
+        worktrees
+    }
+
+    /// A Google `repo` workspace where every project's `.git` is a symlink to
+    /// `.repo/projects/<name>.git` — the layout `repo sync` actually writes on
+    /// unix. Before repo-aware discovery, all of these were invisible because
+    /// the walk's `is_dir()` check rejected symlinks.
+    #[cfg(unix)]
+    #[test]
+    fn test_repo_workspace_symlink_projects_are_discovered() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let projects = make_repo_workspace(
+            root,
+            &["kernel-6.12", "hbre/libmm", "app/qualitytest"],
+            |work, gitdir| std::os::unix::fs::symlink(gitdir, work.join(".git")).unwrap(),
+        );
+
+        let config = Config {
+            root_dirs: vec![root.to_path_buf()],
+            scan_depth: 1, // the walk sees nothing; project.list does the work
+            ..Config::default()
+        };
+        let repos = discover_repos(&config);
+        assert_eq!(repos.len(), 3, "got {repos:?}");
+        for p in &projects {
+            assert!(repos.contains(p), "missing {p:?}");
+        }
+    }
+
+    /// Same workspace layout but with `gitdir:` pointer files instead of
+    /// symlinks (portable; some repo versions/OSes write these).
+    #[test]
+    fn test_repo_workspace_gitdir_file_projects_are_discovered() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let projects = make_repo_workspace(
+            root,
+            &["kernel-6.12", "hbre/libmm"],
+            |work, gitdir| {
+                fs::write(work.join(".git"), format!("gitdir: {}\n", gitdir.display())).unwrap()
+            },
+        );
+
+        let config = Config {
+            root_dirs: vec![root.to_path_buf()],
+            scan_depth: 1,
+            ..Config::default()
+        };
+        let repos = discover_repos(&config);
+        assert_eq!(repos.len(), 2, "got {repos:?}");
+        for p in &projects {
+            assert!(repos.contains(p), "missing {p:?}");
+        }
+    }
+
+    /// A project listed in `.repo/project.list` whose working tree hasn't been
+    /// synced yet must be skipped, not crash discovery.
+    #[test]
+    fn test_repo_workspace_skips_missing_worktrees() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let projects = make_repo_workspace(root, &["synced"], |work, gitdir| {
+            fs::write(work.join(".git"), format!("gitdir: {}\n", gitdir.display())).unwrap()
+        });
+        // A second project that exists only in project.list, not on disk.
+        fs::write(
+            root.join(".repo").join("project.list"),
+            "synced\nnot-synced-yet\n",
+        )
+        .unwrap();
+
+        let config = Config {
+            root_dirs: vec![root.to_path_buf()],
+            scan_depth: 1,
+            ..Config::default()
+        };
+        let repos = discover_repos(&config);
+        assert_eq!(repos.len(), 1, "got {repos:?}");
+        assert!(repos.contains(&projects[0]));
+    }
+
+    /// Native `.git` directories outside `.repo` must still be found alongside
+    /// repo-managed projects, and the repo tool's own `.repo/manifests/.git`
+    /// symlink must NOT be picked up as a project.
+    #[cfg(unix)]
+    #[test]
+    fn test_repo_workspace_mixes_native_and_managed() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let native = make_repo(root, "standalone");
+        make_repo_workspace(root, &["managed"], |work, gitdir| {
+            std::os::unix::fs::symlink(gitdir, work.join(".git")).unwrap()
+        });
+        // Simulate repo's own tooling symlink inside `.repo/`.
+        fs::create_dir_all(root.join(".repo/manifests")).unwrap();
+        fs::create_dir_all(root.join(".repo/manifests-git")).unwrap();
+        fs::write(
+            root.join(".repo/manifests-git/HEAD"),
+            "ref: refs/heads/main\n",
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(
+            root.join(".repo/manifests-git"),
+            root.join(".repo/manifests").join(".git"),
+        )
+        .unwrap();
+
+        let config = Config {
+            root_dirs: vec![root.to_path_buf()],
+            scan_depth: 2,
+            ..Config::default()
+        };
+        let repos = discover_repos(&config);
+        assert_eq!(repos.len(), 2, "got {repos:?}");
+        assert!(repos.contains(&native));
+        assert!(repos.contains(&root.join("managed")));
+        assert!(!repos.contains(&root.join(".repo/manifests")));
     }
 }


### PR DESCRIPTION
Two changes that make gitpane usable on large Google `repo` (git-repo) workspaces:

**`feat(scanner): discover Google repo workspaces via .repo/project.list`**

A Google `repo` workspace links each project's working-copy `.git` to
`.repo/projects/<name>.git` as a symlink, so the walkdir scan — which
only accepts a `.git` directory containing HEAD — skips every project
and a large checkout appears as a handful of native repos.

Read the authoritative `.repo/project.list` as a second discovery
source: exact, scales to hundreds of projects, and automatically picks
up projects added or removed by later `repo sync` runs. Also relax the
walk to accept `.git` symlinks and `gitdir:` pointer files (submodules
/ linked worktrees) and prune the `.repo` metadata subtree. Exclusions
and dedup are shared between both discovery paths.

**`feat(repo-list): show breadcrumb paths instead of bare basenames`**

The repo list derived each row's label from the directory basename
(path.file_name()), so same-named repos were indistinguishable (e.g.
hbre/camsys vs kernel-6.12/.../camsys) and the name was squeezed in at
the end of a long indicator row, getting truncated first in a narrow
panel.

Label each repo with its path relative to the workspace root, anchored
at the left of the row with the status indicators trailing after it,
and middle-ellipsize deep paths ("kernel-6.12/…/camsys") so they can
never push the indicators off-screen. The relative path is computed
from the configured roots (basename fallback for repos outside them),
so alphabetical and dirty-first sorts now group rows by directory.

Adds display_path / status_block_width / rendered_name /
middle_ellipsize helpers, threads roots through RepoList (also for
repos added at rescan time), and covers breadcrumb rendering, path
disambiguation, and ellipsizing with new tests.