### PR TITLE
fix: resolve the real remote for pull/push instead of hard-coding origin

### DIFF
--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -205,7 +205,11 @@ impl App {
             | Action::GitPullSubmodules(ref id) => {
                 if let Some(target) = self.repo_list.resolve_target(id) {
                     let branch = target.branch.clone();
-                    let mut git_args: Vec<String> = match action {
+                    // Subcommand only; the remote and branch are resolved
+                    // inside the blocking thread (reading the repo's remotes
+                    // is I/O) so the command targets the right remote even
+                    // when the workspace has no `origin` (e.g. Gerrit).
+                    let git_op: Vec<String> = match action {
                         Action::GitPush(_) => vec!["push".into()],
                         Action::GitPull(_) => vec!["pull".into()],
                         Action::GitPullRebase(_) => {
@@ -216,11 +220,6 @@ impl App {
                         }
                         _ => unreachable!(),
                     };
-                    // Add origin <branch> so pull/push works even without upstream config
-                    if !branch.is_empty() && branch != "(no branch)" {
-                        git_args.push("origin".into());
-                        git_args.push(branch);
-                    }
                     // The op runs in `exec_path` (the worktree's own
                     // directory when a worktree is targeted) but the
                     // parent repo's row shows the spinner and is
@@ -230,6 +229,19 @@ impl App {
                     let path = target.exec_path.clone();
                     let tx = self.action_tx.clone();
                     tokio::task::spawn_blocking(move || {
+                        // Resolve the remote here (blocking I/O) and append
+                        // `<remote> <branch>` so pull/push work without an
+                        // upstream configured. When the repo has no remote at
+                        // all, omit it and let git use the repo's own
+                        // upstream (or report the missing remote).
+                        let mut git_args = git_op;
+                        if !branch.is_empty()
+                            && branch != "(no branch)"
+                            && let Some(remote) = crate::git::resolve_remote_name(&path)
+                        {
+                            git_args.push(remote);
+                            git_args.push(branch);
+                        }
                         let guard = GitOpGuard::new(parent_id.clone(), tx.clone());
                         let output = std::process::Command::new("git")
                             .arg("-C")

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -39,6 +39,44 @@ pub(crate) fn git_available() -> bool {
     })
 }
 
+/// The remote to target for a `git pull` / `git push` against `path`.
+///
+/// gitpane passes an explicit `<remote> <branch>` so pull/push work even
+/// without an `upstream` configured, but it should not hard-code `origin`:
+/// Gerrit and mirror workspaces name their remote `gerrit` / `gitea_mirror`
+/// etc. and have no `origin` at all, which would make every pull/push fail
+/// with "fatal: 'origin' does not appear to be a git repository".
+///
+/// Resolution order: `origin` if present, else the sole remote, else the
+/// first remote in lexicographic order (stable even when config order is
+/// not). `None` when the repo has no remotes (the caller then omits the
+/// remote and lets `git pull` / `git push` use the repo's own upstream, or
+/// report the missing remote).
+///
+/// Blocking (opens the repo) — call from `spawn_blocking`.
+pub(crate) fn resolve_remote_name(path: &std::path::Path) -> Option<String> {
+    use git2::Repository;
+
+    let repo = Repository::open(path).ok()?;
+    let mut remotes: Vec<String> = repo
+        .remotes()
+        .ok()?
+        .iter()
+        .filter_map(|r| r.ok().flatten().map(|s| s.to_string()))
+        .collect();
+    if remotes.is_empty() {
+        return None;
+    }
+    if let Some(pos) = remotes.iter().position(|r| r == "origin") {
+        return Some(remotes.swap_remove(pos));
+    }
+    if remotes.len() == 1 {
+        return Some(remotes.pop().unwrap());
+    }
+    remotes.sort();
+    Some(remotes.into_iter().next().unwrap())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -56,5 +94,77 @@ mod tests {
     fn describe_spawn_error_passes_through_other_errors() {
         let err = io::Error::new(io::ErrorKind::PermissionDenied, "permission denied");
         assert_eq!(describe_spawn_error(&err), "permission denied");
+    }
+
+    /// A real git repo (via `git init`) with remotes configured through
+    /// `git remote add`, so `resolve_remote_name` has a real config to read.
+    /// Returns `None` when `git` is unavailable so the suite degrades
+    /// gracefully under environments without git. The `TempDir` is returned
+    /// alongside the path so the repo outlives the test body.
+    fn repo_with_remotes(remotes: &[&str]) -> Option<(tempfile::TempDir, std::path::PathBuf)> {
+        let tmp = tempfile::TempDir::new().ok()?;
+        let init = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(tmp.path())
+            .status()
+            .ok()?;
+        if !init.success() {
+            return None;
+        }
+        for (i, name) in remotes.iter().enumerate() {
+            let add = std::process::Command::new("git")
+                .args([
+                    "remote",
+                    "add",
+                    name,
+                    &format!("https://example.com/repo{i}.git"),
+                ])
+                .current_dir(tmp.path())
+                .status()
+                .ok()?;
+            if !add.success() {
+                return None;
+            }
+        }
+        let dir = tmp.path().to_path_buf();
+        Some((tmp, dir))
+    }
+
+    #[test]
+    fn resolve_remote_prefers_origin() {
+        let Some((_tmp, dir)) = repo_with_remotes(&["origin", "gerrit"]) else {
+            eprintln!("skipping: git unavailable");
+            return;
+        };
+        assert_eq!(resolve_remote_name(&dir).as_deref(), Some("origin"));
+    }
+
+    #[test]
+    fn resolve_remote_uses_sole_remote_when_no_origin() {
+        // Gerrit/mirror workspaces: no origin, a single `gerrit` remote.
+        let Some((_tmp, dir)) = repo_with_remotes(&["gerrit"]) else {
+            eprintln!("skipping: git unavailable");
+            return;
+        };
+        assert_eq!(resolve_remote_name(&dir).as_deref(), Some("gerrit"));
+    }
+
+    #[test]
+    fn resolve_remote_picks_first_lexicographic_without_origin() {
+        let Some((_tmp, dir)) = repo_with_remotes(&["zzz", "gerrit"]) else {
+            eprintln!("skipping: git unavailable");
+            return;
+        };
+        // No origin → lexicographically first, not config order.
+        assert_eq!(resolve_remote_name(&dir).as_deref(), Some("gerrit"));
+    }
+
+    #[test]
+    fn resolve_remote_none_without_remotes() {
+        let Some((_tmp, dir)) = repo_with_remotes(&[]) else {
+            eprintln!("skipping: git unavailable");
+            return;
+        };
+        assert_eq!(resolve_remote_name(&dir), None);
     }
 }


### PR DESCRIPTION
## Problem

`git pull`/`git push` hard-coded `origin` so they worked without an upstream configured:

```
git -C <repo> pull origin <branch>
git -C <repo> push origin <branch>
```

Workspaces whose remote is **not** named `origin` — Gerrit (`gerrit`), gitea mirrors, any renamed remote — have no `origin` at all, so every pull/push failed with `fatal: 'origin' does not appear to be a git repository`, from both the context menu and the keyboard shortcuts.

## Approach

Resolve the remote before running the command (`resolve_remote_name` in `git/mod.rs`):

- `origin` if present
- else the **sole** remote (e.g. a Gerrit workspace with a single `gerrit` remote)
- else the first remote in **lexicographic** order (stable regardless of config order)
- a repo with no remotes omits the remote and lets `git` use its own upstream (or report the missing remote)

The lookup runs inside the blocking thread (`Repository::open` is I/O). The subcommand is built outside, remote + branch appended inside — behavior unchanged for normal `origin` workspaces.

## Test

`cargo test --bin gitpane` — 4 new unit tests: origin preference, sole remote, lexicographic fallback, no remotes.
