### PR TITLE
fix: auto-show the commit diff when a file is selected in the graph

### DIFF
--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -577,6 +577,13 @@ impl App {
                 if generation == self.git_graph.current_detail_generation() {
                     self.git_graph
                         .set_commit_files(oid.clone(), message.clone(), files.clone());
+                    // Auto-load the highlighted file's diff so the Diff pane
+                    // populates without an extra Enter/click on a file row.
+                    if !files.is_empty()
+                        && let Some(action) = self.git_graph.try_show_commit_diff()
+                    {
+                        self.action_tx.send(action)?;
+                    }
                 }
             }
             Action::ShowCommitDiff {

--- a/src/components/git_graph/component.rs
+++ b/src/components/git_graph/component.rs
@@ -347,7 +347,8 @@ impl Component for GitGraph {
                             .unwrap_or(0);
                         detail.file_state.select(Some(i));
                     }
-                    return Ok(None);
+                    // Highlighting a file shows its diff in the Diff pane.
+                    return Ok(self.try_show_commit_diff());
                 }
                 KeyCode::Char('k') | KeyCode::Up => {
                     if !detail.files.is_empty() {
@@ -358,7 +359,7 @@ impl Component for GitGraph {
                             .unwrap_or(0);
                         detail.file_state.select(Some(i));
                     }
-                    return Ok(None);
+                    return Ok(self.try_show_commit_diff());
                 }
                 KeyCode::Enter => {
                     return Ok(self.try_show_commit_diff());
@@ -430,15 +431,16 @@ impl Component for GitGraph {
                         let visual_row = (mouse.row - content_y) as usize;
                         let idx = visual_row + self.state.offset();
                         if idx < self.display_rows().len() {
-                            // Click on already-selected row opens commit files
-                            if self.state.selected() == Some(idx) && self.commit_detail.is_none() {
-                                return Ok(self.try_show_commit_files());
-                            }
                             self.state.select(Some(idx));
                             self.commit_detail = None;
                             if std::mem::take(&mut self.needs_reload) {
                                 self.reload_graph();
                             }
+                            // A single click selects the commit and opens its
+                            // changed files (and, via CommitFilesLoaded, the
+                            // highlighted file's diff), so no second click is
+                            // needed to see the detail.
+                            return Ok(self.try_show_commit_files());
                         }
                     }
                     return Ok(None);

--- a/src/components/git_graph/component.rs
+++ b/src/components/git_graph/component.rs
@@ -456,11 +456,11 @@ impl Component for GitGraph {
                         let visual_row = (mouse.row - content_y) as usize;
                         let idx = visual_row + detail.file_state.offset();
                         if idx < detail.files.len() {
-                            if detail.file_state.selected() == Some(idx) {
-                                open_file_diff = true;
-                            } else {
-                                detail.file_state.select(Some(idx));
-                            }
+                            // Highlighting a file (mouse or keys) shows its
+                            // diff in the Diff pane; re-clicking the same
+                            // file just re-requests it.
+                            detail.file_state.select(Some(idx));
+                            open_file_diff = true;
                         }
                     }
                 }

--- a/src/components/git_graph/mod.rs
+++ b/src/components/git_graph/mod.rs
@@ -719,7 +719,7 @@ impl GitGraph {
         Some(Action::ShowCommitFiles { repo_path, oid })
     }
 
-    fn try_show_commit_diff(&mut self) -> Option<Action> {
+    pub(crate) fn try_show_commit_diff(&mut self) -> Option<Action> {
         let detail = self.commit_detail.as_ref()?;
         let file_idx = detail.file_state.selected()?;
         let (_, file_path) = detail.files.get(file_idx)?;

--- a/src/components/git_graph/tests.rs
+++ b/src/components/git_graph/tests.rs
@@ -502,3 +502,41 @@ fn moving_through_files_requests_their_diff() {
         other => panic!("expected ShowCommitDiff, got {other:?}"),
     }
 }
+
+#[test]
+fn clicking_a_file_row_refreshes_its_diff() {
+    let mut graph = GitGraph::new(std::sync::Arc::new(crate::theme::Theme::default()));
+    graph.repo_path = Some(std::path::PathBuf::from("/repo"));
+    graph.set_commit_files(
+        "abc1234".into(),
+        "first".into(),
+        vec![
+            ("M".into(), "a.rs".into()),
+            ("M".into(), "b.rs".into()),
+        ],
+    );
+    if let Some(detail) = graph.commit_detail.as_mut() {
+        detail.file_list_area = Rect::new(0, 0, 40, 10);
+    }
+
+    // Click the second file row (content_y = area.y + 1 = 1 → row 2 is idx 1).
+    let action = graph
+        .handle_mouse_event(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 2,
+            row: 2,
+            modifiers: KeyModifiers::NONE,
+        })
+        .unwrap();
+    match action {
+        Some(Action::ShowCommitDiff { file_path, .. }) => {
+            assert_eq!(file_path, std::path::PathBuf::from("b.rs"));
+        }
+        other => panic!("expected ShowCommitDiff, got {other:?}"),
+    }
+    // The highlight moved to the clicked file too.
+    assert_eq!(
+        graph.commit_detail.as_ref().unwrap().file_state.selected(),
+        Some(1)
+    );
+}

--- a/src/components/git_graph/tests.rs
+++ b/src/components/git_graph/tests.rs
@@ -428,3 +428,77 @@ fn test_set_rows_resets_abort_counter() {
     graph.set_rows(vec![mock_row("abc1234", "ok", "Alice")]);
     assert_eq!(graph.consecutive_aborts, 0);
 }
+
+#[test]
+fn clicking_a_commit_row_opens_its_files() {
+    let mut graph = GitGraph::new(std::sync::Arc::new(crate::theme::Theme::default()));
+    graph.repo_path = Some(std::path::PathBuf::from("/repo"));
+    graph.set_rows(vec![mock_row("abc1234", "first", "Alice")]);
+    graph.graph_list_area = Rect::new(0, 0, 80, 4);
+
+    // A single left click (not a second one) must open the commit's files.
+    let action = graph
+        .handle_mouse_event(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 1,
+            row: 1,
+            modifiers: KeyModifiers::NONE,
+        })
+        .unwrap();
+    assert!(matches!(action, Some(Action::ShowCommitFiles { .. })));
+    assert_eq!(graph.state.selected(), Some(0));
+}
+
+#[test]
+fn highlighted_file_diff_is_requested_after_files_load() {
+    let mut graph = GitGraph::new(std::sync::Arc::new(crate::theme::Theme::default()));
+    graph.repo_path = Some(std::path::PathBuf::from("/repo"));
+    graph.set_rows(vec![mock_row("abc1234", "first", "Alice")]);
+    graph.state.select(Some(0));
+
+    // CommitFilesLoaded path: files arrive, first file is auto-highlighted.
+    graph.set_commit_files(
+        "abc1234".into(),
+        "first".into(),
+        vec![
+            ("M".into(), "src/main.rs".into()),
+            ("A".into(), "src/lib.rs".into()),
+        ],
+    );
+
+    // The App then asks for the highlighted file's diff automatically; the
+    // first file is selected, so the diff must target it.
+    let action = graph.try_show_commit_diff().expect("auto diff");
+    match action {
+        Action::ShowCommitDiff { oid, file_path, .. } => {
+            assert_eq!(oid, "abc1234");
+            assert_eq!(file_path, std::path::PathBuf::from("src/main.rs"));
+        }
+        other => panic!("expected ShowCommitDiff, got {other:?}"),
+    }
+}
+
+#[test]
+fn moving_through_files_requests_their_diff() {
+    let mut graph = GitGraph::new(std::sync::Arc::new(crate::theme::Theme::default()));
+    graph.repo_path = Some(std::path::PathBuf::from("/repo"));
+    graph.set_commit_files(
+        "abc1234".into(),
+        "first".into(),
+        vec![
+            ("M".into(), "a.rs".into()),
+            ("M".into(), "b.rs".into()),
+        ],
+    );
+    // Detail open, file 0 selected; pressing Down moves to file 1 and must
+    // request its diff (no Enter needed).
+    let action = graph
+        .handle_key_event(KeyEvent::from(KeyCode::Down))
+        .unwrap();
+    match action {
+        Some(Action::ShowCommitDiff { file_path, .. }) => {
+            assert_eq!(file_path, std::path::PathBuf::from("b.rs"));
+        }
+        other => panic!("expected ShowCommitDiff, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Two fixes for the git graph's commit detail so the Diff pane follows
the selection instead of waiting for an extra Enter/click.

**`fix(graph): auto-show the highlighted file's diff when a commit opens`**

Opening a commit's changed files left the Diff pane empty until the
file was activated again with Enter or a second click. The commit
detail's first file is auto-highlighted on load, so request its diff
right after CommitFilesLoaded and route the result to the Diff pane.

Also open the files on a single click on a commit row (previously the
first click only selected it), and request the diff as the file
highlight moves, so the detail tracks the selection without extra
activation.

**`fix(graph): refresh the diff when a file is clicked with the mouse`**

Clicking a file row in the commit detail only refreshed the diff when
the clicked file was already highlighted; clicking a different file
just moved the highlight and left the Diff pane stale. Request the diff
for any clicked file, matching the keyboard j/k behavior.