### PR TITLE
git: defer pull/push to configured upstream and finish the origin sweep

### DIFF
--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -227,17 +227,22 @@ impl App {
                     let parent_id = RepoId(self.repo_list.repos[target.parent_index].path.clone());
                     self.repo_list.repos[target.parent_index].git_op = true;
                     let path = target.exec_path.clone();
+                    let is_push = matches!(action, Action::GitPush(_));
                     let tx = self.action_tx.clone();
                     tokio::task::spawn_blocking(move || {
                         // Resolve the remote here (blocking I/O) and append
                         // `<remote> <branch>` so pull/push work without an
-                        // upstream configured. When the repo has no remote at
-                        // all, omit it and let git use the repo's own
-                        // upstream (or report the missing remote).
+                        // upstream configured. Runs bare when git can resolve
+                        // the destination itself (configured upstream / push
+                        // remote) or the repo has no remote. `"HEAD"` is the
+                        // git2 shorthand for a detached HEAD — no branch to
+                        // sync, so run bare and let git report it.
                         let mut git_args = git_op;
                         if !branch.is_empty()
                             && branch != "(no branch)"
-                            && let Some(remote) = crate::git::resolve_remote_name(&path)
+                            && branch != "HEAD"
+                            && let Some(remote) =
+                                crate::git::resolve_sync_remote(&path, &branch, is_push)
                         {
                             git_args.push(remote);
                             git_args.push(branch);
@@ -301,10 +306,21 @@ impl App {
                             .map(|s| s.to_string())
                             .collect(),
                         Action::GitSubmoduleUpdateLatest(_) => {
-                            ["submodule", "foreach", "git", "pull", "origin", "HEAD"]
-                                .iter()
-                                .map(|s| s.to_string())
-                                .collect()
+                            // foreach runs the command through sh, so the
+                            // subshell picks each submodule's own remote
+                            // instead of a hard-coded `origin` (absent in
+                            // Gerrit/mirror workspaces).
+                            // ponytail: first-listed remote per submodule;
+                            // resolve_sync_remote per submodule if anyone
+                            // runs multi-remote submodules.
+                            [
+                                "submodule",
+                                "foreach",
+                                "git pull \"$(git remote | head -n1)\" HEAD",
+                            ]
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect()
                         }
                         _ => unreachable!(),
                     };

--- a/src/app/github.rs
+++ b/src/app/github.rs
@@ -179,7 +179,7 @@ impl App {
             return;
         }
         if entry.owner_repo.is_none() {
-            entry.owner_repo = github::origin_owner_repo(&path);
+            entry.owner_repo = github::github_owner_repo(&path);
         }
         let Some((owner, repo)) = entry.owner_repo.clone() else {
             // Not a github.com repo: record the attempt so we don't re-probe the

--- a/src/git/github.rs
+++ b/src/git/github.rs
@@ -92,14 +92,30 @@ pub(crate) fn gh_available() -> bool {
     })
 }
 
-/// Resolve a repo's `origin` remote to `(owner, repo)` when it is a github.com
-/// remote, else `None`. Reads the remote URL through git2 (already a dep) and
-/// parses the common SSH/HTTPS forms.
-pub(crate) fn origin_owner_repo(path: &Path) -> Option<(String, String)> {
+/// Resolve a repo's github.com remote to `(owner, repo)`, else `None`.
+/// `origin` wins when it parses as github.com; otherwise the first (sorted)
+/// remote with a github.com URL — so a mirror workspace whose GitHub remote
+/// is named `github` still gets PR links and status checks. Reads the remote
+/// URL through git2 (already a dep) and parses the common SSH/HTTPS forms.
+pub(crate) fn github_owner_repo(path: &Path) -> Option<(String, String)> {
     let repo = git2::Repository::open(path).ok()?;
-    let remote = repo.find_remote("origin").ok()?;
-    let url = remote.url().ok()?;
-    parse_github_owner_repo(url)
+    if let Ok(remote) = repo.find_remote("origin")
+        && let Ok(url) = remote.url()
+        && let Some(pair) = parse_github_owner_repo(url)
+    {
+        return Some(pair);
+    }
+    let mut names: Vec<String> = repo
+        .remotes()
+        .ok()?
+        .iter()
+        .filter_map(|r| r.ok().flatten().map(|s| s.to_string()))
+        .collect();
+    names.sort();
+    names.iter().filter(|n| *n != "origin").find_map(|name| {
+        let remote = repo.find_remote(name).ok()?;
+        parse_github_owner_repo(remote.url().ok()?)
+    })
 }
 
 /// Parse `owner`/`repo` out of a github.com remote URL. Supports:

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -39,42 +39,65 @@ pub(crate) fn git_available() -> bool {
     })
 }
 
-/// The remote to target for a `git pull` / `git push` against `path`.
-///
-/// gitpane passes an explicit `<remote> <branch>` so pull/push work even
-/// without an `upstream` configured, but it should not hard-code `origin`:
-/// Gerrit and mirror workspaces name their remote `gerrit` / `gitea_mirror`
-/// etc. and have no `origin` at all, which would make every pull/push fail
-/// with "fatal: 'origin' does not appear to be a git repository".
-///
-/// Resolution order: `origin` if present, else the sole remote, else the
-/// first remote in lexicographic order (stable even when config order is
-/// not). `None` when the repo has no remotes (the caller then omits the
-/// remote and lets `git pull` / `git push` use the repo's own upstream, or
-/// report the missing remote).
-///
-/// Blocking (opens the repo) — call from `spawn_blocking`.
-pub(crate) fn resolve_remote_name(path: &std::path::Path) -> Option<String> {
-    use git2::Repository;
-
-    let repo = Repository::open(path).ok()?;
+/// The remote gitpane should treat as canonical for `repo` when nothing more
+/// specific is configured: `origin` if present, else the lexicographically
+/// first remote (stable even when config order is not). Gerrit and mirror
+/// workspaces name their remote `gerrit` / `gitea_mirror` etc. and have no
+/// `origin` at all, so hard-coding `origin` breaks them. `None` when the repo
+/// has no remotes.
+pub(crate) fn preferred_remote(repo: &git2::Repository) -> Option<String> {
     let mut remotes: Vec<String> = repo
         .remotes()
         .ok()?
         .iter()
         .filter_map(|r| r.ok().flatten().map(|s| s.to_string()))
         .collect();
-    if remotes.is_empty() {
-        return None;
-    }
-    if let Some(pos) = remotes.iter().position(|r| r == "origin") {
-        return Some(remotes.swap_remove(pos));
-    }
-    if remotes.len() == 1 {
-        return Some(remotes.pop().unwrap());
+    if remotes.iter().any(|r| r == "origin") {
+        return Some("origin".into());
     }
     remotes.sort();
-    Some(remotes.into_iter().next().unwrap())
+    remotes.into_iter().next()
+}
+
+/// The explicit `<remote>` to append to a `git pull` / `git push` of `branch`
+/// at `path`, or `None` when the command should run bare.
+///
+/// `None` covers two cases the caller treats identically (append nothing):
+/// git can already resolve the destination itself — a configured upstream
+/// (`branch.<name>.remote` + `.merge`), or for pushes `branch.<name>.pushRemote`
+/// / `remote.pushDefault` — in which case a bare command also honors renamed
+/// upstream branches (local `main` tracking `gerrit/master`) that an explicit
+/// `<remote> <branch>` would break; or the repo has no remotes at all and git
+/// gets to report that.
+///
+/// Explicit fallback order: the branch's own `branch.<name>.remote` when it
+/// names a real remote (the user's intent even without a `.merge` ref), else
+/// [`preferred_remote`].
+///
+/// Blocking (opens the repo) — call from `spawn_blocking`.
+pub(crate) fn resolve_sync_remote(
+    path: &std::path::Path,
+    branch: &str,
+    push: bool,
+) -> Option<String> {
+    let repo = git2::Repository::open(path).ok()?;
+    let config = repo.config().ok()?;
+    let get = |key: &str| config.get_string(key).ok();
+
+    let upstream = get(&format!("branch.{branch}.remote"));
+    let has_merge = get(&format!("branch.{branch}.merge")).is_some();
+    let has_push_dest = push
+        && (get(&format!("branch.{branch}.pushremote")).is_some()
+            || get("remote.pushdefault").is_some());
+    if (upstream.is_some() && has_merge) || has_push_dest {
+        return None;
+    }
+    if let Some(remote) = upstream
+        && repo.find_remote(&remote).is_ok()
+    {
+        return Some(remote);
+    }
+    preferred_remote(&repo)
 }
 
 #[cfg(test)]
@@ -96,75 +119,91 @@ mod tests {
         assert_eq!(describe_spawn_error(&err), "permission denied");
     }
 
-    /// A real git repo (via `git init`) with remotes configured through
-    /// `git remote add`, so `resolve_remote_name` has a real config to read.
-    /// Returns `None` when `git` is unavailable so the suite degrades
-    /// gracefully under environments without git. The `TempDir` is returned
-    /// alongside the path so the repo outlives the test body.
-    fn repo_with_remotes(remotes: &[&str]) -> Option<(tempfile::TempDir, std::path::PathBuf)> {
-        let tmp = tempfile::TempDir::new().ok()?;
-        let init = std::process::Command::new("git")
-            .args(["init", "-q"])
-            .current_dir(tmp.path())
-            .status()
-            .ok()?;
-        if !init.success() {
-            return None;
-        }
+    /// A git2-native temp repo with the given remotes configured — no `git`
+    /// binary involved, so these tests never skip.
+    fn repo_with_remotes(remotes: &[&str]) -> (tempfile::TempDir, git2::Repository) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = git2::Repository::init(tmp.path()).unwrap();
         for (i, name) in remotes.iter().enumerate() {
-            let add = std::process::Command::new("git")
-                .args([
-                    "remote",
-                    "add",
-                    name,
-                    &format!("https://example.com/repo{i}.git"),
-                ])
-                .current_dir(tmp.path())
-                .status()
-                .ok()?;
-            if !add.success() {
-                return None;
-            }
+            repo.remote(name, &format!("https://example.com/repo{i}.git"))
+                .unwrap();
         }
-        let dir = tmp.path().to_path_buf();
-        Some((tmp, dir))
+        (tmp, repo)
     }
 
     #[test]
-    fn resolve_remote_prefers_origin() {
-        let Some((_tmp, dir)) = repo_with_remotes(&["origin", "gerrit"]) else {
-            eprintln!("skipping: git unavailable");
-            return;
-        };
-        assert_eq!(resolve_remote_name(&dir).as_deref(), Some("origin"));
+    fn sync_remote_prefers_origin_without_upstream() {
+        let (tmp, _repo) = repo_with_remotes(&["origin", "gerrit"]);
+        assert_eq!(
+            resolve_sync_remote(tmp.path(), "main", false).as_deref(),
+            Some("origin")
+        );
     }
 
     #[test]
-    fn resolve_remote_uses_sole_remote_when_no_origin() {
+    fn sync_remote_uses_sole_remote_when_no_origin() {
         // Gerrit/mirror workspaces: no origin, a single `gerrit` remote.
-        let Some((_tmp, dir)) = repo_with_remotes(&["gerrit"]) else {
-            eprintln!("skipping: git unavailable");
-            return;
-        };
-        assert_eq!(resolve_remote_name(&dir).as_deref(), Some("gerrit"));
+        let (tmp, _repo) = repo_with_remotes(&["gerrit"]);
+        assert_eq!(
+            resolve_sync_remote(tmp.path(), "main", false).as_deref(),
+            Some("gerrit")
+        );
     }
 
     #[test]
-    fn resolve_remote_picks_first_lexicographic_without_origin() {
-        let Some((_tmp, dir)) = repo_with_remotes(&["zzz", "gerrit"]) else {
-            eprintln!("skipping: git unavailable");
-            return;
-        };
+    fn sync_remote_picks_first_lexicographic_without_origin() {
+        let (tmp, _repo) = repo_with_remotes(&["zzz", "gerrit"]);
         // No origin → lexicographically first, not config order.
-        assert_eq!(resolve_remote_name(&dir).as_deref(), Some("gerrit"));
+        assert_eq!(
+            resolve_sync_remote(tmp.path(), "main", false).as_deref(),
+            Some("gerrit")
+        );
     }
 
     #[test]
-    fn resolve_remote_none_without_remotes() {
-        let Some((_tmp, dir)) = repo_with_remotes(&[]) else {
-            eprintln!("skipping: git unavailable");
-            return;
-        };
-        assert_eq!(resolve_remote_name(&dir), None);
+    fn sync_remote_none_without_remotes() {
+        let (tmp, _repo) = repo_with_remotes(&[]);
+        assert_eq!(resolve_sync_remote(tmp.path(), "main", false), None);
+    }
+
+    #[test]
+    fn sync_remote_defers_to_configured_upstream() {
+        // Renamed upstream (local main tracking gerrit/master): a bare
+        // `git pull` resolves it correctly; an explicit `gerrit main` would
+        // fetch a nonexistent ref, so the resolver must return None.
+        let (tmp, repo) = repo_with_remotes(&["origin", "gerrit"]);
+        let mut config = repo.config().unwrap();
+        config.set_str("branch.main.remote", "gerrit").unwrap();
+        config
+            .set_str("branch.main.merge", "refs/heads/master")
+            .unwrap();
+        assert_eq!(resolve_sync_remote(tmp.path(), "main", false), None);
+        assert_eq!(resolve_sync_remote(tmp.path(), "main", true), None);
+    }
+
+    #[test]
+    fn sync_remote_prefers_branch_remote_over_origin() {
+        // Partial upstream (remote without a merge ref): still the user's
+        // configured intent, so it beats the origin default.
+        let (tmp, repo) = repo_with_remotes(&["origin", "gerrit"]);
+        let mut config = repo.config().unwrap();
+        config.set_str("branch.main.remote", "gerrit").unwrap();
+        assert_eq!(
+            resolve_sync_remote(tmp.path(), "main", false).as_deref(),
+            Some("gerrit")
+        );
+    }
+
+    #[test]
+    fn sync_remote_defers_to_push_remote_only_for_push() {
+        let (tmp, repo) = repo_with_remotes(&["origin", "gerrit"]);
+        let mut config = repo.config().unwrap();
+        config.set_str("branch.main.pushremote", "gerrit").unwrap();
+        assert_eq!(resolve_sync_remote(tmp.path(), "main", true), None);
+        // Pull ignores push config and still gets an explicit remote.
+        assert_eq!(
+            resolve_sync_remote(tmp.path(), "main", false).as_deref(),
+            Some("origin")
+        );
     }
 }

--- a/src/git/status/mod.rs
+++ b/src/git/status/mod.rs
@@ -302,23 +302,27 @@ fn query_status_inner(
 }
 
 /// Resolve the repository's default branch as a diff-able ref name in
-/// `origin/<branch>` form (so `git diff <base>...HEAD` works without a matching
-/// local branch): `origin/HEAD`'s symbolic target first, then `origin/main`,
-/// then `origin/master`. `None` when none resolve.
+/// `<remote>/<branch>` form (so `git diff <base>...HEAD` works without a
+/// matching local branch): the preferred remote's `HEAD` symbolic target
+/// first, then its `main`, then its `master`. `None` when none resolve.
+/// The remote comes from [`crate::git::preferred_remote`] so Gerrit/mirror
+/// workspaces without an `origin` still get a review base; repos with
+/// remote-tracking refs but no configured remotes fall back to `origin`.
 pub(crate) fn default_branch_name(repo: &Repository) -> Option<String> {
-    if let Ok(head_ref) = repo.find_reference("refs/remotes/origin/HEAD")
+    let remote = crate::git::preferred_remote(repo).unwrap_or_else(|| "origin".to_string());
+    if let Ok(head_ref) = repo.find_reference(&format!("refs/remotes/{remote}/HEAD"))
         && let Ok(Some(target_name)) = head_ref.symbolic_target()
         && repo.find_reference(target_name).is_ok()
         && let Some(short) = target_name.strip_prefix("refs/remotes/")
     {
         return Some(short.to_string());
     }
-    for (full, short) in [
-        ("refs/remotes/origin/main", "origin/main"),
-        ("refs/remotes/origin/master", "origin/master"),
-    ] {
-        if repo.find_reference(full).is_ok() {
-            return Some(short.to_string());
+    for branch in ["main", "master"] {
+        if repo
+            .find_reference(&format!("refs/remotes/{remote}/{branch}"))
+            .is_ok()
+        {
+            return Some(format!("{remote}/{branch}"));
         }
     }
     None

--- a/src/git/status/tests_basic.rs
+++ b/src/git/status/tests_basic.rs
@@ -394,3 +394,15 @@ fn test_submodule_state_priority_dirty_over_modified() {
     assert!(flags.is_wd_modified());
     // Our mapping logic checks dirty first, so this should map to Dirty
 }
+
+#[test]
+fn test_default_branch_name_uses_non_origin_remote() {
+    // Gerrit/mirror workspace: no origin, remote named `gerrit`.
+    let (_tmp, repo) = init_temp_repo();
+    repo.remote("gerrit", "https://example.com/repo.git")
+        .unwrap();
+    let oid = repo.head().unwrap().target().unwrap();
+    repo.reference("refs/remotes/gerrit/main", oid, true, "test")
+        .unwrap();
+    assert_eq!(default_branch_name(&repo).as_deref(), Some("gerrit/main"));
+}


### PR DESCRIPTION
Addresses the review follow-ups tracked in #38.

## What was missing

The merged remote-resolution change picked a better remote name but still forced an explicit `<remote> <branch>` on every pull/push, and the origin hard-coding survived in three sibling paths.

## Changes

- `resolve_sync_remote` returns `None` whenever git can resolve the destination itself (configured upstream via `branch.<name>.remote` + `.merge`, or for pushes `branch.<name>.pushRemote` / `remote.pushDefault`), so the command runs bare and correctly handles renamed upstreams like local `main` tracking `gerrit/master`. The explicit fallback prefers the branch's own configured remote over `origin`.
- `preferred_remote` (origin, else first sorted remote) now also backs `default_branch_name` (review-launcher diff base) and GitHub owner/repo detection, which scans all remotes for a github.com URL when `origin` misses.
- Submodule update-latest resolves each submodule's own remote in the `foreach` subshell instead of hard-coding `origin`.
- Detached HEAD (git2 shorthand `HEAD`) no longer leaks into `git pull <remote> HEAD`.
- The resolver test helper builds repos with git2 instead of shelling out to a `git` binary, so its tests can no longer silently skip.

## Verification

410 unit tests pass, including new coverage for renamed upstreams, partial upstreams, push-remote deferral, and non-origin default branches.
