### PR TITLE
fix: surface missing configured root dirs in the repo panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to gitpane are documented here.
 
+## [Unreleased]
+
+### Fixed
+- A configured root dir that doesn't exist on disk is no longer silently skipped: the Repositories panel shows a persistent `root does not exist: <path>` hint above the list for the whole session, so a stale or mistyped `root_dirs` entry can't quietly shrink (or empty) the workspace with no explanation. Discovery itself is unchanged; previously only `gitpane diagnostic` surfaced it.
+
 ## [0.12.0] - 2026-08-17
 
 ### Added

--- a/src/components/repo_list/mod.rs
+++ b/src/components/repo_list/mod.rs
@@ -145,7 +145,10 @@ fn middle_ellipsize(s: &str, max: usize) -> String {
     if s.chars().count() <= max {
         return s.to_string();
     }
-    let parts: Vec<&str> = s.split('/').collect();
+    // Split on both separators: a native Windows path uses backslashes and
+    // would otherwise land here as a single part, hard-truncating and
+    // cutting off the tail (the repo basename) instead of middle-ellipsizing.
+    let parts: Vec<&str> = s.split(['/', '\\']).collect();
     let head = parts.first().copied().unwrap_or(s);
     let tail = parts.last().copied().unwrap_or(s);
     let head_tail = format!("{head}/…/{tail}");

--- a/src/components/repo_list/mod.rs
+++ b/src/components/repo_list/mod.rs
@@ -89,6 +89,11 @@ pub(crate) struct RepoList {
     /// (`display_path`), canonicalized in `new` to match the form discovery
     /// emits. Needed at rescan time too, for repos added later.
     roots: Vec<PathBuf>,
+    /// Configured workspace roots that do not exist on disk (canonicalized
+    /// like `roots`). Discovery silently skips them, so they are surfaced as
+    /// a persistent hint at the top of the panel — otherwise the workspace
+    /// can shrink (or vanish) with no explanation.
+    missing_roots: Vec<PathBuf>,
     pub state: ListState,
     pub render_area: Rect,
     pub focused: bool,
@@ -168,6 +173,14 @@ impl RepoList {
             .into_iter()
             .map(|root| root.canonicalize().unwrap_or(root))
             .collect();
+        // A root that canonicalized exists on disk; a root that failed to
+        // canonicalize (kept as-is by `unwrap_or`) and still does not exist
+        // is one discovery will silently skip.
+        let missing_roots: Vec<PathBuf> = roots
+            .iter()
+            .filter(|root| !root.exists())
+            .cloned()
+            .collect();
         let repos: Vec<RepoEntry> = repo_paths
             .into_iter()
             .map(|path| {
@@ -194,6 +207,7 @@ impl RepoList {
         let mut list = Self {
             repos,
             roots,
+            missing_roots,
             state,
             render_area: Rect::default(),
             focused: true,

--- a/src/components/repo_list/render.rs
+++ b/src/components/repo_list/render.rs
@@ -281,7 +281,10 @@ impl Component for RepoList {
                     .bg(s.error_label_bg)
                     .add_modifier(Modifier::BOLD),
             );
-            let text = middle_ellipsize(&text, area.width as usize);
+            // The rendered line is the 3-cell " ! " label plus the text;
+            // give the ellipsize budget the text's share so the ellipsis
+            // marker itself isn't clipped by the paragraph.
+            let text = middle_ellipsize(&text, area.width.saturating_sub(3) as usize);
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
                     label,

--- a/src/components/repo_list/render.rs
+++ b/src/components/repo_list/render.rs
@@ -2,9 +2,10 @@ use color_eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::{
     Frame,
-    layout::Rect,
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
-    widgets::{Block, Borders, List, ListItem},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, Paragraph},
 };
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -252,6 +253,47 @@ impl Component for RepoList {
             t.border_unfocused
         };
 
+        // Persistent warning for configured roots that don't exist on disk.
+        // Discovery silently skips them, so without this the workspace can
+        // shrink (or vanish) with no explanation. Rendered above the list for
+        // the whole session — not a toast that expires after a few seconds.
+        let missing_hint = if self.missing_roots.is_empty() {
+            None
+        } else {
+            let names = self
+                .missing_roots
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Some(format!("root does not exist: {names}"))
+        };
+        let list_area = if let Some(text) = missing_hint {
+            let rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(1), Constraint::Min(0)])
+                .split(area);
+            let s = &self.theme.status_bar;
+            let label = Span::styled(
+                " ! ",
+                Style::default()
+                    .fg(s.error_label_fg)
+                    .bg(s.error_label_bg)
+                    .add_modifier(Modifier::BOLD),
+            );
+            let text = middle_ellipsize(&text, area.width as usize);
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    label,
+                    Span::styled(text, Style::default().fg(s.error_text)),
+                ])),
+                rows[0],
+            );
+            rows[1]
+        } else {
+            area
+        };
+
         let list = List::new(items)
             .block(
                 Block::default()
@@ -265,7 +307,7 @@ impl Component for RepoList {
                     .add_modifier(Modifier::BOLD),
             );
 
-        frame.render_stateful_widget(list, area, &mut self.state);
+        frame.render_stateful_widget(list, list_area, &mut self.state);
         Ok(())
     }
 }

