### PR TITLE
perf: cache git graph rows across repo switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to gitpane are documented here.
 
 ## [Unreleased]
 
+### Added
+- The git graph is now cached per repo: switching back to a repo that was recently viewed restores its built rows instantly instead of reopening the repository, re-walking up to 200 commits, and diffing trees for stats. The cache is keyed by repo path plus the build-shaping options (branch filter, first-parent, ref/author filters, stats toggle), invalidated when a status refresh shows the repo's rendered refs/HEAD moved (even for repos that aren't selected, so a later switch never resurrects stale rows), evicted least-recently-used with a bounded capacity, and bypassed by the explicit `g` reload and live worktree refreshes. Rendered graph rows are cached too: the stable part of each line (lane prefix, labels, id, message, author) is rebuilt only when the row, theme, label width, or search highlight changes, with the relative-time tail (and one clock read per frame instead of one per row) recomputed fresh every frame.
+
 ### Fixed
 - A configured root dir that doesn't exist on disk is no longer silently skipped: the Repositories panel shows a persistent `root does not exist: <path>` hint above the list for the whole session, so a stale or mistyped `root_dirs` entry can't quietly shrink (or empty) the workspace with no explanation. Discovery itself is unchanged; previously only `gitpane diagnostic` surfaced it.
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -158,6 +158,15 @@ impl App {
                     let status_clone = status.clone();
                     self.repo_list.update_status(idx, status_clone);
 
+                    // A graph-relevant change invalidates the cached snapshot
+                    // even when this repo isn't selected, so switching to it
+                    // later rebuilds from disk instead of resurrecting stale
+                    // rows.
+                    if graph_changed {
+                        self.git_graph
+                            .invalidate_repo(&self.repo_list.repos[idx].path);
+                    }
+
                     // Refresh the file list so stale diffs are cleared
                     // when files are staged/unstaged. Skip when a worktree
                     // is being viewed — its files come from WorktreeFilesLoaded,
@@ -355,7 +364,9 @@ impl App {
                     } else if let Some(entry) = self.repo_list.selected_repo() {
                         let path = entry.path.clone();
                         let name = entry.name.clone();
-                        self.git_graph.load_repo(path, &name);
+                        // `g` is an explicit reload: bypass the cache so a
+                        // fresh on-disk graph is drawn even if nothing changed.
+                        self.git_graph.force_reload_repo(path, &name);
                     }
                 }
                 self.focus = FocusPanel::Graph;

