### PR TITLE
tui: rework the input-idle probe around a single deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to gitpane are documented here.
 
+## [Unreleased]
+
+### Changed
+- Sleep-when-hidden now also applies outside tmux, superseding the v0.11.0 note that outside-tmux behavior was unchanged. With `watch.sleep_when_hidden = true` (the default), a session with no input for `watch.doze_after_secs` (default 120) drops to deep sleep: periodic polling, fetching, and watcher-driven refreshes all pause until the next input. Any deliberate input counts as presence (keys, mouse clicks and scrolls, paste, resize, focus changes), the idle timer wakes exactly once at the deadline instead of polling every 3 seconds, and the probe reports its state immediately on startup so a resumed session never sits stale.
+
 ## [0.11.0] - 2026-08-15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,5 @@ wait-timeout = "0.2.1"
 arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
 
 [dev-dependencies]
+tokio = { version = "1.23.1", features = ["full", "test-util"] }
 tempfile = "3"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -102,10 +102,13 @@ pub(crate) struct WatchConfig {
     /// Stop periodic polls/fetches when this instance's tmux pane is hidden
     /// (detached session, background window, or zoomed away) or the session
     /// has been input-idle. Only the visible, active instance does work.
+    /// Outside tmux, input idleness alone drives it.
     #[serde(default = "default_sleep_when_hidden")]
     pub sleep_when_hidden: bool,
-    /// Seconds without tmux input before a visible pane stops polling and
-    /// relies on watcher events alone (it still refreshes on real changes).
+    /// Seconds without input before periodic work stops. Under tmux a
+    /// visible pane dozes (watcher refreshes still land); outside tmux the
+    /// instance deep-sleeps and watcher refreshes pause too until the next
+    /// input.
     #[serde(default = "default_doze_after_secs")]
     pub doze_after_secs: u64,
 }

--- a/src/session/visibility.rs
+++ b/src/session/visibility.rs
@@ -1,11 +1,10 @@
 //! Decides how much background work this instance should do. Under tmux the
 //! verdict combines pane visibility with recent client activity; outside tmux
-//! (when `sleep_when_hidden` is on) [`input_idle_state`] falls back to input
-//! idleness alone, which the caller escalates to `DeepSleep` since idleness is
-//! the only signal available there. Probe or parse failure fails open to
-//! `Awake`.
-
-use std::time::{Duration, Instant};
+//! (when `sleep_when_hidden` is on) an input-idle probe in `tui.rs` drives
+//! the state from input events alone, escalating idle straight to `DeepSleep`
+//! since idleness is the only signal available there. Probe or parse failure
+//! fails open to `Awake`.
+use std::time::Duration;
 /// How much background work the instance should do right now.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub(crate) enum PowerState {
@@ -97,30 +96,6 @@ pub(crate) fn parse_power_state(
     })
 }
 