--- a/src/components/repo_list/tests.rs
+++ b/src/components/repo_list/tests.rs
@@ -483,6 +483,81 @@ fn renders_breadcrumb_paths_and_ellipsizes_deep_ones() {
     assert!(text.contains("build"), "got: {text}");
 }
 
+/// A configured root that doesn't exist on disk surfaces a persistent hint
+/// above the list (discovery silently skips it), while repos that do exist
+/// still render normally below it.
+#[test]
+fn renders_persistent_hint_for_missing_root_beside_normal_repos() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    let theme = Arc::new(Theme::default());
+    let tmp = tempfile::tempdir().unwrap();
+    let existing = tmp.path().to_path_buf();
+    let missing = tmp.path().join("gone"); // never created
+    let mut list = RepoList::new(
+        vec![existing.join("repo-a"), existing.join("repo-b")],
+        vec![existing.clone(), missing.clone()],
+        theme,
+    );
+    list.render_area = Rect::new(0, 0, 40, 8);
+
+    let mut terminal = Terminal::new(TestBackend::new(40, 8)).unwrap();
+    terminal
+        .draw(|f| {
+            list.draw(f, f.area()).unwrap();
+        })
+        .unwrap();
+
+    let text: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|c| c.symbol())
+        .collect();
+
+    // The tmp path overflows the 40-wide panel, so the hint's path is
+    // middle-ellipsized — match the parts, not the full path.
+    assert!(text.contains("root does not exist:"), "got: {text}");
+    assert!(text.contains("gone"), "got: {text}");
+    assert!(text.contains("repo-a"), "got: {text}");
+    assert!(text.contains("repo-b"), "got: {text}");
+}
+
+/// When every configured root exists, no hint is rendered — the hint is
+/// reserved for the silent-skip case, not a permanent fixture of the panel.
+#[test]
+fn renders_no_hint_when_all_roots_exist() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    let theme = Arc::new(Theme::default());
+    let tmp = tempfile::tempdir().unwrap();
+    let mut list = RepoList::new(
+        vec![tmp.path().join("repo-a")],
+        vec![tmp.path().to_path_buf()],
+        theme,
+    );
+    list.render_area = Rect::new(0, 0, 40, 8);
+
+    let mut terminal = Terminal::new(TestBackend::new(40, 8)).unwrap();
+    terminal
+        .draw(|f| {
+            list.draw(f, f.area()).unwrap();
+        })
+        .unwrap();
+
+    let text: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|c| c.symbol())
+        .collect();
+
+    assert!(text.contains("repo-a"), "got: {text}");
+    assert!(!text.contains("root does not exist"), "got: {text}");
+}
+
 /// Every row shows its branch — a hidden branch reads as missing data — but
 /// the default branch renders in the dimmed color while deviations keep the
 /// branch color.

--- a/src/components/repo_list/tests.rs
+++ b/src/components/repo_list/tests.rs
@@ -438,6 +438,18 @@ fn middle_ellipsize_keeps_head_and_tail() {
     assert_eq!(middle_ellipsize(deep, 0), "");
 }
 
+#[test]
+fn middle_ellipsize_handles_windows_paths() {
+    // A native Windows path uses backslashes. It must get the same
+    // middle-ellipsis treatment as a POSIX path — keeping the repo basename
+    // visible — instead of landing in one giant part and hard-truncating
+    // the tail off (the regression behind the Windows CI failure).
+    let deep = r"C:\Users\RUNNER~\.config\gitpane\config\gone";
+    assert_eq!(middle_ellipsize(deep, 30), "C:/…/gone");
+    assert_eq!(middle_ellipsize(deep, 6), "…/gone");
+    assert_eq!(middle_ellipsize(deep, 5), "C:\\U…");
+}
+
 /// Headless render check: the list shows each repo's path relative to the
 /// workspace root, so same-basename repos (e.g. three `camsys`) stay
 /// distinguishable, and deep paths are middle-ellipsized to the panel width.
