### PR TITLE
app: gate quit on in-flight mutating git operations

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -4,7 +4,18 @@ impl App {
     pub(super) fn handle_action(&mut self, action: Action, tui: &mut Tui) -> Result<()> {
         match action {
             Action::Quit => {
-                self.should_quit = true;
+                if self.should_quit {
+                    // Second request: stop waiting for in-flight git ops.
+                    self.force_quit = true;
+                } else {
+                    self.should_quit = true;
+                    if MUTATING_GIT_OPS.load(Ordering::SeqCst) > 0 {
+                        self.action_tx.send(Action::Error(
+                            "waiting for a git operation to finish; press q again to quit now"
+                                .to_string(),
+                        ))?;
+                    }
+                }
             }
             Action::Tick => {
                 if self.clear_expired_messages() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,6 +2,7 @@ use color_eyre::Result;
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
@@ -119,8 +120,16 @@ struct GitOpGuard {
     completed: bool,
 }
 
+/// In-flight mutating git operations (pull/push/submodule/custom ops)
+/// across the whole process — one count per live [`GitOpGuard`]. Quit waits
+/// for this to reach zero: exiting would close the children's piped
+/// stdout/stderr and SIGPIPE a `git pull` mid-merge (see `main.rs`).
+/// Read-only status queries are not counted and stay abandonable.
+static MUTATING_GIT_OPS: AtomicUsize = AtomicUsize::new(0);
+
 impl GitOpGuard {
     fn new(id: RepoId, tx: UnboundedSender<Action>) -> Self {
+        MUTATING_GIT_OPS.fetch_add(1, Ordering::SeqCst);
         Self {
             id,
             tx,
@@ -135,6 +144,7 @@ impl GitOpGuard {
 
 impl Drop for GitOpGuard {
     fn drop(&mut self) {
+        MUTATING_GIT_OPS.fetch_sub(1, Ordering::SeqCst);
         if !self.completed {
             let _ = self.tx.send(Action::RefreshRepo(self.id.clone()));
         }
@@ -144,6 +154,8 @@ impl Drop for GitOpGuard {
 pub(crate) struct App {
     config: Config,
     should_quit: bool,
+    /// Second quit request: exit without waiting for in-flight git ops.
+    force_quit: bool,
     repo_list: RepoList,
     file_list: FileList,
     git_graph: GitGraph,
@@ -351,6 +363,7 @@ impl App {
         let mut app = Self {
             config,
             should_quit: false,
+            force_quit: false,
             repo_list: RepoList::new(repo_paths, roots, theme.clone()),
             file_list: FileList::new(theme.clone()),
             git_graph,
@@ -653,12 +666,21 @@ impl App {
                 self.handle_action(Action::Render, &mut tui)?;
             }
 
-            if self.should_quit {
+            if self.ready_to_exit() {
                 tui.exit()?;
                 break;
             }
         }
         Ok(())
+    }
+
+    /// Whether the run loop may exit now. Quitting waits for in-flight
+    /// mutating git operations (their piped stdio dies with the process,
+    /// SIGPIPE-ing the child mid-write) unless the user pressed quit a
+    /// second time. The loop re-checks on every tick, so completion of the
+    /// last operation exits within one tick.
+    fn ready_to_exit(&self) -> bool {
+        self.should_quit && (self.force_quit || MUTATING_GIT_OPS.load(Ordering::SeqCst) == 0)
     }
 
     /// Translate one TUI event into actions. Kept free of `Tui` so tests can

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -368,3 +368,27 @@ fn doze_to_awake_does_not_replay_or_repaint() {
     app.handle_event(Event::Power(PowerState::Awake)).unwrap();
     assert!(drain_actions(&mut app).is_empty());
 }
+
+#[tokio::test]
+async fn quit_waits_for_mutating_git_ops_and_force_quits_on_second_request() {
+    let mut app = power_test_app();
+    assert!(!app.ready_to_exit());
+
+    // Quit with nothing in flight exits immediately.
+    app.should_quit = true;
+    assert!(app.ready_to_exit());
+
+    // An in-flight mutating op (live GitOpGuard) defers the exit...
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let guard = GitOpGuard::new(RepoId(std::path::PathBuf::from("/tmp/repo")), tx);
+    assert!(!app.ready_to_exit());
+
+    // ...unless the user insists with a second quit request.
+    app.force_quit = true;
+    assert!(app.ready_to_exit());
+
+    // Completion of the op re-enables the normal exit path.
+    app.force_quit = false;
+    guard.complete();
+    assert!(app.ready_to_exit());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,8 +54,19 @@ enum Command {
 /// queued in the blocking pool; tokio's `Runtime` Drop waits forever for
 /// `spawn_blocking` tasks to return, which made pressing `q` hang for tens
 /// of seconds while the last poll drained. `shutdown_background` unblocks
-/// shutdown immediately — still-running queries are reclaimed with the
-/// process (they only read `.git`, so dropping them mid-read is safe).
+/// shutdown immediately. That is safe for everything that can still be in
+/// flight here: in-process status queries only read `.git`, and the status
+/// poll's `git fetch` child (spawned with null stdio) survives as an
+/// independent, crash-safe git process. Mutating operations (pull, push,
+/// submodule updates) hold piped stdio that would SIGPIPE the child
+/// mid-write, so the app instead gates quitting on their completion (see
+/// `GitOpGuard` in `app`); they only reach this line still running when the
+/// user force-quits with a second `q`.
+///
+/// `block_on` runs under `catch_unwind` so a panic inside the app also
+/// takes the `shutdown_background` path — unwinding through the runtime's
+/// normal Drop would block on the same spawn_blocking tasks and delay the
+/// panic report by up to the fetch timeout.
 fn main() -> Result<()> {
     color_eyre::install()?;
 
@@ -63,12 +74,15 @@ fn main() -> Result<()> {
         .enable_all()
         .build()?;
 
-    let result = runtime.block_on(run());
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| runtime.block_on(run())));
 
     // Do not wait for in-flight blocking-pool tasks (see doc above).
     runtime.shutdown_background();
 
-    result
+    match result {
+        Ok(result) => result,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
 }
 
 async fn run() -> Result<()> {


### PR DESCRIPTION
Addresses the review follow-ups tracked in #42.

Stacked on #39 for the same reason as #41: the pre-push test suite cannot run on a base that still has the shelled-out test helper, which mutates the real repo's git config under a hook's `GIT_DIR` environment. Merge #39 first; GitHub retargets this PR automatically.

## Changes

- Quitting now waits for in-flight **mutating** git operations. A process-wide atomic counts live `GitOpGuard`s (which already bracket exactly pull/push/submodule/custom ops); the run loop exits only at zero. Exiting earlier closes the children's piped stdout/stderr and SIGPIPEs a `git pull` mid-merge. Read-only status queries stay abandonable, preserving the fast quit from the original change.
- While waiting, the status bar shows a notice, and a second `q` force-quits, the escape hatch for a pull hung on the network (those children have no timeout).
- A panic inside `run()` now also takes the `shutdown_background` path (`block_on` under `catch_unwind`), instead of hanging on the runtime's normal Drop for up to the fetch timeout before the panic report prints.
- The safety comment in `main.rs` states the real invariants: read-only in-process queries, a crash-safe null-stdio fetch child, and mutating ops gated at quit.

## Verification

411 tests pass on the stacked branch, including a new behavioral test covering deferred quit while a guard is live, force-quit override, and exit re-enabling on completion.