-/// Non-tmux fallback power state: without a tmux pane to probe, the instance's
-/// state is driven purely by how long it has been since the user last typed or
-/// clicked. `last_input` is the wall-clock of the most recent input event
-/// (`None` when none has been seen since start — treated as awake so a fresh
-/// instance polls normally).
-///
-/// This is the *input-idleness* verdict only: it returns [`PowerState::Doze`]
-/// after `doze_after` and never produces `DeepSleep`, because idleness alone
-/// cannot tell whether the pane is hidden. The caller decides the semantics of
-/// that idle verdict for its environment — the non-tmux probe (`tui.rs`)
-/// remaps `Doze` to `DeepSleep` since outside tmux idle means the user has
-/// left and watcher-driven refreshes must pause too.
-pub(crate) fn input_idle_state(
-    last_input: Option<Instant>,
-    now: Instant,
-    doze_after: Duration,
-) -> PowerState {
-    match last_input {
-        None => PowerState::Awake,
-        Some(last) if now.saturating_duration_since(last) >= doze_after => PowerState::Doze,
-        Some(_) => PowerState::Awake,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -209,55 +184,5 @@ mod tests {
         assert_eq!(parse_power_state("no tmux server", NOW, DOZE), None);
         assert_eq!(parse_power_state("1,x,1,0,9999", NOW, DOZE), None);
         assert_eq!(parse_power_state("1,1", NOW, DOZE), None);
-    }
-
-    #[test]
-    fn input_idle_state_awake_with_no_input_yet() {
-        // A fresh instance with no recorded input polls normally.
-        assert_eq!(
-            input_idle_state(None, Instant::now(), DOZE),
-            PowerState::Awake
-        );
-    }
-
-    #[test]
-    fn input_idle_state_awake_within_doze_window() {
-        let now = Instant::now();
-        let last = now - Duration::from_secs(10);
-        assert_eq!(input_idle_state(Some(last), now, DOZE), PowerState::Awake);
-    }
-
-    #[test]
-    fn input_idle_state_dozes_after_inactivity() {
-        let now = Instant::now();
-        let last = now - Duration::from_secs(121);
-        assert_eq!(input_idle_state(Some(last), now, DOZE), PowerState::Doze);
-    }
-
-    #[test]
-    fn input_idle_state_dozes_at_exact_threshold() {
-        let now = Instant::now();
-        let last = now - Duration::from_secs(120);
-        assert_eq!(input_idle_state(Some(last), now, DOZE), PowerState::Doze);
-    }
-
-    #[test]
-    fn input_idle_state_never_deep_sleeps() {
-        // Without visibility information we never assume the pane is hidden.
-        let now = Instant::now();
-        let last = now - Duration::from_secs(10_000);
-        assert_eq!(input_idle_state(Some(last), now, DOZE), PowerState::Doze);
-        assert_ne!(
-            input_idle_state(Some(last), now, DOZE),
-            PowerState::DeepSleep
-        );
-    }
-
-    #[test]
-    fn input_idle_state_clock_skew_does_not_underflow() {
-        // A last-input time in the future must not panic or count as idle.
-        let now = Instant::now();
-        let last = now + Duration::from_secs(5);
-        assert_eq!(input_idle_state(Some(last), now, DOZE), PowerState::Awake);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -10,7 +10,7 @@ use crossterm::{
 use futures::StreamExt;
 use ratatui::backend::CrosstermBackend;
 use std::io::{self, Stdout, stdout};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::{
     sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
     task::JoinHandle,
@@ -44,7 +44,8 @@ pub(crate) struct Tui {
     poll_local_interval: Duration,
     poll_fetch_interval: Duration,
     /// Gate periodic work on tmux pane visibility/idleness (see
-    /// [`visibility`]). Outside tmux this has no effect.
+    /// [`visibility`]); outside tmux, on input idleness alone — idle drops
+    /// to [`PowerState::DeepSleep`], pausing watcher refreshes too.
     sleep_when_hidden: bool,
     /// Input-idle time before a visible pane stops polling.
     doze_after: Duration,
@@ -293,30 +294,32 @@ impl Tui {
                         let _ = event_tx.send(Event::Render);
                     }
                     Some(Ok(event)) = crossterm_event => {
-                        // Forward input to the non-tmux idle probe so it can
-                        // wake the instance (no-op when not wired).
-                        match &event {
+                        // Any deliberate user event counts as presence for
+                        // the non-tmux idle probe (no-op when not wired);
+                        // only plain cursor moves are excluded as noise. The
+                        // peek borrows, so the match below still moves the
+                        // event (Paste forwards its text without a clone).
+                        if let Some(tx) = &input_tx
+                            && !matches!(
+                                &event,
+                                CrosstermEvent::Mouse(m)
+                                    if m.kind == crossterm::event::MouseEventKind::Moved
+                            )
+                        {
+                            let _ = tx.send(());
+                        }
+                        match event {
                             CrosstermEvent::Key(key) if key.kind == KeyEventKind::Press => {
-                                let _ = event_tx.send(Event::Key(*key));
-                                if let Some(tx) = &input_tx {
-                                    let _ = tx.send(());
-                                }
+                                let _ = event_tx.send(Event::Key(key));
                             }
                             CrosstermEvent::Mouse(mouse) => {
-                                // Plain cursor moves should not count as the
-                                // user actively working; everything else does.
-                                let meaningful =
-                                    !matches!(mouse.kind, crossterm::event::MouseEventKind::Moved);
-                                if meaningful && let Some(tx) = &input_tx {
-                                    let _ = tx.send(());
-                                }
-                                let _ = event_tx.send(Event::Mouse(*mouse));
+                                let _ = event_tx.send(Event::Mouse(mouse));
                             }
                             CrosstermEvent::Paste(text) => {
-                                let _ = event_tx.send(Event::Paste(text.clone()));
+                                let _ = event_tx.send(Event::Paste(text));
                             }
                             CrosstermEvent::Resize(w, h) => {
-                                let _ = event_tx.send(Event::Resize(*w, *h));
+                                let _ = event_tx.send(Event::Resize(w, h));
                             }
                             CrosstermEvent::FocusGained => {
                                 let _ = event_tx.send(Event::FocusGained);
@@ -341,6 +344,20 @@ impl Drop for Tui {
     }
 }
 
+/// Send `state` when it differs from `*last`, updating `*last`. `false` when
+/// the receiver is gone — the probe loop should break.
+fn emit_if_changed(
+    tx: &UnboundedSender<PowerState>,
+    last: &mut Option<PowerState>,
+    state: PowerState,
+) -> bool {
+    if *last == Some(state) {
+        return true;
+    }
+    *last = Some(state);
+    tx.send(state).is_ok()
+}
+
 /// Periodically probes tmux for this pane's visibility/idleness and emits
 /// [`PowerState`] transitions. With no pane and no input channel (outside
 /// tmux with the feature disabled) the sender is dropped immediately, so the
@@ -349,10 +366,11 @@ impl Drop for Tui {
 /// input handling.
 ///
 /// Outside tmux, when `sleep_when_hidden` is enabled, `input_rx` is wired to
-/// the event loop's key/mouse stream and an input-idle probe takes over:
+/// the event loop's input stream and [`spawn_input_idle_probe`] takes over:
 /// every input resets the idle clock and wakes the instance immediately, and
-/// after `doze_after` without input it drops to [`PowerState::Doze`]
-/// (`DeepSleep` is unreachable without visibility information).
+/// after `doze_after` without input it drops straight to
+/// [`PowerState::DeepSleep`] — without visibility information, idle is
+/// treated as the user having left (see that fn's docs for why not `Doze`).
 fn spawn_visibility_probe(
     pane: Option<String>,
     input_rx: Option<UnboundedReceiver<()>>,
@@ -366,7 +384,7 @@ fn spawn_visibility_probe(
         let Some(input_rx) = input_rx else {
             return rx;
         };
-        spawn_input_idle_probe(input_rx, doze_after, VISIBILITY_PROBE_INTERVAL, token, tx);
+        spawn_input_idle_probe(input_rx, doze_after, token, tx);
         return rx;
     };
     tokio::spawn(async move {
@@ -394,11 +412,8 @@ fn spawn_visibility_probe(
             let state = output
                 .and_then(|o| visibility::parse_power_state(&o, now_epoch, doze_after))
                 .unwrap_or(PowerState::Awake);
-            if last != Some(state) {
-                last = Some(state);
-                if tx.send(state).is_err() {
-                    break;
-                }
+            if !emit_if_changed(&tx, &mut last, state) {
+                break;
             }
         }
     });
@@ -407,10 +422,10 @@ fn spawn_visibility_probe(
 
 /// Non-tmux fallback probe: there is no tmux pane to ask about visibility, so
 /// the [`PowerState`] is driven purely by input idleness. Every event on
-/// `input_rx` (a key press or a meaningful mouse action) marks the user active
-/// and immediately wakes the instance; after `doze_after` without any input the
-/// instance drops to [`PowerState::DeepSleep`] — everything pauses, including
-/// watcher-driven refreshes, until the next input.
+/// `input_rx` (any deliberate key/mouse/paste/resize/focus action) marks the
+/// user active and immediately wakes the instance; after `doze_after` without
+/// any input the instance drops to [`PowerState::DeepSleep`] — everything
+/// pauses, including watcher-driven refreshes, until the next input.
 ///
 /// Outside tmux we cannot tell whether the pane is actually visible, so input
 /// idleness is treated as "the user has left". Emitting `DeepSleep` (rather
@@ -419,55 +434,44 @@ fn spawn_visibility_probe(
 /// status queries in-flight forever and dirty-replay re-queues them into a
 /// self-sustaining refresh loop. DeepSleep gates the watcher too, breaking that
 /// loop, and reuses upstream's existing wake-and-refresh semantics.
+///
+/// A single `sleep_until` deadline (reset on every input) wakes the task
+/// exactly once when idleness is reached — no periodic polling and no timer
+/// rebuild per input event.
 fn spawn_input_idle_probe(
-    input_rx: UnboundedReceiver<()>,
+    mut input_rx: UnboundedReceiver<()>,
     doze_after: Duration,
-    probe_interval: Duration,
     token: CancellationToken,
     tx: UnboundedSender<PowerState>,
 ) {
     tokio::spawn(async move {
-        // `None` so the first tick always delivers a state, resyncing any
-        // stale consumer state after an inline-suspend re-entry.
-        let mut last: Option<PowerState> = None;
-        // Start the idle clock at launch: a fresh instance polls normally,
-        // then DeepSleeps once `doze_after` elapses without any input. (`None`
-        // would keep the instance awake forever, since `input_idle_state`
-        // treats "no input recorded" as active.)
-        let mut last_input: Option<Instant> = Some(Instant::now());
-        let mut input_rx = input_rx;
+        // Unconditional first report, mirroring the tmux probe's instant
+        // first tick: after an inline-suspend re-entry the consumers' state
+        // may be stale, and only an immediate report resyncs it.
+        let mut last = None;
+        if !emit_if_changed(&tx, &mut last, PowerState::Awake) {
+            return;
+        }
+        // Idle clock starts at launch: a fresh instance polls normally, then
+        // DeepSleeps once `doze_after` elapses without any input.
+        let mut deadline = tokio::time::Instant::now() + doze_after;
         loop {
             tokio::select! {
                 _ = token.cancelled() => break,
-                Some(()) = input_rx.recv() => {
+                maybe = input_rx.recv() => {
+                    let Some(()) = maybe else { break };
                     // Any input marks the user active and wakes immediately.
-                    last_input = Some(Instant::now());
-                    if last != Some(PowerState::Awake) {
-                        last = Some(PowerState::Awake);
-                        if tx.send(PowerState::Awake).is_err() {
-                            break;
-                        }
+                    deadline = tokio::time::Instant::now() + doze_after;
+                    if !emit_if_changed(&tx, &mut last, PowerState::Awake) {
+                        break;
                     }
                 }
-                _ = tokio::time::sleep(probe_interval) => {
-                    // Outside tmux there is no visibility signal: input idle
-                    // means the user has left, not merely paused. Emit
-                    // DeepSleep (not Doze) so the app gates watcher-driven
-                    // refreshes too — on huge workspaces the Doze semantics
-                    // (watcher keeps refreshing) would otherwise self-sustain
-                    // a refresh loop, since slow status queries stay
-                    // in-flight and dirty-replay keeps re-queuing them.
-                    let state =
-                        visibility::input_idle_state(last_input, Instant::now(), doze_after);
-                    let state = match state {
-                        PowerState::Doze => PowerState::DeepSleep,
-                        other => other,
-                    };
-                    if last != Some(state) {
-                        last = Some(state);
-                        if tx.send(state).is_err() {
-                            break;
-                        }
+                // Disabled while asleep so the past deadline can't busy-loop.
+                _ = tokio::time::sleep_until(deadline),
+                    if last != Some(PowerState::DeepSleep) =>
+                {
+                    if !emit_if_changed(&tx, &mut last, PowerState::DeepSleep) {
+                        break;
                     }
                 }
             }
@@ -479,10 +483,13 @@ fn spawn_input_idle_probe(
 mod tests {
     use super::*;
 
-    /// The input-idle probe emits `DeepSleep` after `doze_after` without
-    /// input (outside tmux there is no visibility signal, so idle == user
-    /// left), wakes to `Awake` immediately on input, and never emits `Doze`.
-    #[tokio::test]
+    /// The input-idle probe reports `Awake` immediately on spawn (resyncing
+    /// stale consumers after an inline-suspend re-entry), drops to
+    /// `DeepSleep` once `doze_after` elapses without input (outside tmux
+    /// there is no visibility signal, so idle == user left; `Doze` is never
+    /// emitted), and wakes back to `Awake` on the next input. Paused time
+    /// makes the timing deterministic — no real waiting, no CI flake.
+    #[tokio::test(start_paused = true)]
     async fn input_idle_probe_deep_sleeps_and_wakes_on_input() {
         let (input_tx, input_rx) = mpsc::unbounded_channel();
         let (state_tx, mut state_rx) = mpsc::unbounded_channel();
@@ -491,37 +498,19 @@ mod tests {
         spawn_input_idle_probe(
             input_rx,
             Duration::from_millis(100),
-            Duration::from_millis(20),
             token.clone(),
             state_tx,
         );
 
-        // No input ever arrives → the instance should drop to DeepSleep
-        // within a few probe ticks, and never emit an intermediate Doze.
-        let slept = tokio::time::timeout(Duration::from_secs(1), async {
-            loop {
-                match state_rx.recv().await {
-                    Some(PowerState::DeepSleep) => return PowerState::DeepSleep,
-                    // Doze must never be emitted: outside tmux the probe
-                    // remaps it to DeepSleep (see the fn docs).
-                    Some(PowerState::Doze) => panic!("probe must not emit Doze"),
-                    Some(_) => continue,
-                    None => panic!("probe sender dropped"),
-                }
-            }
-        })
-        .await
-        .expect("probe should emit DeepSleep after idleness");
-        assert_eq!(slept, PowerState::DeepSleep);
+        // Unconditional first report lands before any deadline elapses.
+        assert_eq!(state_rx.recv().await, Some(PowerState::Awake));
+        // No input → the next report is DeepSleep at the doze deadline,
+        // with no intermediate Doze possible.
+        assert_eq!(state_rx.recv().await, Some(PowerState::DeepSleep));
 
-        // A single input event wakes it back to Awake immediately (before the
-        // next 100ms doze threshold).
+        // A single input event wakes it back to Awake immediately.
         input_tx.send(()).unwrap();
-        let wake = tokio::time::timeout(Duration::from_secs(1), state_rx.recv())
-            .await
-            .expect("probe should emit Awake on input")
-            .expect("probe sender dropped");
-        assert_eq!(wake, PowerState::Awake);
+        assert_eq!(state_rx.recv().await, Some(PowerState::Awake));
 
         token.cancel();
     }


### PR DESCRIPTION
Addresses the review follow-ups tracked in #40.

Stacked on #39: it needs the git2-based test helper from that branch, because the shelled-out helper mutates the real repo's git config when the test suite runs under a git hook's `GIT_DIR` environment (the pre-push hook run reproduced this: fake `gerrit`/`zzz` remotes landed in the main checkout's config). Merge #39 first; GitHub will retarget this PR to main automatically.

## Changes

- The event loop peeks at the crossterm event by reference only to decide presence, then matches by value, so Paste forwards its text without cloning the full clipboard content, and the `*key` / `*mouse` derefs are gone.
- Presence now counts any deliberate user event (keys, mouse except plain moves, paste, resize, focus changes), so an actively pasting or resizing user no longer slides into deep sleep.
- `spawn_input_idle_probe` runs on a single `sleep_until(last_input + doze_after)` deadline, reset on input and disabled while asleep: one timer wakeup per idle period instead of a 3-second poll forever, and no timer rebuild on every keystroke.
- The probe sends an unconditional `Awake` on spawn, mirroring the tmux probe's instant first tick, closing the window after an inline-command suspend where repo-change events were dropped against a stale power state.
- `emit_if_changed` replaces three copy-pasted send blocks; `input_idle_state` and its tests are deleted since the deadline design has no intermediate Doze verdict to translate.
- Doc drift fixed (`sleep_when_hidden` field, `spawn_visibility_probe`, `doze_after_secs`) and an Unreleased changelog entry supersedes the v0.11.0 claim that outside-tmux behavior is unchanged.
- The probe test runs under paused time (`tokio/test-util`, dev-dependency only), making it deterministic instead of relying on a real-timer margin on noisy CI runners.

## Verification

404 unit tests pass on the stacked branch (400 from this change plus the four resolver tests from #39; the six deleted `input_idle_state` tests account for the reduction).