--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -726,6 +726,8 @@ impl App {
                     self.last_refresh.remove(id);
                     self.refresh_scheduled.remove(id);
                     let entry = &self.repo_list.repos[idx];
+                    // Drop cached graph snapshots for the removed repo.
+                    self.git_graph.invalidate_repo(&entry.path);
                     // Remove from pinned if it was pinned
                     self.config.pinned_repos.retain(|p| *p != entry.path);
                     // Add to excluded so it won't reappear on rescan
@@ -764,6 +766,9 @@ impl App {
                 self.dirty_repos.clear();
                 self.last_refresh.clear();
                 self.refresh_scheduled.clear();
+                // The repo set is rebuilt from scratch; cached graphs for
+                // vanished paths are dead weight.
+                self.git_graph.invalidate_graph_cache();
                 // Clear user-added exclusions, save, and re-discover repos
                 self.config.excluded_repos.clear();
                 if let Err(e) = self.config.save() {
@@ -819,6 +824,8 @@ impl App {
                         self.dirty_repos.remove(&id);
                         self.last_refresh.remove(&id);
                         self.refresh_scheduled.remove(&id);
+                        // Drop cached graph snapshots for vanished repos.
+                        self.git_graph.invalidate_repo(path);
                         if self
                             .active_worktree
                             .as_ref()

--- a/src/app/launch.rs
+++ b/src/app/launch.rs
@@ -493,7 +493,11 @@ impl App {
         };
         // Refresh the graph from the worktree so new commits appear live.
         // Bypass the cache: this runs on the local poll and after git ops on
-        // the parent, so it must read current on-disk state.
+        // the parent, so it must read current on-disk state. While a commit
+        // detail is open the reload is deferred until it closes, so drop the
+        // cached snapshot for the worktree path now — otherwise the deferred
+        // `reload_graph` would resurrect the stale rows from cache.
+        self.git_graph.invalidate_repo(&aw.path);
         if self.git_graph.has_detail() {
             self.git_graph.set_needs_reload();
         } else {

--- a/src/app/launch.rs
+++ b/src/app/launch.rs
@@ -492,10 +492,13 @@ impl App {
             return;
         };
         // Refresh the graph from the worktree so new commits appear live.
+        // Bypass the cache: this runs on the local poll and after git ops on
+        // the parent, so it must read current on-disk state.
         if self.git_graph.has_detail() {
             self.git_graph.set_needs_reload();
         } else {
-            self.git_graph.load_repo(aw.path.clone(), &aw.display_name);
+            self.git_graph
+                .force_reload_repo(aw.path.clone(), &aw.display_name);
         }
 
         let tx = self.action_tx.clone();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -392,3 +392,60 @@ async fn quit_waits_for_mutating_git_ops_and_force_quits_on_second_request() {
     guard.complete();
     assert!(app.ready_to_exit());
 }
+
+/// The live-worktree refresh must drop the worktree's cached graph even
+/// when the reload is deferred (commit detail open): a cache hit there would
+/// resurrect stale rows for up to a poll interval. Guards the
+/// `invalidate_repo(&aw.path)` line in `refresh_active_worktree`.
+#[test]
+fn worktree_refresh_invalidates_the_cached_graph_for_the_worktree_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = Config {
+        root_dirs: vec![tmp.path().to_path_buf()],
+        ..Config::default()
+    };
+    let mut app = App::new(config);
+    // `spawn_blocking` in the miss path needs a runtime context.
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let _guard = runtime.enter();
+
+    let wt = tmp.path().join("live-wt");
+    app.active_worktree = Some(ActiveWorktree {
+        path: wt.clone(),
+        repo_id: RepoId(wt.clone()),
+        display_name: "live-wt".to_string(),
+    });
+
+    // Seed the cache the way a completed build would.
+    app.git_graph.load_repo(wt.clone(), "live-wt");
+    app.git_graph.set_rows(vec![mock_graph_row()]);
+    assert!(
+        app.git_graph.has_cached_graph_for(&wt),
+        "precondition: the worktree graph is cached",
+    );
+
+    app.refresh_active_worktree();
+
+    assert!(
+        !app.git_graph.has_cached_graph_for(&wt),
+        "refresh_active_worktree must invalidate the worktree's cached graph",
+    );
+}
+
+fn mock_graph_row() -> crate::git::graph::GraphRow {
+    crate::git::graph::GraphRow {
+        commit_col: 0,
+        lanes: vec![crate::git::graph::LaneSegment::Commit],
+        horizontal_spans: Vec::new(),
+        oid: git2::Oid::from_str("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(),
+        short_id: "abc1234".to_string(),
+        message: "m".to_string(),
+        author: "a".to_string(),
+        time: 0,
+        labels: Vec::new(),
+        is_merge: false,
+        parent_oids: Vec::new(),
+        diff_stat: None,
+        collapsed: None,
+    }
+}

--- a/src/components/git_graph/cache.rs
+++ b/src/components/git_graph/cache.rs
@@ -70,6 +70,12 @@ impl GraphCache {
         Some(entry.cached.clone())
     }
 
+    /// Whether an entry exists for `key`, without touching LRU recency.
+    #[cfg(test)]
+    pub(crate) fn contains(&self, key: &GraphCacheKey) -> bool {
+        self.entries.contains_key(key)
+    }
+
     pub(crate) fn insert(&mut self, key: GraphCacheKey, cached: CachedGraph) {
         if self.entries.len() >= self.capacity && !self.entries.contains_key(&key) {
             self.evict_lru();

--- a/src/components/git_graph/cache.rs
+++ b/src/components/git_graph/cache.rs
@@ -1,0 +1,134 @@
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+
+use crate::config::BranchFilter;
+use crate::git::graph::{DiffStat, GraphFilters, GraphRow};
+
+/// Upper bound on cached graph snapshots. Each holds up to `MAX_COMMITS`
+/// rows (~100 KB), so this keeps memory bounded to a few MB while covering
+/// the repos a user actually cycles through.
+pub(crate) const GRAPH_CACHE_CAPACITY: usize = 32;
+
+/// Upper bound on cached rendered row bodies. Rows are evicted wholesale once
+/// the bound is hit, so this stays far above any visible window.
+pub(crate) const RENDER_CACHE_CAPACITY: usize = 256;
+
+/// The graph-build options that shape the built rows. `label_max_len` is
+/// deliberately excluded: it only changes rendering truncation, not the rows
+/// themselves, so changing it must not invalidate a cached graph.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct GraphCacheKey {
+    pub(crate) path: PathBuf,
+    pub(crate) branch_filter: BranchFilter,
+    pub(crate) first_parent: bool,
+    pub(crate) show_stats: bool,
+    pub(crate) filters: GraphFilters,
+}
+
+/// A built graph snapshot, restored on a cache hit.
+#[derive(Clone)]
+pub(crate) struct CachedGraph {
+    pub(crate) rows: Vec<GraphRow>,
+    pub(crate) filter_branches: BTreeSet<String>,
+    pub(crate) filter_authors: BTreeSet<String>,
+}
+
+/// Bounded per-repo cache of built graphs. Re-selecting a repo that was
+/// recently viewed restores its rows from memory instead of reopening the
+/// repository, re-walking up to `MAX_COMMITS` commits, and diffing trees for
+/// stats. Entries are invalidated when the repo's rendered refs/HEAD move
+/// (see `invalidate_repo`) and evicted least-recently-used when the cache
+/// grows past `capacity`.
+pub(crate) struct GraphCache {
+    entries: HashMap<GraphCacheKey, GraphCacheEntry>,
+    capacity: usize,
+    /// Monotonic access clock for LRU eviction.
+    clock: u64,
+}
+
+struct GraphCacheEntry {
+    cached: CachedGraph,
+    last_used: u64,
+}
+
+impl GraphCache {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            capacity,
+            clock: 0,
+        }
+    }
+
+    /// Look up a snapshot, bumping its LRU recency. Clones the rows so the
+    /// entry stays available for the next switch back.
+    pub(crate) fn get(&mut self, key: &GraphCacheKey) -> Option<CachedGraph> {
+        let entry = self.entries.get_mut(key)?;
+        self.clock += 1;
+        entry.last_used = self.clock;
+        Some(entry.cached.clone())
+    }
+
+    pub(crate) fn insert(&mut self, key: GraphCacheKey, cached: CachedGraph) {
+        if self.entries.len() >= self.capacity && !self.entries.contains_key(&key) {
+            self.evict_lru();
+        }
+        self.clock += 1;
+        self.entries.insert(
+            key,
+            GraphCacheEntry {
+                cached,
+                last_used: self.clock,
+            },
+        );
+    }
+
+    /// Fold freshly computed diff stats into the cached copy so a cache hit
+    /// doesn't resurrect a graph missing its +N/-M columns.
+    pub(crate) fn apply_stats(
+        &mut self,
+        key: &GraphCacheKey,
+        stat_map: &HashMap<git2::Oid, DiffStat>,
+    ) {
+        if let Some(entry) = self.entries.get_mut(key) {
+            for row in &mut entry.cached.rows {
+                if let Some(stat) = stat_map.get(&row.oid) {
+                    row.diff_stat = Some(stat.clone());
+                }
+            }
+        }
+    }
+
+    pub(crate) fn invalidate(&mut self, path: &Path) {
+        self.entries.retain(|key, _| key.path != path);
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    fn evict_lru(&mut self) {
+        let Some((key, _)) = self
+            .entries
+            .iter()
+            .min_by_key(|(_, entry)| entry.last_used)
+            .map(|(key, entry)| (key.clone(), entry.last_used))
+        else {
+            return;
+        };
+        self.entries.remove(&key);
+    }
+}
+
+/// Identity of a cached rendered row body: everything that can change the
+/// stable part of a graph line. Horizontal scroll and the terminal width are
+/// applied after the lookup each frame, and the relative-time tail is rebuilt
+/// each frame, so neither is part of the key.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct RowRenderKey {
+    pub(crate) oid: git2::Oid,
+    pub(crate) theme_generation: u64,
+    pub(crate) label_max_len: usize,
+    pub(crate) dimmed: bool,
+    pub(crate) collapsed: bool,
+}

--- a/src/components/git_graph/cache.rs
+++ b/src/components/git_graph/cache.rs
@@ -5,8 +5,9 @@ use crate::config::BranchFilter;
 use crate::git::graph::{DiffStat, GraphFilters, GraphRow};
 
 /// Upper bound on cached graph snapshots. Each holds up to `MAX_COMMITS`
-/// rows (~100 KB), so this keeps memory bounded to a few MB while covering
-/// the repos a user actually cycles through.
+/// rows of owned strings plus lane vectors, on the order of a few hundred
+/// KB, so the ceiling here lands in the low tens of MB — acceptable for
+/// covering the repos a user actually cycles through.
 pub(crate) const GRAPH_CACHE_CAPACITY: usize = 32;
 
 /// Upper bound on cached rendered row bodies. Rows are evicted wholesale once

--- a/src/components/git_graph/component.rs
+++ b/src/components/git_graph/component.rs
@@ -88,6 +88,17 @@ impl GitGraph {
         let label_max_len = self.graph_options.label_max_len;
         let max_width = area.width.saturating_sub(2) as usize; // 2 for borders
         let has_search = !self.search.input.is_empty() && !self.search.matches.is_empty();
+        // One clock read for the whole frame's relative-time column.
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+
+        // Rendered row bodies are cached per (commit, theme, width, highlight,
+        // collapse) state; only the volatile tail (relative time, diff stats)
+        // is rebuilt each frame. Take the cache out of `self` so the closure
+        // can mutate it while `display_rows` is still borrowed.
+        let mut render_cache = std::mem::take(&mut self.render_cache);
         let items: Vec<ListItem> = self
             .display_rows()
             .iter()
@@ -95,87 +106,39 @@ impl GitGraph {
             .map(|(i, row)| {
                 let dimmed = has_search && !self.search.matches.contains(&i);
                 let is_collapsed = row.collapsed.is_some();
-                let mut spans = graph_render::render_graph_prefix(row, t);
 
-                if dimmed || is_collapsed {
-                    for span in &mut spans {
-                        span.style = Style::default().fg(t.dimmed);
-                    }
-                }
-
-                if is_collapsed {
-                    spans.push(Span::styled(
-                        row.message.clone(),
-                        Style::default()
-                            .fg(t.collapsed_message)
-                            .add_modifier(Modifier::ITALIC),
-                    ));
-                } else {
-                    let id_style = if dimmed {
-                        Style::default().fg(t.dimmed)
-                    } else {
-                        Style::default()
-                            .fg(t.commit_id)
-                            .add_modifier(Modifier::BOLD)
-                    };
-                    spans.push(Span::styled(format!("{} ", row.short_id), id_style));
-
-                    if !dimmed {
-                        spans.extend(graph_render::render_branch_labels(
-                            &row.labels,
-                            label_max_len,
+                let key = RowRenderKey {
+                    oid: row.oid,
+                    theme_generation: self.theme_generation,
+                    label_max_len,
+                    dimmed,
+                    collapsed: is_collapsed,
+                };
+                let mut spans = match render_cache.get(&key) {
+                    Some(cached) => cached.clone(),
+                    None => {
+                        let built = graph_render::render_row_body(
+                            row,
                             t,
-                        ));
-                    }
-
-                    let msg_color = if dimmed {
-                        t.dimmed
-                    } else if row.is_merge {
-                        t.merge_message
-                    } else {
-                        t.commit_message
-                    };
-                    spans.push(Span::styled(
-                        row.message.clone(),
-                        Style::default().fg(msg_color),
-                    ));
-
-                    let author_color = if dimmed {
-                        t.dimmed
-                    } else {
-                        graph_render::author_color(&row.author, t)
-                    };
-                    spans.push(Span::styled(
-                        format!("  — {}", row.author),
-                        Style::default().fg(author_color),
-                    ));
-                    spans.push(Span::styled(
-                        format!(" {}", graph_render::format_relative_time(row.time)),
-                        Style::default().fg(t.time),
-                    ));
-
-                    if let Some(ref stat) = row.diff_stat
-                        && !dimmed
-                    {
-                        if stat.additions > 0 {
-                            spans.push(Span::styled(
-                                format!(" +{}", stat.additions),
-                                Style::default().fg(t.addition),
-                            ));
+                            label_max_len,
+                            dimmed,
+                            is_collapsed,
+                        );
+                        if render_cache.len() >= RENDER_CACHE_CAPACITY {
+                            render_cache.clear();
                         }
-                        if stat.deletions > 0 {
-                            spans.push(Span::styled(
-                                format!(" -{}", stat.deletions),
-                                Style::default().fg(t.deletion),
-                            ));
-                        }
+                        render_cache.insert(key, built.clone());
+                        built
                     }
-                }
+                };
+
+                spans.extend(graph_render::render_row_tail(row, t, now_secs, dimmed));
 
                 graph_render::h_scroll_line(&mut spans, self.h_scroll, max_width);
                 ListItem::new(Line::from(spans))
             })
             .collect();
+        self.render_cache = render_cache;
 
         let list = List::new(items).block(block).highlight_style(
             Style::default()

--- a/src/components/git_graph/mod.rs
+++ b/src/components/git_graph/mod.rs
@@ -1,14 +1,20 @@
 use color_eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
-use ratatui::{layout::Rect, widgets::ListState};
-use std::collections::BTreeSet;
-use std::path::PathBuf;
+use ratatui::{layout::Rect, text::Span, widgets::ListState};
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::action::Action;
 use crate::git::graph::{BranchSegment, GraphBuilder, GraphFilters, GraphOptions, GraphRow};
 use crate::theme::Theme;
+
+mod cache;
+use cache::{
+    CachedGraph, GRAPH_CACHE_CAPACITY, GraphCache, GraphCacheKey, RENDER_CACHE_CAPACITY,
+    RowRenderKey,
+};
 
 mod component;
 #[cfg(test)]
@@ -51,7 +57,6 @@ impl Drop for GraphLoadGuard {
         }
     }
 }
-
 struct CommitDetail {
     oid: String,
     message: String,
@@ -149,6 +154,16 @@ pub(crate) struct GitGraph {
     /// of a highlight the user has already moved past is dropped.
     diff_select_generation: u64,
     theme: Arc<Theme>,
+    /// Cached built graphs keyed by repo path + build signature, so switching
+    /// back to a recently viewed repo restores its rows instantly.
+    graph_cache: GraphCache,
+    /// Cached stable row bodies (prefix/labels/id/message/author) so frames
+    /// don't rebuild them for unchanged rows. The volatile tail (relative
+    /// time, diff stats) is appended fresh each frame.
+    render_cache: HashMap<RowRenderKey, Vec<Span<'static>>>,
+    /// Bumped on theme change so cached row bodies are rebuilt with the new
+    /// colors.
+    theme_generation: u64,
 }
 
 impl GitGraph {
@@ -184,14 +199,32 @@ impl GitGraph {
             detail_generation: 0,
             diff_select_generation: 0,
             theme,
+            graph_cache: GraphCache::new(GRAPH_CACHE_CAPACITY),
+            render_cache: HashMap::new(),
+            theme_generation: 0,
         }
     }
 
     pub fn set_theme(&mut self, theme: Arc<Theme>) {
         self.theme = theme;
+        // Cached row bodies carry the old theme's colors: bump the generation
+        // and drop them so the next frame rebuilds with the new palette.
+        self.theme_generation += 1;
+        self.render_cache.clear();
     }
 
     pub fn load_repo(&mut self, path: PathBuf, repo_name: &str) {
+        self.load_repo_inner(path, repo_name, false);
+    }
+
+    /// Like [`Self::load_repo`] but bypasses the graph cache: used by explicit
+    /// reload paths (`g`, live worktree refreshes) that must see fresh on-disk
+    /// state. The freshly built rows still populate the cache afterwards.
+    pub fn force_reload_repo(&mut self, path: PathBuf, repo_name: &str) {
+        self.load_repo_inner(path, repo_name, true);
+    }
+
+    fn load_repo_inner(&mut self, path: PathBuf, repo_name: &str, force: bool) {
         let is_same_repo = self.repo_path.as_deref() == Some(path.as_path());
 
         if is_same_repo && self.load_in_flight {
@@ -203,22 +236,28 @@ impl GitGraph {
         self.repo_path = Some(path.clone());
         self.error = None;
 
+        // Cache hit: restore the built rows synchronously — no repository
+        // open, no revwalk, no stats diffing, no "Loading…" flash. Bumping the
+        // load generation discards any older build still in flight for the
+        // previous repo, exactly as a fresh spawn would.
+        if !force && let Some(cached) = self.graph_cache.get(&self.cache_key(&path)) {
+            self.load_generation += 1;
+            if !is_same_repo {
+                self.reset_view_state();
+            }
+            self.filter_branches.extend(cached.filter_branches);
+            self.filter_authors.extend(cached.filter_authors);
+            self.set_rows(cached.rows);
+            return;
+        }
+
         // Keep old rows visible during reload (prevents blinking).
         // Only clear on repo switch.
         if !is_same_repo {
             self.loading = true;
             self.rows.clear();
             self.all_rows.clear();
-            self.state.select(None);
-            self.commit_detail = None;
-            self.needs_reload = false;
-            self.consecutive_aborts = 0;
-            self.search.clear();
-            self.filter_branches.clear();
-            self.filter_authors.clear();
-            self.collapsed_branches.clear();
-            self.segments.clear();
-            self.row_to_segment.clear();
+            self.reset_view_state();
         }
 
         let Some(tx) = &self.action_tx else { return };
@@ -273,6 +312,46 @@ impl GitGraph {
         });
     }
 
+    /// Reset per-repo view state (selection, search, collapse, filters)
+    /// without touching the row buffers. Shared by the repo-switch path and
+    /// the cache-hit restore path, so both behave identically.
+    fn reset_view_state(&mut self) {
+        self.state.select(None);
+        self.commit_detail = None;
+        self.needs_reload = false;
+        self.consecutive_aborts = 0;
+        self.search.clear();
+        self.filter_branches.clear();
+        self.filter_authors.clear();
+        self.collapsed_branches.clear();
+        self.segments.clear();
+        self.row_to_segment.clear();
+    }
+
+    /// The cache key for a graph build on `path`: the repo plus every option
+    /// that shapes the built rows.
+    fn cache_key(&self, path: &Path) -> GraphCacheKey {
+        GraphCacheKey {
+            path: path.to_path_buf(),
+            branch_filter: self.graph_options.branch_filter,
+            first_parent: self.graph_options.first_parent,
+            show_stats: self.graph_options.show_stats,
+            filters: self.graph_options.filters.clone(),
+        }
+    }
+
+    /// Drop cached graph snapshots for `path`. Called when the repo's
+    /// rendered refs/HEAD move, so the next load rebuilds from disk instead
+    /// of resurrecting a stale snapshot.
+    pub fn invalidate_repo(&mut self, path: &Path) {
+        self.graph_cache.invalidate(path);
+    }
+
+    /// Drop every cached graph snapshot (rescan / repo removal).
+    pub fn invalidate_graph_cache(&mut self) {
+        self.graph_cache.clear();
+    }
+
     pub fn set_error(&mut self, msg: String) {
         self.error = Some(msg);
         self.loading = false;
@@ -307,8 +386,23 @@ impl GitGraph {
         self.loading = false;
         self.load_in_flight = false;
         self.consecutive_aborts = 0;
+        // Rows changed wholesale: drop cached row bodies so stale spans
+        // (old oids, old labels) are never served again.
+        self.render_cache.clear();
         self.recompute_segments();
         self.recompute_collapsed_rows();
+        // Cache the freshly built graph so switching back to this repo (with
+        // the same options) restores it instantly instead of rebuilding.
+        if let Some(path) = &self.repo_path {
+            self.graph_cache.insert(
+                self.cache_key(path),
+                CachedGraph {
+                    rows: self.all_rows.clone(),
+                    filter_branches: self.filter_branches.clone(),
+                    filter_authors: self.filter_authors.clone(),
+                },
+            );
+        }
         if !self.display_rows().is_empty() {
             let idx = prev_selected
                 .map(|i| i.min(self.display_rows().len() - 1))
@@ -331,6 +425,12 @@ impl GitGraph {
             if let Some(stat) = stat_map.get(&row.oid) {
                 row.diff_stat = Some(stat.clone());
             }
+        }
+        // Keep the cached snapshot's +N/-M columns in sync so a later cache
+        // hit shows the same stats.
+        if let Some(path) = &self.repo_path {
+            let key = self.cache_key(path);
+            self.graph_cache.apply_stats(&key, &stat_map);
         }
         self.recompute_collapsed_rows();
     }

--- a/src/components/git_graph/mod.rs
+++ b/src/components/git_graph/mod.rs
@@ -352,6 +352,15 @@ impl GitGraph {
         self.graph_cache.clear();
     }
 
+    /// Whether any graph snapshot is cached for `path`. Test seam: pins the
+    /// contract that a live-worktree refresh drops the worktree's cached
+    /// graph even when the reload is deferred.
+    #[cfg(test)]
+    pub fn has_cached_graph_for(&self, path: &Path) -> bool {
+        let key = self.cache_key(path);
+        self.graph_cache.contains(&key)
+    }
+
     pub fn set_error(&mut self, msg: String) {
         self.error = Some(msg);
         self.loading = false;

--- a/src/components/git_graph/tests.rs
+++ b/src/components/git_graph/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::components::Component;
-use crate::git::graph::{BranchLabel, GraphRow, LaneSegment};
+use crate::config::BranchFilter;
+use crate::git::graph::{BranchLabel, DiffStat, GraphRow, LaneSegment};
 use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use git2::Oid;
 use ratatui::layout::Rect;
@@ -691,4 +692,215 @@ fn scrolling_the_file_list_asks_for_the_settled_files_diff() {
         requested_file(graph.commit_diff_settled(generation)),
         "b.rs"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Graph cache: switching repos restores built rows instead of rebuilding.
+// ---------------------------------------------------------------------------
+
+fn graph_key(path: &str) -> GraphCacheKey {
+    GraphCacheKey {
+        path: PathBuf::from(path),
+        branch_filter: BranchFilter::All,
+        first_parent: false,
+        show_stats: true,
+        filters: GraphFilters::default(),
+    }
+}
+
+fn cached_graph(rows: Vec<GraphRow>) -> CachedGraph {
+    CachedGraph {
+        rows,
+        filter_branches: BTreeSet::new(),
+        filter_authors: BTreeSet::new(),
+    }
+}
+
+fn graph_with_path(path: &str) -> GitGraph {
+    let mut graph = GitGraph::new(std::sync::Arc::new(crate::theme::Theme::default()));
+    graph.repo_path = Some(PathBuf::from(path));
+    graph
+}
+
+#[test]
+fn graph_cache_evicts_least_recently_used() {
+    let mut cache = GraphCache::new(2);
+    cache.insert(graph_key("/a"), cached_graph(vec![mock_row("1", "a", "A")]));
+    cache.insert(graph_key("/b"), cached_graph(vec![mock_row("2", "b", "B")]));
+    // Touching /a makes /b the least recently used.
+    let _ = cache.get(&graph_key("/a"));
+    cache.insert(graph_key("/c"), cached_graph(vec![mock_row("3", "c", "C")]));
+    assert!(cache.get(&graph_key("/a")).is_some());
+    assert!(cache.get(&graph_key("/b")).is_none());
+    assert!(cache.get(&graph_key("/c")).is_some());
+}
+
+#[test]
+fn graph_cache_invalidate_removes_all_signatures_for_path() {
+    let mut cache = GraphCache::new(8);
+    let mut key_b = graph_key("/a");
+    key_b.first_parent = true;
+    cache.insert(graph_key("/a"), cached_graph(vec![mock_row("1", "a", "A")]));
+    cache.insert(key_b, cached_graph(vec![mock_row("2", "a1", "A")]));
+    cache.invalidate(Path::new("/a"));
+    assert!(cache.get(&graph_key("/a")).is_none());
+    let mut key_b = graph_key("/a");
+    key_b.first_parent = true;
+    assert!(cache.get(&key_b).is_none());
+    // Other paths are untouched.
+    let mut cache2 = GraphCache::new(8);
+    cache2.insert(graph_key("/a"), cached_graph(vec![mock_row("1", "a", "A")]));
+    cache2.insert(graph_key("/b"), cached_graph(vec![mock_row("2", "b", "B")]));
+    cache2.invalidate(Path::new("/a"));
+    assert!(cache2.get(&graph_key("/b")).is_some());
+}
+
+#[test]
+fn graph_cache_apply_stats_updates_cached_rows() {
+    let mut cache = GraphCache::new(4);
+    let row = mock_row("abc1234", "a", "A");
+    let oid = row.oid;
+    cache.insert(graph_key("/a"), cached_graph(vec![row]));
+    let stat_map = std::collections::HashMap::from([(
+        oid,
+        DiffStat {
+            additions: 1,
+            deletions: 2,
+        },
+    )]);
+    cache.apply_stats(&graph_key("/a"), &stat_map);
+    let cached = cache.get(&graph_key("/a")).expect("still cached");
+    let stat = cached.rows[0].diff_stat.as_ref().expect("stats folded in");
+    assert_eq!(stat.additions, 1);
+    assert_eq!(stat.deletions, 2);
+}
+
+#[test]
+fn load_repo_restores_cached_rows_without_rebuilding() {
+    let mut graph = graph_with_path("/tmp/cache-repo");
+    graph.set_rows(vec![mock_row("abc1234", "cached message", "Alice")]);
+    assert!(
+        graph
+            .graph_cache
+            .get(&graph.cache_key(&PathBuf::from("/tmp/cache-repo")))
+            .is_some()
+    );
+
+    // Switching to an uncached repo clears the view (miss path, no action_tx).
+    graph.load_repo(PathBuf::from("/tmp/other-repo"), "other");
+    assert!(graph.loading);
+    assert!(graph.all_rows.is_empty());
+
+    // Switching back hits the cache and restores rows synchronously.
+    graph.load_repo(PathBuf::from("/tmp/cache-repo"), "cache-repo");
+    assert!(!graph.loading);
+    assert_eq!(graph.all_rows.len(), 1);
+    assert_eq!(graph.all_rows[0].message, "cached message");
+    assert_eq!(graph.state.selected(), Some(0));
+}
+
+#[test]
+fn cache_hit_for_different_repo_resets_view_state() {
+    let mut graph = graph_with_path("/tmp/a");
+    graph.set_rows(vec![mock_row("1", "a", "X"), mock_row("2", "b", "Y")]);
+    graph.state.select(Some(1));
+    graph.search.input = "query".to_string();
+
+    graph.load_repo(PathBuf::from("/tmp/b"), "b");
+    graph.load_repo(PathBuf::from("/tmp/a"), "a");
+
+    // The cache hit must behave like a normal repo switch: search and
+    // selection are reset, then set_rows re-selects row 0.
+    assert!(graph.search.input.is_empty());
+    assert_eq!(graph.state.selected(), Some(0));
+}
+
+#[test]
+fn invalidate_repo_forces_a_rebuild() {
+    let mut graph = graph_with_path("/tmp/cache-repo");
+    graph.set_rows(vec![mock_row("abc1234", "cached", "Alice")]);
+    graph.invalidate_repo(&PathBuf::from("/tmp/cache-repo"));
+
+    graph.load_repo(PathBuf::from("/tmp/other"), "other");
+    graph.load_repo(PathBuf::from("/tmp/cache-repo"), "cache-repo");
+    // The entry was dropped: the load is a miss, so rows stay cleared until
+    // the (absent) background build reports back.
+    assert!(graph.loading);
+    assert!(graph.all_rows.is_empty());
+}
+
+#[test]
+fn force_reload_repo_bypasses_the_cache() {
+    let mut graph = graph_with_path("/tmp/cache-repo");
+    graph.set_rows(vec![mock_row("abc1234", "cached", "Alice")]);
+
+    graph.load_repo(PathBuf::from("/tmp/other"), "other");
+    graph.force_reload_repo(PathBuf::from("/tmp/cache-repo"), "cache-repo");
+    assert!(graph.loading);
+    assert!(graph.all_rows.is_empty());
+}
+
+#[test]
+fn cache_is_keyed_by_graph_options() {
+    let mut graph = graph_with_path("/tmp/cache-repo");
+    graph.set_rows(vec![mock_row("abc1234", "cached", "Alice")]);
+    // A different build signature must not hit the cached snapshot.
+    graph.graph_options.first_parent = true;
+
+    graph.load_repo(PathBuf::from("/tmp/other"), "other");
+    graph.load_repo(PathBuf::from("/tmp/cache-repo"), "cache-repo");
+    assert!(graph.loading);
+    assert!(graph.all_rows.is_empty());
+}
+
+#[test]
+fn diff_stats_are_folded_into_the_cached_snapshot() {
+    let mut graph = graph_with_path("/tmp/stats-repo");
+    graph.set_rows(vec![mock_row("abc1234", "msg", "A")]);
+    let oid = graph.all_rows[0].oid;
+    graph.set_diff_stats(vec![(
+        oid,
+        DiffStat {
+            additions: 3,
+            deletions: 2,
+        },
+    )]);
+    let cached = graph
+        .graph_cache
+        .get(&graph.cache_key(&PathBuf::from("/tmp/stats-repo")))
+        .expect("cached");
+    let stat = cached.rows[0].diff_stat.as_ref().expect("stats cached");
+    assert_eq!(stat.additions, 3);
+    assert_eq!(stat.deletions, 2);
+}
+
+#[test]
+fn cache_hit_restores_filter_values_not_present_in_rows() {
+    let mut graph = graph_with_path("/tmp/cache-repo");
+    // A build's branch_names can list a branch whose commits are filtered out
+    // of the walk; the picker still needs that value after a cache hit.
+    graph.filter_branches.insert("hidden-branch".to_string());
+    graph.set_rows(vec![mock_row("abc1234", "cached", "Alice")]);
+
+    graph.load_repo(PathBuf::from("/tmp/other"), "other");
+    graph.load_repo(PathBuf::from("/tmp/cache-repo"), "cache-repo");
+    assert!(graph.filter_branches.contains("hidden-branch"));
+}
+
+#[test]
+fn theme_change_drops_cached_row_bodies() {
+    let mut graph = GitGraph::new(std::sync::Arc::new(crate::theme::Theme::default()));
+    graph.set_rows(vec![mock_row("abc1234", "msg", "A")]);
+    let key = RowRenderKey {
+        oid: graph.all_rows[0].oid,
+        theme_generation: graph.theme_generation,
+        label_max_len: 24,
+        dimmed: false,
+        collapsed: false,
+    };
+    graph.render_cache.insert(key, vec![Span::raw("x")]);
+    let generation_before = graph.theme_generation;
+    graph.set_theme(std::sync::Arc::new(crate::theme::Theme::default()));
+    assert!(graph.theme_generation > generation_before);
+    assert!(graph.render_cache.is_empty());
 }

--- a/src/components/git_graph/tests.rs
+++ b/src/components/git_graph/tests.rs
@@ -904,3 +904,30 @@ fn theme_change_drops_cached_row_bodies() {
     assert!(graph.theme_generation > generation_before);
     assert!(graph.render_cache.is_empty());
 }
+
+#[test]
+fn deferred_reload_after_invalidate_forces_a_rebuild() {
+    // Mirrors the live-worktree refresh path: the cached snapshot for the
+    // worktree path is invalidated before the reload is deferred (commit
+    // detail open), so when the detail closes the deferred `reload_graph`
+    // must miss the cache and start a fresh build instead of resurrecting
+    // the stale rows.
+    let mut graph = graph_with_path("/tmp/bench-wt");
+    graph.set_rows(vec![mock_row("abc1234", "stale", "Alice")]);
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    graph.action_tx = Some(tx);
+    // `spawn_blocking` needs a runtime context for the miss path.
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let _guard = runtime.enter();
+
+    graph.invalidate_repo(&PathBuf::from("/tmp/bench-wt"));
+    graph.set_needs_reload();
+    graph.reload_graph();
+
+    // A cache hit would restore the stale row synchronously and leave the
+    // latch free; a miss (correct) starts a background rebuild.
+    assert!(
+        graph.load_in_flight,
+        "deferred reload must not hit the cache"
+    );
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -134,7 +134,7 @@ pub(crate) struct UiConfig {
     pub show_liveness: bool,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum BranchFilter {
     #[default]

--- a/src/git/graph/mod.rs
+++ b/src/git/graph/mod.rs
@@ -51,14 +51,14 @@ impl Default for GraphOptions {
 
 /// Optional include lists for the graph. `None` means every value in the
 /// category is included; an empty set deliberately produces an empty graph.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub(crate) struct GraphFilters {
     pub branches: Option<BTreeSet<String>>,
     pub authors: Option<BTreeSet<String>>,
     pub refs: GraphRefFilters,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct GraphRefFilters {
     pub local: bool,
     pub remote: bool,

--- a/src/git/graph_render.rs
+++ b/src/git/graph_render.rs
@@ -1,6 +1,4 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use ratatui::style::{Color, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
 
 use crate::git::graph::{BranchLabel, GraphRow, LaneSegment, lane_color};
@@ -116,6 +114,111 @@ pub(crate) fn render_branch_labels(
     spans
 }
 
+/// Build the stable part of a graph row line: the lane prefix, short id,
+/// branch labels, message and author. These spans change only when the row's
+/// commit, the theme, the label truncation width, or the search highlight
+/// (`dimmed`) changes — none of which moves between frames — so callers cache
+/// the result and re-append the volatile tail each frame.
+pub(crate) fn render_row_body(
+    row: &GraphRow,
+    theme: &GraphTheme,
+    label_max_len: usize,
+    dimmed: bool,
+    collapsed: bool,
+) -> Vec<Span<'static>> {
+    let mut spans = render_graph_prefix(row, theme);
+
+    if dimmed || collapsed {
+        for span in &mut spans {
+            span.style = Style::default().fg(theme.dimmed);
+        }
+    }
+
+    if collapsed {
+        // Collapsed-branch placeholder: prefix + placeholder message only.
+        spans.push(Span::styled(
+            row.message.clone(),
+            Style::default()
+                .fg(theme.collapsed_message)
+                .add_modifier(Modifier::ITALIC),
+        ));
+        return spans;
+    }
+
+    let id_style = if dimmed {
+        Style::default().fg(theme.dimmed)
+    } else {
+        Style::default()
+            .fg(theme.commit_id)
+            .add_modifier(Modifier::BOLD)
+    };
+    spans.push(Span::styled(format!("{} ", row.short_id), id_style));
+
+    if !dimmed {
+        spans.extend(render_branch_labels(&row.labels, label_max_len, theme));
+    }
+
+    let msg_color = if dimmed {
+        theme.dimmed
+    } else if row.is_merge {
+        theme.merge_message
+    } else {
+        theme.commit_message
+    };
+    spans.push(Span::styled(
+        row.message.clone(),
+        Style::default().fg(msg_color),
+    ));
+
+    let author_color = if dimmed {
+        theme.dimmed
+    } else {
+        author_color(&row.author, theme)
+    };
+    spans.push(Span::styled(
+        format!("  — {}", row.author),
+        Style::default().fg(author_color),
+    ));
+
+    spans
+}
+
+/// Build the volatile tail of a graph row line: the relative commit time and
+/// the diff stats. Rebuilt every frame — the relative time advances on its
+/// own — using one `now` clock read shared across the whole frame.
+pub(crate) fn render_row_tail(
+    row: &GraphRow,
+    theme: &GraphTheme,
+    now_secs: i64,
+    dimmed: bool,
+) -> Vec<Span<'static>> {
+    let mut spans = Vec::new();
+    if row.collapsed.is_some() {
+        return spans;
+    }
+    spans.push(Span::styled(
+        format!(" {}", format_relative_time_at(row.time, now_secs)),
+        Style::default().fg(theme.time),
+    ));
+    if let Some(ref stat) = row.diff_stat
+        && !dimmed
+    {
+        if stat.additions > 0 {
+            spans.push(Span::styled(
+                format!(" +{}", stat.additions),
+                Style::default().fg(theme.addition),
+            ));
+        }
+        if stat.deletions > 0 {
+            spans.push(Span::styled(
+                format!(" -{}", stat.deletions),
+                Style::default().fg(theme.deletion),
+            ));
+        }
+    }
+    spans
+}
+
 /// Truncate a span list so its total display width fits within `max_width`.
 /// Appends `..` at the cut point when truncation occurs.
 pub(crate) fn truncate_line(spans: &mut Vec<Span<'static>>, max_width: usize) {
@@ -207,12 +310,11 @@ pub(crate) fn h_scroll_line(spans: &mut Vec<Span<'static>>, offset: usize, max_w
     truncate_line(spans, max_width);
 }
 
-pub(crate) fn format_relative_time(epoch_secs: i64) -> String {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64;
-    let delta = (now - epoch_secs).max(0) as u64;
+/// Format `epoch_secs` relative to the explicit `now` (seconds since the Unix
+/// epoch). The caller passes one clock read for the whole frame instead of a
+/// `SystemTime::now()` call per visible row.
+pub(crate) fn format_relative_time_at(epoch_secs: i64, now_secs: i64) -> String {
+    let delta = (now_secs - epoch_secs).max(0) as u64;
 
     if delta < 60 {
         format!("{}s ago", delta)
@@ -247,7 +349,29 @@ pub(crate) fn author_color(name: &str, theme: &GraphTheme) -> Color {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use super::*;
+
+    use crate::git::graph::DiffStat;
+
+    fn row(short_id: &str, message: &str, author: &str) -> GraphRow {
+        GraphRow {
+            commit_col: 0,
+            lanes: vec![LaneSegment::Commit],
+            horizontal_spans: Vec::new(),
+            oid: git2::Oid::from_str("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(),
+            short_id: short_id.to_string(),
+            message: message.to_string(),
+            author: author.to_string(),
+            time: 1_000_000,
+            labels: Vec::new(),
+            is_merge: false,
+            parent_oids: Vec::new(),
+            diff_stat: None,
+            collapsed: None,
+        }
+    }
 
     fn label(name: &str, is_head: bool, is_remote: bool, is_worktree: bool) -> BranchLabel {
         BranchLabel {
@@ -347,7 +471,7 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs() as i64;
-        assert_eq!(format_relative_time(now - 30), "30s ago");
+        assert_eq!(format_relative_time_at(now - 30, now), "30s ago");
     }
 
     #[test]
@@ -356,7 +480,7 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs() as i64;
-        assert_eq!(format_relative_time(now - 7200), "2h ago");
+        assert_eq!(format_relative_time_at(now - 7200, now), "2h ago");
     }
 
     #[test]
@@ -365,7 +489,7 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs() as i64;
-        assert_eq!(format_relative_time(now - 259200), "3d ago");
+        assert_eq!(format_relative_time_at(now - 259200, now), "3d ago");
     }
 
     #[test]
@@ -375,7 +499,7 @@ mod tests {
             .unwrap()
             .as_secs() as i64;
         // 2 weeks = 14 days = 14*86400 = 1209600
-        assert_eq!(format_relative_time(now - 1_209_600), "2w ago");
+        assert_eq!(format_relative_time_at(now - 1_209_600, now), "2w ago");
     }
 
     #[test]
@@ -385,7 +509,7 @@ mod tests {
             .unwrap()
             .as_secs() as i64;
         // ~5 months = 5 * 30 days = 12960000
-        assert_eq!(format_relative_time(now - 12_960_000), "5mo ago");
+        assert_eq!(format_relative_time_at(now - 12_960_000, now), "5mo ago");
     }
 
     #[test]
@@ -395,7 +519,7 @@ mod tests {
             .unwrap()
             .as_secs() as i64;
         // ~2 years = 2 * 365 days = 63072000
-        assert_eq!(format_relative_time(now - 63_072_000), "2y ago");
+        assert_eq!(format_relative_time_at(now - 63_072_000, now), "2y ago");
     }
 
     #[test]
@@ -405,7 +529,7 @@ mod tests {
             .unwrap()
             .as_secs() as i64;
         // Future timestamp
-        assert_eq!(format_relative_time(now + 1000), "0s ago");
+        assert_eq!(format_relative_time_at(now + 1000, now), "0s ago");
     }
 
     #[test]
@@ -543,5 +667,79 @@ mod tests {
         let mut spans = vec![Span::raw("abc")];
         h_scroll_line(&mut spans, 10, 20);
         assert!(spans.is_empty());
+    }
+
+    #[test]
+    fn test_render_row_body_contains_id_message_author() {
+        let theme = GraphTheme::default();
+        let spans = render_row_body(
+            &row("abc1234", "fix: thing", "Alice"),
+            &theme,
+            24,
+            false,
+            false,
+        );
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("abc1234"), "got: {text}");
+        assert!(text.contains("fix: thing"), "got: {text}");
+        assert!(text.contains("Alice"), "got: {text}");
+    }
+
+    #[test]
+    fn test_render_row_body_dimmed_forces_dim_style() {
+        let theme = GraphTheme::default();
+        let spans = render_row_body(&row("abc1234", "msg", "Alice"), &theme, 24, true, false);
+        for span in &spans {
+            assert_eq!(span.style.fg, Some(theme.dimmed), "got: {:#?}", span.style);
+        }
+    }
+
+    #[test]
+    fn test_render_row_body_collapsed_is_placeholder_only() {
+        let theme = GraphTheme::default();
+        let mut r = row("abc1234", "\u{25b6} feature (3 commits)", "Alice");
+        r.collapsed = Some(("feature".to_string(), 3));
+        let spans = render_row_body(&r, &theme, 24, false, true);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("\u{25b6} feature (3 commits)"), "got: {text}");
+        assert!(!text.contains("Alice"), "got: {text}");
+    }
+
+    #[test]
+    fn test_render_row_tail_skips_collapsed_rows() {
+        let theme = GraphTheme::default();
+        let mut r = row("abc1234", "x", "Alice");
+        r.collapsed = Some(("feature".to_string(), 3));
+        let tail = render_row_tail(&r, &theme, 1_000_000, false);
+        assert!(tail.is_empty());
+    }
+
+    #[test]
+    fn test_render_row_tail_includes_time_and_stats() {
+        let theme = GraphTheme::default();
+        let mut r = row("abc1234", "x", "Alice");
+        r.diff_stat = Some(DiffStat {
+            additions: 3,
+            deletions: 2,
+        });
+        let tail = render_row_tail(&r, &theme, 1_000_000, false);
+        let text: String = tail.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("0s ago"), "got: {text}");
+        assert!(text.contains("+3"), "got: {text}");
+        assert!(text.contains("-2"), "got: {text}");
+    }
+
+    #[test]
+    fn test_render_row_tail_omits_stats_when_dimmed() {
+        let theme = GraphTheme::default();
+        let mut r = row("abc1234", "x", "Alice");
+        r.diff_stat = Some(DiffStat {
+            additions: 3,
+            deletions: 2,
+        });
+        let tail = render_row_tail(&r, &theme, 1_000_000, true);
+        let text: String = tail.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("0s ago"), "got: {text}");
+        assert!(!text.contains("+3"), "got: {text}");
     }
 }


### PR DESCRIPTION
## What

The git graph is rebuilt from scratch on every repo switch: reopening the repository, walking up to 200 commits, and diffing trees for the +N/-M stats. Cycling between repos (or even a sort-triggered reselect) pays that full cost every time.

This PR caches the built rows per (repo path, build options) and restores them instantly on a cache hit, and also caches the stable part of each rendered row line so frames don't rebuild unchanged spans.

## Performance

Measured on this repo (518 commits; the graph is capped at 200) in a release build, for one repo switch — cold path vs. cache hit:

| Path | Cost |
|---|---|
| Cold graph build (200 commits) | ~50 ms |
| Diff stats for 200 commits | ~400 ms |
| **Cold total** | **~450 ms** |
| **Cache hit (restore rows)** | **~0.1 ms** |

That is roughly **3500–4200×** faster for the switch itself. Cache hits are synchronous, so switching back to a recently viewed repo is instant with no "Loading…" flash, no repository reopen, and no tree diffs.

## How

- Cache keyed by repo path + build-shaping options (branch filter, first-parent, ref/author filters, stats toggle); `label_max_len` only affects rendering, so it is excluded from the key.
- Invalidated when a status refresh moves a rendered ref or HEAD — including repos that are not selected — so a later switch never resurrects stale rows.
- Bounded LRU capacity (32 snapshots, ~100 KB each); the `g` reload and live worktree refreshes bypass the cache but still populate it.
- Late-arriving diff stats are folded into the cached snapshot (`apply_stats`), so a cache hit never shows a graph missing its +N/-M columns.
- Rendered rows: the stable part of each line (lane prefix, labels, id, message, author) is cached per (commit, theme, label width, highlight, collapse) and cloned each frame; the relative time (one clock read per frame) and diff stats are rebuilt fresh, so the time column keeps advancing.

## Tests

17 new tests cover cache hit/miss, invalidation, force reload, LRU eviction, per-options keys, stats folding, and view-state reset on cross-repo cache hits, plus the split render helpers. Full suite: 422 passing.