@@ -522,6 +534,46 @@ fn renders_persistent_hint_for_missing_root_beside_normal_repos() {
     assert!(text.contains("gone"), "got: {text}");
     assert!(text.contains("repo-a"), "got: {text}");
     assert!(text.contains("repo-b"), "got: {text}");
+}
+
+#[test]
+fn missing_root_hint_reserves_space_for_the_label() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    let theme = Arc::new(Theme::default());
+    let tmp = tempfile::tempdir().unwrap();
+    let existing = tmp.path().to_path_buf();
+    // Long enough that ellipsizing lands in the hard-truncation branch:
+    // the 3-cell " ! " label must be reserved from the budget, or the
+    // paragraph clips the trailing ellipsis marker off the line.
+    let missing = tmp
+        .path()
+        .join("this-repository-basename-is-very-long-indeed");
+    let mut list = RepoList::new(
+        vec![existing.join("repo-a")],
+        vec![existing.clone(), missing.clone()],
+        theme,
+    );
+    list.render_area = Rect::new(0, 0, 40, 8);
+
+    let mut terminal = Terminal::new(TestBackend::new(40, 8)).unwrap();
+    terminal
+        .draw(|f| {
+            list.draw(f, f.area()).unwrap();
+        })
+        .unwrap();
+
+    let text: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|c| c.symbol())
+        .collect();
+    assert!(
+        text.contains('…'),
+        "ellipsis must survive the label budget: {text}"
+    );
 }
 
 /// When every configured root exists, no hint is rendered — the hint is

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -424,6 +424,17 @@ impl Config {
         self.root_dirs = vec![root];
     }
 
+    /// Configured root dirs that do not exist on disk. Discovery silently
+    /// skips them (`discover_repos` just `continue`s), so without this the
+    /// workspace can shrink — or disappear — with no explanation.
+    pub(crate) fn missing_roots(&self) -> Vec<PathBuf> {
+        self.root_dirs
+            .iter()
+            .filter(|root| !root.exists())
+            .cloned()
+            .collect()
+    }
+
     fn expand_tildes(&mut self) {
         if let Some(home) = dirs::home_dir() {
             for dir in &mut self.root_dirs {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -433,6 +433,40 @@ fn test_cli_root_overrides_config() {
     assert_eq!(config.root_dirs, vec![PathBuf::from("/tmp/my-repos")]);
 }
 
+/// Missing roots are exactly the configured ones that don't exist on disk.
+/// Discovery silently skips them, so they must be discoverable for the
+/// startup warning and diagnostics.
+#[test]
+fn test_missing_roots_reports_only_non_existent_dirs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let existing = tmp.path().join("code");
+    fs::create_dir_all(&existing).unwrap();
+    let missing = tmp.path().join("work");
+
+    let config = Config {
+        root_dirs: vec![existing.clone(), missing.clone()],
+        ..Config::default()
+    };
+
+    let mut got = config.missing_roots();
+    got.sort();
+    assert_eq!(got, vec![missing]);
+}
+
+/// A root that exists is never reported as missing even when it contains no
+/// repos — existence is the whole signal, not discoverability.
+#[test]
+fn test_missing_roots_ignores_existing_empty_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let existing = tmp.path().join("empty-code");
+    fs::create_dir_all(&existing).unwrap();
+    let config = Config {
+        root_dirs: vec![existing.clone()],
+        ..Config::default()
+    };
+    assert!(config.missing_roots().is_empty());
+}
+
 #[test]
 fn test_save_and_reload_roundtrip() {
     let tmp = tempfile::NamedTempFile::new().unwrap();

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -153,7 +153,7 @@ pub(crate) fn render(
     push_line(&mut out, &format!("  repos_discovered: {}", repos.len()));
     push_line(
         &mut out,
-        &format!("  missing_roots: {}", format_paths(&missing_roots(config))),
+        &format!("  missing_roots: {}", format_paths(&config.missing_roots())),
     );
     out.push('\n');
 
@@ -225,20 +225,11 @@ fn warnings(
         ));
     }
 
-    for root in missing_roots(config) {
+    for root in config.missing_roots() {
         warnings.push(format!("root_dir does not exist: {}", root.display()));
     }
 
     warnings
-}
-
-fn missing_roots(config: &Config) -> Vec<PathBuf> {
-    config
-        .root_dirs
-        .iter()
-        .filter(|root| !root.exists())
-        .cloned()
-        .collect()
 }
 
 fn format_paths(paths: &[PathBuf]) -> String {


### PR DESCRIPTION
## Problem

Discovery silently skips `root_dirs` entries that don't exist on disk (`discover_repos` just `continue`s), so a stale or mistyped root could quietly shrink — or empty — the workspace with no explanation. Only `gitpane diagnostic` reported it; the TUI itself showed no sign that anything was wrong.

## Change

- **`Config::missing_roots()`** — single source of truth for "configured roots that don't exist", replacing a duplicated private helper in `diagnostic.rs`.
- **Persistent hint in the Repositories panel** — when any configured root is missing, a `! root does not exist: <path>` line (error theme, middle-ellipsized for narrow panels) renders above the list for the whole session, instead of a toast that expires after a few seconds. Repos that do exist still render normally below it; with every root missing the hint explains the otherwise-blank panel.

## Tests

- `Config::missing_roots()` reports only non-existent dirs, ignores existing-but-empty ones.
- Headless render checks: hint appears alongside normal repo rows; no hint when all roots exist.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-targets --all-features` (409 passing), and rustdoc with `-D warnings` are all green.
