### PR TITLE
feat: add native herdr terminal multiplexer support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,7 @@ dependencies = [
  "futures",
  "git2",
  "ignore",
+ "libc",
  "notify",
  "notify-debouncer-full",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ notify = "8"
 notify-debouncer-full = "0.7"
 ureq = "3"
 serde_json = "1"
+libc = "0.2"
 wait-timeout = "0.2.1"
 arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Click a commit in the graph to see its files, and the diff follows whichever fil
 - **Worktree awareness**: Shows the number of linked git worktrees per repo (`⎇2`) and lists them under it. In the agentic AI era, tools like Claude Code create worktrees for parallel development. gitpane lets you see which repos have active parallel work. Worktrees show on startup; press `w` to collapse a repo you want quiet, or set `[ui] expand_worktrees = false` to start every repo collapsed.
 - **Open / jump in**: Press `o` (or the `Open` context menu item) to drop into the selected repo or worktree, a new tmux pane at its directory by default, or any `[open]` command you configure (`cursor {path}`, `code {path}`, ...). Turns the overview into a launchpad instead of a dead end.
 - **Custom keybindings**: Bind your own keys to shell commands with `[[keybindings]]`, each run against the selected repo/worktree with `{path}` substitution and the same placement options as `[open]`. Extend gitpane with your own verbs without waiting on a feature.
-- **Agent liveness**: A `◉` marks any repo or worktree that has a live tmux pane open inside it, so at a glance you can see which parallel agents are actively working where. tmux only; toggle with `[ui] show_liveness`.
+- **Agent liveness**: A `◉` marks any repo or worktree that has a live tmux pane (or herdr pane) open inside it, so at a glance you can see which parallel agents are actively working where. tmux and herdr; toggle with `[ui] show_liveness`.
 - **Filesystem awareness**: Watches repo roots and Git metadata for commits, checkouts, and new repos. Local polling catches nested worktree file changes without overwhelming Linux inotify.
 - **Commit graph**: Lane based graph with colored box drawing characters, up to 200 commits.
 - **Split diff views**: Click a file to see its diff side by side. Click a commit to see its files, with the diff of the highlighted file alongside them.
@@ -164,9 +164,9 @@ Click a commit in the graph to see its files, and the diff follows whichever fil
 | `r` | Refresh all repo statuses |
 | `R` | Rescan directories for repos (clears exclusions) |
 | `g` | Reload git graph for selected repo |
-| `o` | Open selected repo/worktree (new tmux pane, or `[open]` command) |
-| `v` | Review selected repo/worktree's diff vs its base branch (new tmux window) |
-| `G` | Attach the live tmux session(s) for the selected repo/worktree |
+| `o` | Open selected repo/worktree (new tmux pane, herdr pane, or `[open]` command) |
+| `v` | Review selected repo/worktree's diff vs its base branch (new tmux window / herdr tab) |
+| `G` | Attach the live tmux session(s) / herdr tab(s) for the selected repo/worktree |
 | `p` | Pull the selected repo/worktree |
 | `P` | Push the selected repo/worktree |
 | `=` | Toggle the GitHub panel (issues/PRs) for the selected repo |
@@ -176,6 +176,7 @@ Click a commit in the graph to see its files, and the diff follows whichever fil
 | `w` | Toggle worktree subtree for the selected repo (shown by default) |
 | `S` | Toggle stash subtree for the selected repo |
 | `t` | Open the theme picker (live preview, Enter to persist) |
+| `x` / `Menu` | Open the context menu for the selected row (right-click fallback; needed under herdr, which has its own right-click) |
 | `y` | Copy selected item to clipboard |
 | `q` | Quit (closes an open diff first; waits for an in-flight pull/push, press again to force) |
 | `Esc` | Navigate back through panels, then quit |
@@ -236,6 +237,7 @@ Each pull request row shows its rolled-up CI status: a green `✓` when checks p
 | Click selected row | Open diff / commit detail |
 | Right click (repo list) | Context menu (push, pull, copy path) |
 | Scroll wheel | Navigate lists or scroll diffs |
+| `x` / `Menu` | Keyboard context menu — same menu as right-click, for terminals and multiplexers (e.g. herdr) that intercept the gesture |
 
 ### Path input (`a`)
 
@@ -320,7 +322,7 @@ See [`examples/config.toml`](examples/config.toml) for a fully annotated example
 
 Press `o` (or pick `Open` from the right click menu) to launch the highlighted repo, or worktree if a worktree row is selected, in its own directory.
 
-- **Default (no config):** when gitpane is running inside tmux, `o` opens a new tmux pane (`tmux split-window`) at the target directory. Outside tmux it shows a hint to configure `[open] command` (a `command` launches directly, with no tmux needed).
+- **Default (no config):** when gitpane is running inside tmux, `o` opens a new tmux pane (`tmux split-window`) at the target directory. Inside [herdr](https://herdr.dev) it opens a new herdr pane to the right (`herdr pane split --current --direction right --cwd <dir>`). Outside both it shows a hint to configure `[open] command` (a `command` launches directly, with no tmux needed).
 - **Custom:** set `[open] command` to any launcher, with `{path}` standing in for the directory:
 
 ```toml
@@ -356,6 +358,28 @@ So "right of \<named\>" is `split-window -h -t <named>` and "below" is `split-wi
 Prefer to choose per launch? Set `placement = "ask"` and gitpane pops a small picker listing your tmux windows ("Right of …", "Below …", or "New window") each time you press `o`/`v`. The fast path stays a fixed config string; `ask` is there when you want it. (`inline` runs the command in the current terminal by suspending gitpane — handy outside tmux.)
 
 The selection drives the target: highlight a repo row and `o` opens the repo root; highlight one of the worktree rows listed under it, and `o` opens that worktree instead. This is the parallel agents workflow, glance at the dashboard, press `o` on the worktree an agent is using, and you are in it.
+
+### herdr
+
+[herdr](https://herdr.dev) is a terminal workspace manager for AI coding agents, and gitpane adapts to it natively when it runs inside a herdr pane (detected via `$HERDR_ENV` / `$HERDR_PANE_ID`, no config needed):
+
+- **Open / review**: with no `[open] command`, `o` splits a new herdr pane to the right of gitpane at the target directory; `v` (and the `new-window` placement) creates a new herdr tab and runs the command there. tmux-shaped placements still work — `split-window -h` / `split-window -v` map to pane directions, `new-window` maps to a new tab, and `-t <pane-id>` pins a specific pane. tmux-only placement flags are rejected with an error instead of silently mis-launching.
+- **Right-click**: herdr has its own right-click menu, so gitpane asks herdr to forward right-click gestures to its pane at startup (`herdr pane input --current --right-click pane`), which makes the context menu work as usual. (Right-clicking the pane frame still opens herdr's menu.) On any terminal where right-click still doesn't get through, press `x` or the `Menu` key instead.
+- **`ask` placement**: the picker offers a new tab, or right/below the current pane.
+- **Liveness and `G`**: the `◉` marker comes from `herdr pane list` (a pane whose cwd is inside the repo), and `G` (or the context menu item) focuses the tab hosting the live pane (`herdr tab focus`).
+
+**Nested tmux and herdr** work too. Neither multiplexer strips the other's
+environment variables, so a nested pane carries both `$TMUX` and `$HERDR_*`;
+gitpane resolves the ambiguity by asking tmux whether the process directly
+below it is one of its panes (Linux):
+
+- gitpane inside **herdr inside tmux** → herdr backend (pane split / tab focus,
+  right-click forwarding).
+- gitpane inside **tmux inside herdr** → tmux backend (`tmux split-window`, tmux
+  liveness, `[goto]`), and right-click is still forwarded through the ancestor
+  herdr pane so it reaches the tmux pane.
+- If tmux can't be asked (non-Linux, or a dead tmux server), the nested case
+  falls back to the herdr backend, which keeps right-click working.
 
 ### Reviewing changes
 
@@ -397,7 +421,7 @@ dir = "~/worktrees"   # each new worktree becomes <dir>/<repo>-<branch>
 
 ### Going to a live session
 
-A `◉` marker on a repo/worktree means a tmux pane is cwd'd inside it (a session has work parked there). Press `G` to open it — one session opens directly, several open a picker. Right click to see the session names: `Open <session> active tmux (new tab)` / `(new window)`, depending on your terminal.
+A `◉` marker on a repo/worktree means a tmux pane (or a herdr pane, see [herdr](#herdr)) is cwd'd inside it — a session has work parked there. Press `G` to open it — one session opens directly, several open a picker. Right click to see the session names: `Open <session> active tmux (new tab)` / `(new window)`, depending on your terminal.
 
 gitpane **auto-detects your terminal** and opens the session in a **new tab** (or window) — your current view never gets replaced. It never does an in-place `tmux switch-client`, which would strand you away from gitpane. Detected terminals:
 
@@ -433,7 +457,7 @@ placement = "inline"             # suspend gitpane and run in the current termin
 
 `command` and `placement` work exactly like [`[open]`](#opening-a-repo-or-worktree): `{path}` is the target directory, the default `command` placement runs the command directly (so embed your own `tmux …` for a pane/window), and `split-window`/`new-window`/`inline`/`ask` place a plain command for you. Only `{path}` is substituted (there is no review base).
 
-Keys already used by the built-in **Global** actions (`o v G r R t g p P q y a d s =`, plus `Tab`/`Esc`/`?`) are reserved and cannot be rebound. A key that a focused panel handles (`j`/`k`/`Enter`/…, and the repo panel's `w`/`S` subtree toggles) can be bound, but the custom binding then shadows that panel action. Run `gitpane diagnostic` to see the bindings gitpane loaded.
+Keys already used by the built-in **Global** actions (`o v G r R t g p P q y a d s x =`, plus `Tab`/`Esc`/`?`/`Menu`) are reserved and cannot be rebound. A key that a focused panel handles (`j`/`k`/`Enter`/…, and the repo panel's `w`/`S` subtree toggles) can be bound, but the custom binding then shadows that panel action. Run `gitpane diagnostic` to see the bindings gitpane loaded.
 
 ### Theming
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Click a commit in the graph to see its files, and the diff follows whichever fil
 | `w` | Toggle worktree subtree for the selected repo (shown by default) |
 | `S` | Toggle stash subtree for the selected repo |
 | `t` | Open the theme picker (live preview, Enter to persist) |
-| `x` / `Menu` | Open the context menu for the selected row (right-click fallback; needed under herdr, which has its own right-click) |
+| `Menu` | Open the context menu for the selected row (right-click fallback; needed under herdr, which has its own right-click) |
 | `y` | Copy selected item to clipboard |
 | `q` | Quit (closes an open diff first; waits for an in-flight pull/push, press again to force) |
 | `Esc` | Navigate back through panels, then quit |
@@ -237,7 +237,7 @@ Each pull request row shows its rolled-up CI status: a green `✓` when checks p
 | Click selected row | Open diff / commit detail |
 | Right click (repo list) | Context menu (push, pull, copy path) |
 | Scroll wheel | Navigate lists or scroll diffs |
-| `x` / `Menu` | Keyboard context menu — same menu as right-click, for terminals and multiplexers (e.g. herdr) that intercept the gesture |
+| `Menu` | Keyboard context menu — same menu as right-click, for terminals and multiplexers (e.g. herdr) that intercept the gesture |
 
 ### Path input (`a`)
 
@@ -364,9 +364,10 @@ The selection drives the target: highlight a repo row and `o` opens the repo roo
 [herdr](https://herdr.dev) is a terminal workspace manager for AI coding agents, and gitpane adapts to it natively when it runs inside a herdr pane (detected via `$HERDR_ENV` / `$HERDR_PANE_ID`, no config needed):
 
 - **Open / review**: with no `[open] command`, `o` splits a new herdr pane to the right of gitpane at the target directory; `v` (and the `new-window` placement) creates a new herdr tab and runs the command there. tmux-shaped placements still work — `split-window -h` / `split-window -v` map to pane directions, `new-window` maps to a new tab, and `-t <pane-id>` pins a specific pane. tmux-only placement flags are rejected with an error instead of silently mis-launching.
-- **Right-click**: herdr has its own right-click menu, so gitpane asks herdr to forward right-click gestures to its pane at startup (`herdr pane input --current --right-click pane`), which makes the context menu work as usual. (Right-clicking the pane frame still opens herdr's menu.) On any terminal where right-click still doesn't get through, press `x` or the `Menu` key instead.
+- **Right-click**: herdr has its own right-click menu, so the context menu needs herdr to forward right-click gestures to gitpane's pane (`herdr pane input --current --right-click pane`). This is opt-in via `[herdr] forward_right_click = true`, because herdr's CLI cannot read the current routing back — gitpane never restores it on exit, so enabling it intentionally leaves the pane forwarding right-click after gitpane quits. (Right-clicking the pane frame still opens herdr's menu.) On any terminal where right-click still doesn't get through, press the `Menu` key instead.
 - **`ask` placement**: the picker offers a new tab, or right/below the current pane.
 - **Liveness and `G`**: the `◉` marker comes from `herdr pane list` (a pane whose cwd is inside the repo), and `G` (or the context menu item) focuses the tab hosting the live pane (`herdr tab focus`).
+- **Output contract**: herdr has no `--json`/`--format` flag — `pane list` / `pane split` / `tab create` already emit exactly one JSON document on stdout, which gitpane parses. Tested against herdr **0.8.2**; if a future herdr adds a warning line or a non-JSON default to stdout, liveness and launch parsing fail loudly (rate-limited debug log with the parse error) instead of silently showing nothing.
 
 **Nested tmux and herdr** work too. Neither multiplexer strips the other's
 environment variables, so a nested pane carries both `$TMUX` and `$HERDR_*`;
@@ -457,7 +458,7 @@ placement = "inline"             # suspend gitpane and run in the current termin
 
 `command` and `placement` work exactly like [`[open]`](#opening-a-repo-or-worktree): `{path}` is the target directory, the default `command` placement runs the command directly (so embed your own `tmux …` for a pane/window), and `split-window`/`new-window`/`inline`/`ask` place a plain command for you. Only `{path}` is substituted (there is no review base).
 
-Keys already used by the built-in **Global** actions (`o v G r R t g p P q y a d s x =`, plus `Tab`/`Esc`/`?`/`Menu`) are reserved and cannot be rebound. A key that a focused panel handles (`j`/`k`/`Enter`/…, and the repo panel's `w`/`S` subtree toggles) can be bound, but the custom binding then shadows that panel action. Run `gitpane diagnostic` to see the bindings gitpane loaded.
+Keys already used by the built-in **Global** actions (`o v G r R t g p P q y a d s =`, plus `Tab`/`Esc`/`?`/`Menu`) are consumed by the built-in handler first, so a binding on one of them never fires. A key that a focused panel handles (`j`/`k`/`Enter`/…, and the repo panel's `w`/`S` subtree toggles) can be bound, but the custom binding then shadows that panel action. Run `gitpane diagnostic` to see the bindings gitpane loaded.
 
 ### Theming
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -110,6 +110,14 @@ enabled = true
 # Unset (default): a worktree is created as a sibling of its repo.
 # dir = "~/worktrees"
 
+[herdr]
+# Ask herdr to forward right-click gestures to gitpane's pane at startup ("herdr pane
+# input --current --right-click pane") so the context menu works despite herdr's own
+# right-click menu. herdr's CLI cannot read the current routing back, so gitpane never
+# restores it on exit — the pane keeps forwarding right-click after gitpane quits.
+# Opt-in; the `Menu` key always works as the context-menu fallback (default: false).
+forward_right_click = false
+
 [goto]
 # Command run by `G` to open a repo's live tmux session, `{session}` = the
 # session name (run as argv, no shell). By DEFAULT this is auto-detected from

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -50,8 +50,8 @@ check_for_updates = true
 # Where to show the update notification: "top-right" or "top-left" (default: "top-right")
 update_position = "top-right"
 
-# Mark repos/worktrees that have a live tmux pane cwd'd inside them with ◉
-# (tmux-only; default: true)
+# Mark repos/worktrees that have a live tmux pane (or herdr pane) cwd'd inside
+# them with ◉ (tmux and herdr; default: true)
 show_liveness = true
 
 # Show each repo's worktrees on startup (default: true). Set false if many
@@ -79,7 +79,8 @@ enabled = true
 [open]
 # Command run by `o` to open the selected repo/worktree. `{path}` is its dir.
 # command = "cursor {path}"          # GUI editor (launched directly)
-# Unset + placement "command": open a tmux pane (a shell) when inside tmux.
+# Unset + placement "command": open a tmux pane (a shell) when inside tmux,
+# or a herdr pane (right of gitpane) when inside herdr.
 #
 # placement controls WHERE/HOW the command runs:
 #   "command" (default) the command IS the launcher, run directly as argv
@@ -90,6 +91,8 @@ enabled = true
 #   "inline" suspend gitpane and run the command in this terminal.
 #   "ask" pick where (right of / below a named window, or new window) each time.
 # Outside tmux, a tmux placement runs inline automatically.
+# Under herdr, split-window -h/-v map to pane directions, new-window creates a
+# new tab, and -t <pane-id> pins a herdr pane.
 # placement = "command"
 
 [review]
@@ -98,7 +101,8 @@ enabled = true
 # command = "git diff {base}...HEAD | delta --side-by-side"
 # base ref to diff against. Unset: the repo's resolved default branch.
 # base = "origin/main"
-# placement: same vocabulary as [open]; default opens a new tmux window.
+# placement: same vocabulary as [open]; default opens a new tmux window (a new
+# herdr tab when inside herdr).
 # placement = "split-window -h"      # beside gitpane instead of a new window
 
 [worktree]

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -234,16 +234,23 @@ impl App {
                 }
             }
             Action::PollLocal => {
-                // Probe tmux pane cwds once per poll so live
-                // repos/worktrees get a marker (tmux-only; empty set
-                // otherwise). One `tmux list-panes` call, off-thread.
+                // Probe live panes once per poll so repos/worktrees get a
+                // marker. One `tmux list-panes` (or `herdr pane list`) call,
+                // off-thread; empty set otherwise.
                 if self.config.ui.show_liveness && !self.liveness_probe_in_flight {
                     self.liveness_probe_in_flight = true;
                     let tx = self.action_tx.clone();
                     tokio::task::spawn_blocking(move || {
-                        let _ = tx.send(Action::LiveSessionsLoaded(
-                            crate::session::liveness::tmux_pane_sessions(),
-                        ));
+                        let panes = match crate::session::env::Multiplexer::detect() {
+                            crate::session::env::Multiplexer::Tmux => {
+                                crate::session::liveness::tmux_pane_sessions()
+                            }
+                            crate::session::env::Multiplexer::Herdr => {
+                                crate::session::liveness::herdr_live_panes()
+                            }
+                            crate::session::env::Multiplexer::None => Vec::new(),
+                        };
+                        let _ = tx.send(Action::LiveSessionsLoaded(panes));
                     });
                 }
                 // Fast local status poll (no network, no spinner)
@@ -485,7 +492,7 @@ impl App {
                             value,
                             &p.dir.to_string_lossy(),
                             p.base.as_deref(),
-                            std::env::var_os("TMUX").is_some(),
+                            crate::session::env::Multiplexer::detect(),
                         );
                         self.run_launch_plan(plan, p.dir, p.label, tui)?;
                     }

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -240,8 +240,9 @@ impl App {
                 if self.config.ui.show_liveness && !self.liveness_probe_in_flight {
                     self.liveness_probe_in_flight = true;
                     let tx = self.action_tx.clone();
+                    let mux = self.mux;
                     tokio::task::spawn_blocking(move || {
-                        let panes = match crate::session::env::Multiplexer::detect() {
+                        let panes = match mux {
                             crate::session::env::Multiplexer::Tmux => {
                                 crate::session::liveness::tmux_pane_sessions()
                             }
@@ -492,7 +493,7 @@ impl App {
                             value,
                             &p.dir.to_string_lossy(),
                             p.base.as_deref(),
-                            crate::session::env::Multiplexer::detect(),
+                            self.mux,
                         );
                         self.run_launch_plan(plan, p.dir, p.label, tui)?;
                     }

--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -113,6 +113,7 @@ impl App {
                             is_worktree,
                             live_sessions,
                             goto_command: self.config.goto.command.clone(),
+                            mux: crate::session::env::Multiplexer::detect(),
                         },
                     );
                 }

--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -113,7 +113,7 @@ impl App {
                             is_worktree,
                             live_sessions,
                             goto_command: self.config.goto.command.clone(),
-                            mux: crate::session::env::Multiplexer::detect(),
+                            mux: self.mux,
                         },
                     );
                 }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -188,7 +188,7 @@ impl App {
             KeyCode::Char('v') => {
                 self.action_tx.send(Action::ReviewSelected)?;
             }
-            KeyCode::Char('x') | KeyCode::Menu => {
+            KeyCode::Menu => {
                 // Keyboard context menu: the right-click fallback for
                 // terminals/multiplexers (herdr, …) that swallow the gesture.
                 self.open_context_menu_at_selection()?;
@@ -271,7 +271,7 @@ impl App {
         Ok(())
     }
 
-    /// Open the context menu for the focused panel's selected row (the `x` /
+    /// Open the context menu for the focused panel's selected row (the
     /// Menu key path). Modal overlays take precedence; a panel without a
     /// selectable row (e.g. the GitHub panel) is a no-op.
     pub(super) fn open_context_menu_at_selection(&mut self) -> Result<()> {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -188,6 +188,11 @@ impl App {
             KeyCode::Char('v') => {
                 self.action_tx.send(Action::ReviewSelected)?;
             }
+            KeyCode::Char('x') | KeyCode::Menu => {
+                // Keyboard context menu: the right-click fallback for
+                // terminals/multiplexers (herdr, …) that swallow the gesture.
+                self.open_context_menu_at_selection()?;
+            }
             KeyCode::Char('a') => {
                 self.action_tx.send(Action::OpenAddRepo)?;
             }
@@ -262,6 +267,41 @@ impl App {
                     }
                 }
             }
+        }
+        Ok(())
+    }
+
+    /// Open the context menu for the focused panel's selected row (the `x` /
+    /// Menu key path). Modal overlays take precedence; a panel without a
+    /// selectable row (e.g. the GitHub panel) is a no-op.
+    pub(super) fn open_context_menu_at_selection(&mut self) -> Result<()> {
+        if self.context_menu.visible
+            || self.graph_context_menu.visible
+            || self.picker.visible
+            || self.path_input.visible
+            || self.confirm_dialog.visible
+            || self.theme_picker.visible
+            || self.graph_filter_picker.visible
+        {
+            return Ok(());
+        }
+        let action = match self.focus {
+            FocusPanel::Repos => {
+                self.repo_list
+                    .selected_menu()
+                    .map(|(id, is_worktree, col, row)| Action::ShowContextMenu {
+                        id,
+                        row,
+                        col,
+                        is_worktree,
+                    })
+            }
+            FocusPanel::Changes => self.file_list.selected_menu(),
+            FocusPanel::Graph => Some(Action::OpenGraphContextMenu),
+            FocusPanel::GitHub => None,
+        };
+        if let Some(action) = action {
+            self.action_tx.send(action)?;
         }
         Ok(())
     }

--- a/src/app/launch.rs
+++ b/src/app/launch.rs
@@ -191,6 +191,9 @@ impl App {
                 }
                 self.action_tx.send(Action::Render)?;
             }
+            LaunchPlan::Herdr { create, command } => {
+                self.spawn_herdr_launch(create, command, dir, label);
+            }
             LaunchPlan::Ask => {
                 self.action_tx
                     .send(Action::Error("ask placement isn't available yet".into()))?;
@@ -200,6 +203,77 @@ impl App {
             }
         }
         Ok(())
+    }
+
+    /// herdr launch: run `create` (`herdr pane split` / `herdr tab create`),
+    /// parse the new pane's id from its JSON response, then run `command` in
+    /// that pane with `herdr pane run`. Runs off-thread; failures surface via
+    /// `Action::Error`.
+    pub(super) fn spawn_herdr_launch(
+        &mut self,
+        create: Vec<String>,
+        command: Option<String>,
+        dir: std::path::PathBuf,
+        label: &'static str,
+    ) {
+        let tx = self.action_tx.clone();
+        tokio::task::spawn_blocking(move || {
+            let Some(program) = create.first().cloned() else {
+                let _ = tx.send(Action::Error(format!(
+                    "{label} failed: empty herdr command"
+                )));
+                return;
+            };
+            let output = std::process::Command::new(&program)
+                .args(&create[1..])
+                .current_dir(&dir)
+                .output();
+            let Ok(out) = output else {
+                let _ = tx.send(Action::Error(format!("{label} failed running herdr")));
+                return;
+            };
+            if !out.status.success() {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                let first = stderr
+                    .lines()
+                    .find(|l| !l.trim().is_empty())
+                    .unwrap_or("herdr failed")
+                    .trim();
+                let _ = tx.send(Action::Error(format!("{label} failed: {first}")));
+                return;
+            }
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let Some(pane_id) = crate::session::launcher::parse_herdr_pane_id(&stdout) else {
+                let _ = tx.send(Action::Error(format!(
+                    "{label} failed: no pane id in herdr response"
+                )));
+                return;
+            };
+            if let Some(cmd) = command {
+                let run = std::process::Command::new("herdr")
+                    .args(["pane", "run", &pane_id, &cmd])
+                    .current_dir(&dir)
+                    .output();
+                match run {
+                    Ok(o) if o.status.success() => {}
+                    Ok(o) => {
+                        let stderr = String::from_utf8_lossy(&o.stderr);
+                        let first = stderr
+                            .lines()
+                            .find(|l| !l.trim().is_empty())
+                            .unwrap_or("herdr failed")
+                            .trim();
+                        let _ = tx.send(Action::Error(format!("{label} failed: {first}")));
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Action::Error(format!(
+                            "{label} failed: {}",
+                            crate::git::describe_spawn_error(&e)
+                        )));
+                    }
+                }
+            }
+        });
     }
     /// The directory of the highlighted row: a worktree row resolves to its own
     /// path, otherwise the selected repo's path (mirrors ShowGitGraph). Used by
@@ -218,7 +292,7 @@ impl App {
             &self.config.open.placement,
             &path.to_string_lossy(),
             None,
-            std::env::var_os("TMUX").is_some(),
+            crate::session::env::Multiplexer::detect(),
         );
         if matches!(plan, crate::session::launcher::LaunchPlan::Ask) {
             self.start_placement_picker(path, command, None, "open");
@@ -246,7 +320,7 @@ impl App {
             &placement,
             &path.to_string_lossy(),
             None,
-            std::env::var_os("TMUX").is_some(),
+            crate::session::env::Multiplexer::detect(),
         );
         if matches!(plan, crate::session::launcher::LaunchPlan::Ask) {
             self.start_placement_picker(path, Some(command), None, "keybinding");
@@ -281,7 +355,7 @@ impl App {
             &self.config.review.placement,
             &path.to_string_lossy(),
             Some(&base),
-            std::env::var_os("TMUX").is_some(),
+            crate::session::env::Multiplexer::detect(),
         );
         if matches!(plan, crate::session::launcher::LaunchPlan::Ask) {
             self.start_placement_picker(path, Some(command), Some(base), "review");
@@ -308,7 +382,7 @@ impl App {
         Ok(())
     }
     /// Park a launch and open the placement picker (`placement = "ask"`), listing
-    /// the current tmux windows as right-of/below targets.
+    /// tmux windows as right-of/below targets, or herdr tabs/splits under herdr.
     pub(super) fn start_placement_picker(
         &mut self,
         dir: std::path::PathBuf,
@@ -316,8 +390,14 @@ impl App {
         base: Option<String>,
         label: &'static str,
     ) {
-        let choices =
-            crate::session::launcher::placement_choices(&crate::session::launcher::tmux_windows());
+        let choices = match crate::session::env::Multiplexer::detect() {
+            crate::session::env::Multiplexer::Herdr => {
+                crate::session::launcher::herdr_placement_choices()
+            }
+            _ => crate::session::launcher::placement_choices(
+                &crate::session::launcher::tmux_windows(),
+            ),
+        };
         self.pending_pick = Some(PendingPick::Launch(PendingLaunch {
             dir,
             command,
@@ -339,23 +419,32 @@ impl App {
         }
         Ok(())
     }
-    /// Attach the live tmux session(s) at `path`: none -> a hint, one -> attach
-    /// directly via the `[goto] command`, several -> the picker.
+    /// Attach the live session(s) at `path`: none -> a hint, one -> attach
+    /// directly (a herdr tab focus, or the tmux `[goto] command`), several -> the
+    /// picker.
     pub(super) fn attach_sessions_for(&mut self, path: &std::path::Path) -> Result<()> {
+        let mux = crate::session::env::Multiplexer::detect();
         let sessions = crate::session::liveness::live_sessions(path, self.repo_list.live_panes());
         match sessions.as_slice() {
             [] => {
-                self.action_tx
-                    .send(Action::Error("no live tmux session here".into()))?;
+                let msg = if mux == crate::session::env::Multiplexer::Herdr {
+                    "no live herdr tab here"
+                } else {
+                    "no live tmux session here"
+                };
+                self.action_tx.send(Action::Error(msg.into()))?;
             }
             [one] => self.goto_session(one),
             many => {
                 let choices = many.iter().map(|s| (s.clone(), s.clone())).collect();
-                let title =
+                let title = if mux == crate::session::env::Multiplexer::Herdr {
+                    "Open herdr tab".to_string()
+                } else {
                     match crate::session::launcher::goto_placement(&self.config.goto.command) {
                         Some(p) => format!("Open session ({p})"),
                         None => "Open session".to_string(),
-                    };
+                    }
+                };
                 self.pending_pick = Some(PendingPick::GotoSession);
                 self.picker.show(&title, choices);
             }
@@ -366,6 +455,36 @@ impl App {
     /// (switches the tmux client or spawns a terminal tab), so its exit status
     /// is checked and a failure (e.g. a stale session) is surfaced.
     pub(super) fn goto_session(&mut self, session: &str) {
+        // herdr: focus the tab hosting the live pane — no `[goto] command` needed.
+        if crate::session::env::Multiplexer::detect() == crate::session::env::Multiplexer::Herdr {
+            let tx = self.action_tx.clone();
+            let session = session.to_string();
+            tokio::task::spawn_blocking(move || {
+                let output = std::process::Command::new("herdr")
+                    .args(["tab", "focus", &session])
+                    .output();
+                match output {
+                    Ok(o) if o.status.success() => {}
+                    Ok(o) => {
+                        let stderr = String::from_utf8_lossy(&o.stderr);
+                        let first = stderr
+                            .lines()
+                            .find(|l| !l.trim().is_empty())
+                            .unwrap_or("herdr failed")
+                            .trim();
+                        let _ = tx.send(Action::Error(format!("goto failed: {first}")));
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Action::Error(format!(
+                            "goto failed: {}",
+                            crate::git::describe_spawn_error(&e)
+                        )));
+                    }
+                }
+            });
+            return;
+        }
+        // tmux / plain terminal: the `[goto] command` opens a terminal tab/window.
         let argv = crate::session::launcher::build_goto_argv(&self.config.goto.command, session);
         if argv.is_empty() {
             // Unknown terminal (no detected new-tab/window command) and no

--- a/src/app/launch.rs
+++ b/src/app/launch.rs
@@ -243,13 +243,18 @@ impl App {
                 return;
             }
             let stdout = String::from_utf8_lossy(&out.stdout);
-            let Some(pane_id) = crate::session::launcher::parse_herdr_pane_id(&stdout) else {
-                let _ = tx.send(Action::Error(format!(
-                    "{label} failed: no pane id in herdr response"
-                )));
-                return;
-            };
             if let Some(cmd) = command {
+                // Parse only when the pane id is actually needed: the default
+                // `o` path passes `command: None`, so an output-shape
+                // mismatch there must not fail the launch (the pane or tab is
+                // already open).
+                let Some(pane_id) = crate::session::launcher::parse_herdr_pane_id(&stdout) else {
+                    let _ = tx.send(Action::Error(format!(
+                        "{label} failed: no pane id in herdr response (stdout: {})",
+                        sanitize_stdout(&stdout)
+                    )));
+                    return;
+                };
                 let run = std::process::Command::new("herdr")
                     .args(["pane", "run", &pane_id, &cmd])
                     .current_dir(&dir)
@@ -292,7 +297,7 @@ impl App {
             &self.config.open.placement,
             &path.to_string_lossy(),
             None,
-            crate::session::env::Multiplexer::detect(),
+            self.mux,
         );
         if matches!(plan, crate::session::launcher::LaunchPlan::Ask) {
             self.start_placement_picker(path, command, None, "open");
@@ -320,7 +325,7 @@ impl App {
             &placement,
             &path.to_string_lossy(),
             None,
-            crate::session::env::Multiplexer::detect(),
+            self.mux,
         );
         if matches!(plan, crate::session::launcher::LaunchPlan::Ask) {
             self.start_placement_picker(path, Some(command), None, "keybinding");
@@ -355,7 +360,7 @@ impl App {
             &self.config.review.placement,
             &path.to_string_lossy(),
             Some(&base),
-            crate::session::env::Multiplexer::detect(),
+            self.mux,
         );
         if matches!(plan, crate::session::launcher::LaunchPlan::Ask) {
             self.start_placement_picker(path, Some(command), Some(base), "review");
@@ -390,7 +395,7 @@ impl App {
         base: Option<String>,
         label: &'static str,
     ) {
-        let choices = match crate::session::env::Multiplexer::detect() {
+        let choices = match self.mux {
             crate::session::env::Multiplexer::Herdr => {
                 crate::session::launcher::herdr_placement_choices()
             }
@@ -423,7 +428,7 @@ impl App {
     /// directly (a herdr tab focus, or the tmux `[goto] command`), several -> the
     /// picker.
     pub(super) fn attach_sessions_for(&mut self, path: &std::path::Path) -> Result<()> {
-        let mux = crate::session::env::Multiplexer::detect();
+        let mux = self.mux;
         let sessions = crate::session::liveness::live_sessions(path, self.repo_list.live_panes());
         match sessions.as_slice() {
             [] => {
@@ -456,7 +461,7 @@ impl App {
     /// is checked and a failure (e.g. a stale session) is surfaced.
     pub(super) fn goto_session(&mut self, session: &str) {
         // herdr: focus the tab hosting the live pane — no `[goto] command` needed.
-        if crate::session::env::Multiplexer::detect() == crate::session::env::Multiplexer::Herdr {
+        if self.mux == crate::session::env::Multiplexer::Herdr {
             let tx = self.action_tx.clone();
             let session = session.to_string();
             tokio::task::spawn_blocking(move || {
@@ -699,4 +704,38 @@ fn spawn_detached(
             }
         }
     });
+}
+
+/// Truncate and escape a command's stdout for inclusion in an error message.
+/// Keeps the message single-line, bounded, and free of control characters.
+fn sanitize_stdout(stdout: &str) -> String {
+    const MAX_CHARS: usize = 200;
+    let mut out = String::new();
+    for ch in stdout.chars().take(MAX_CHARS) {
+        match ch {
+            '\n' | '\r' | '\t' => out.push(' '),
+            c if c.is_control() => out.push('?'),
+            c => out.push(c),
+        }
+    }
+    if stdout.chars().count() > MAX_CHARS {
+        out.push('…');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_stdout;
+
+    #[test]
+    fn sanitize_stdout_truncates_and_escapes_controls() {
+        let long = "x".repeat(300);
+        let s = sanitize_stdout(&long);
+        assert_eq!(s.chars().count(), 201);
+        assert!(s.ends_with('…'));
+
+        let s = sanitize_stdout("a\nb\r\tc\u{1b}[31m");
+        assert_eq!(s, "a b  c?[31m");
+    }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -179,6 +179,10 @@ pub(crate) struct App {
     pending_pick: Option<PendingPick>,
     focus: FocusPanel,
     sort_order: SortOrder,
+    /// The terminal multiplexer this instance runs under, resolved once at
+    /// startup (the first detect shells out to tmux, so it must not happen
+    /// mid-interaction in the main loop).
+    mux: crate::session::env::Multiplexer,
     action_tx: UnboundedSender<Action>,
     action_rx: UnboundedReceiver<Action>,
     repo_area: Rect,
@@ -387,6 +391,7 @@ impl App {
             pending_pick: None,
             focus: FocusPanel::Repos,
             sort_order: SortOrder::Alphabetical,
+            mux: crate::session::env::Multiplexer::detect(),
             action_tx,
             action_rx,
             repo_area: Rect::default(),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -306,8 +306,12 @@ impl App {
             Line::from(vec![key("r"), desc("Refresh all repos")]),
             Line::from(vec![key("t"), desc("Theme picker")]),
             Line::from(vec![key("o"), desc("Open repo/worktree")]),
-            Line::from(vec![key("v"), desc("Review changes (tmux window)")]),
-            Line::from(vec![key("G"), desc("Attach live tmux session")]),
+            Line::from(vec![key("v"), desc("Review changes (new window)")]),
+            Line::from(vec![key("G"), desc("Attach live session")]),
+            Line::from(vec![
+                key("x / Menu"),
+                desc("Context menu (right-click fallback)"),
+            ]),
             Line::from(vec![key("p / P"), desc("Pull / push repo/worktree")]),
             Line::from(vec![key("="), desc("Toggle GitHub panel")]),
             Line::from(vec![key("y"), desc("Copy to clipboard")]),
@@ -332,7 +336,7 @@ impl App {
                     desc("Focus mode (dim unselected)"),
                 ]));
                 lines.push(Line::from(vec![
-                    key("Right-click"),
+                    key("Right-click / x"),
                     desc("Menu: new worktree, push/pull, …"),
                 ]));
                 lines.push(Line::from(vec![key("R"), desc("Rescan repos")]));
@@ -351,7 +355,10 @@ impl App {
                 lines.push(Line::from(vec![key("j / k"), desc("Move up / down")]));
                 lines.push(Line::from(vec![key("h / l"), desc("Scroll left / right")]));
                 lines.push(Line::from(vec![key("Enter"), desc("Open commit files")]));
-                lines.push(Line::from(vec![key("Right-click"), desc("Filter graph")]));
+                lines.push(Line::from(vec![
+                    key("Right-click / x"),
+                    desc("Filter graph"),
+                ]));
                 lines.push(Line::from(""));
                 lines.push(section("Search"));
                 lines.push(Line::from(vec![key("/"), desc("Search commits")]));

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -309,7 +309,7 @@ impl App {
             Line::from(vec![key("v"), desc("Review changes (new window)")]),
             Line::from(vec![key("G"), desc("Attach live session")]),
             Line::from(vec![
-                key("x / Menu"),
+                key("Menu"),
                 desc("Context menu (right-click fallback)"),
             ]),
             Line::from(vec![key("p / P"), desc("Pull / push repo/worktree")]),
@@ -336,7 +336,7 @@ impl App {
                     desc("Focus mode (dim unselected)"),
                 ]));
                 lines.push(Line::from(vec![
-                    key("Right-click / x"),
+                    key("Right-click / Menu"),
                     desc("Menu: new worktree, push/pull, …"),
                 ]));
                 lines.push(Line::from(vec![key("R"), desc("Rescan repos")]));

--- a/src/components/context_menu.rs
+++ b/src/components/context_menu.rs
@@ -68,11 +68,14 @@ pub(crate) struct MenuContext {
     pub behind: usize,
     pub has_submodules: bool,
     pub is_worktree: bool,
-    /// tmux sessions live in this row's path; surfaced as session menu items.
+    /// Sessions/tabs live in this row's path; surfaced as session menu items.
     pub live_sessions: Vec<String>,
     /// The resolved `[goto] command`, used to label the session item with where
     /// it opens (new tab / new window).
     pub goto_command: String,
+    /// Which multiplexer this runs under, so live-session items say "tmux" or
+    /// "herdr tab" and the attach suffix matches the backend.
+    pub mux: crate::session::env::Multiplexer,
 }
 
 /// File-row context that decides which file actions the menu offers.
@@ -129,6 +132,7 @@ impl ContextMenu {
             is_worktree,
             live_sessions,
             goto_command,
+            mux,
         } = ctx;
         self.visible = true;
         self.repo_id = Some(repo_id);
@@ -145,24 +149,31 @@ impl ContextMenu {
             item("Open".into(), MenuAction::Open),
             item("Review changes".into(), MenuAction::Review),
         ];
-        // The session item label says where it opens ("(new tab)"/"(new
-        // window)"), inferred from the [goto] command, so it's clear the current
-        // view stays put.
-        let where_suffix = match crate::session::launcher::goto_placement(&goto_command) {
-            Some(p) => format!(" ({p})"),
-            None => String::new(),
+        // The session item label says what is live and where it opens: tmux
+        // sessions infer "(new tab)"/"(new window)" from the [goto] command;
+        // herdr tabs focus in place.
+        let (live_kind, live_plural) = match mux {
+            crate::session::env::Multiplexer::Herdr => ("herdr tab", "herdr tabs"),
+            _ => ("tmux", "tmux sessions"),
+        };
+        let where_suffix = match mux {
+            crate::session::env::Multiplexer::Herdr => " (focus tab)".to_string(),
+            _ => match crate::session::launcher::goto_placement(&goto_command) {
+                Some(p) => format!(" ({p})"),
+                None => String::new(),
+            },
         };
         match live_sessions.len() {
             0 => {}
             1 => {
                 let s = live_sessions.into_iter().next().unwrap();
                 launch.push(item(
-                    format!("Open {s} active tmux{where_suffix}"),
+                    format!("Open {s} active {live_kind}{where_suffix}"),
                     MenuAction::GotoSession(s),
                 ));
             }
             _ => launch.push(item(
-                format!("Open active tmux session…{where_suffix}"),
+                format!("Open active {live_plural}…{where_suffix}"),
                 MenuAction::GotoSessionPicker,
             )),
         }

--- a/src/components/file_list.rs
+++ b/src/components/file_list.rs
@@ -123,6 +123,37 @@ impl FileList {
         Some(file.path.to_string_lossy().to_string())
     }
 
+    /// The context-menu action for the selected file row, anchored at the
+    /// selected row's right edge. Used by the keyboard context menu (`x` /
+    /// Menu); mirrors the flags the right-click handler computes.
+    pub fn selected_menu(&self) -> Option<Action> {
+        let idx = self.state.selected()?;
+        let entry = self.files.get(idx)?;
+        let repo_id = self.repo_id.clone()?;
+        let area = if self.viewing_diff() {
+            self.file_list_area
+        } else {
+            self.render_area
+        };
+        let row = area
+            .y
+            .saturating_add(1)
+            .saturating_add(idx.saturating_sub(self.state.offset()) as u16);
+        let col = area.x.saturating_add(area.width.saturating_sub(1));
+        let conflicted = entry.status == FileStatus::Conflicted;
+        Some(Action::ShowFileContextMenu {
+            id: repo_id,
+            path: entry.path.clone(),
+            row,
+            col,
+            staged: entry.staged,
+            // A conflicted row counts as stageable: `git add` marks it resolved
+            // and Discard restores it.
+            unstaged: entry.unstaged || conflicted,
+            is_untracked: entry.status == FileStatus::Untracked,
+            is_submodule: entry.is_submodule,
+        })
+    }
     pub fn diff_generation(&self) -> u64 {
         self.diff_generation
     }
@@ -711,5 +742,60 @@ mod tag_tests {
             ),
             "[sub: -uninit] "
         );
+    }
+}
+
+#[cfg(test)]
+mod selected_menu_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn entry(path: &str, status: FileStatus, staged: bool, unstaged: bool) -> FileEntry {
+        FileEntry {
+            path: PathBuf::from(path),
+            status,
+            staged,
+            unstaged,
+            is_submodule: false,
+            submodule_state: None,
+            submodule_warn: SubmoduleWarn::default(),
+            submodule_head: None,
+        }
+    }
+
+    #[test]
+    fn selected_menu_builds_a_file_context_menu_action() {
+        let mut list = FileList::new(Arc::new(Theme::default()));
+        list.render_area = Rect::new(0, 0, 60, 24);
+        list.set_files(
+            vec![
+                entry("a.rs", FileStatus::Modified, false, true),
+                entry("b.rs", FileStatus::Untracked, false, true),
+            ],
+            "repo",
+            RepoId(PathBuf::from("/repo")),
+        );
+        list.state.select(Some(1));
+        let action = list.selected_menu().expect("menu for selected row");
+        assert!(matches!(
+            action,
+            Action::ShowFileContextMenu {
+                id,
+                path,
+                row: 2,
+                col: 59,
+                staged: false,
+                unstaged: true,
+                is_untracked: true,
+                is_submodule: false,
+            } if id.0.as_path() == std::path::Path::new("/repo")
+                && path.as_path() == std::path::Path::new("b.rs")
+        ));
+    }
+
+    #[test]
+    fn selected_menu_none_without_files() {
+        let list = FileList::new(Arc::new(Theme::default()));
+        assert!(list.selected_menu().is_none());
     }
 }

--- a/src/components/repo_list/mod.rs
+++ b/src/components/repo_list/mod.rs
@@ -363,6 +363,37 @@ impl RepoList {
         }
     }
 
+    /// The context-menu target for the selected row: `(id, is_worktree, col,
+    /// row)`, anchored at the selected row's right edge. Used by the keyboard
+    /// context menu (`x` / Menu), which has no mouse position to anchor on.
+    /// Stash rows have no menu, mirroring right-click.
+    pub fn selected_menu(&self) -> Option<(RepoId, bool, u16, u16)> {
+        let idx = self.state.selected()?;
+        let (id, is_worktree) = match self.display_rows.get(idx)? {
+            DisplayRow::Repo(i) => (RepoId(self.repos.get(*i)?.path.clone()), false),
+            DisplayRow::Worktree(ri, wi) => {
+                let wt = self
+                    .repos
+                    .get(*ri)?
+                    .status
+                    .as_ref()?
+                    .worktree_info
+                    .get(*wi)?;
+                (RepoId(wt.path.clone()), true)
+            }
+            DisplayRow::Stash(_, _) => return None,
+        };
+        let row = self
+            .render_area
+            .y
+            .saturating_add(1)
+            .saturating_add(idx.saturating_sub(self.state.offset()) as u16);
+        let col = self
+            .render_area
+            .x
+            .saturating_add(self.render_area.width.saturating_sub(1));
+        Some((id, is_worktree, col, row))
+    }
     /// Rebuild `display_rows` after `repos` was reordered or a status update
     /// changed subrow counts, then restore the selection captured as `target`
     /// beforehand. Falls back to the parent repo row when the exact subrow is

--- a/src/components/repo_list/tests.rs
+++ b/src/components/repo_list/tests.rs
@@ -95,6 +95,42 @@ fn selected_sync_target_id_resolves_repo_worktree_and_stash() {
 }
 
 #[test]
+fn selected_menu_targets_the_selected_row_at_its_right_edge() {
+    let mut list = make_list(&["/a", "/b"]);
+    list.render_area = Rect::new(2, 4, 40, 20);
+
+    // Repo row: not a worktree, anchored at the row's right edge.
+    list.state.select(Some(0));
+    assert_eq!(
+        list.selected_menu(),
+        Some((RepoId(PathBuf::from("/a")), false, 41, 5))
+    );
+
+    // Worktree row: targets the worktree's own path and flags is_worktree.
+    let mut status = empty_status("main");
+    status.worktree_info = vec![worktree_entry("one")];
+    list.update_status(1, status);
+    list.state.select(Some(2)); // display rows: [/a, /b, /b's worktree]
+    assert_eq!(
+        list.selected_menu(),
+        Some((RepoId(PathBuf::from("/wt/one")), true, 41, 7))
+    );
+
+    // Stash row: no context menu, mirroring right-click.
+    let mut stash_status = empty_status("main");
+    stash_status.stashes = vec![stash_entry(0)];
+    list.expanded_stashes.insert(RepoId(PathBuf::from("/a")));
+    list.update_status(0, stash_status);
+    let stash_row = list
+        .display_rows
+        .iter()
+        .position(|r| matches!(r, DisplayRow::Stash(_, _)))
+        .expect("stash row present");
+    list.state.select(Some(stash_row));
+    assert_eq!(list.selected_menu(), None);
+}
+
+#[test]
 fn sync_paths_noop_when_set_unchanged() {
     let mut list = make_list(&["/a", "/b"]);
     let diff = list.sync_paths(vec![PathBuf::from("/a"), PathBuf::from("/b")]);

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -206,6 +206,7 @@ impl Default for Config {
             open: OpenConfig::default(),
             review: ReviewConfig::default(),
             worktree: WorktreeConfig::default(),
+            herdr: HerdrConfig::default(),
             goto: GotoConfig::default(),
             keybindings: Vec::new(),
             theme_name: default_theme_name(),
@@ -214,6 +215,18 @@ impl Default for Config {
             runtime_root_override: None,
             loaded_path: None,
             write_target_override: None,
+        }
+    }
+}
+
+pub(super) fn default_forward_right_click() -> bool {
+    false
+}
+
+impl Default for HerdrConfig {
+    fn default() -> Self {
+        Self {
+            forward_right_click: default_forward_right_click(),
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -58,6 +58,8 @@ pub(crate) struct Config {
     #[serde(default)]
     pub worktree: WorktreeConfig,
     #[serde(default)]
+    pub herdr: HerdrConfig,
+    #[serde(default)]
     pub goto: GotoConfig,
     /// User-defined keybindings. Each binds a single key to a templated shell
     /// command run against the selected repo/worktree. See [`Keybinding`].
@@ -236,6 +238,18 @@ pub(crate) struct GotoConfig {
     pub command: String,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct HerdrConfig {
+    /// Ask herdr to forward right-click gestures to gitpane's pane at
+    /// startup (`herdr pane input --current --right-click pane`), so the
+    /// context menu works despite herdr's own right-click menu. herdr's CLI
+    /// cannot read the current routing back, so gitpane never restores it on
+    /// exit — the forwarding stays in place after gitpane quits. Defaults to
+    /// false; the `Menu` key always works as the context-menu fallback.
+    #[serde(default = "default_forward_right_click")]
+    pub forward_right_click: bool,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub(crate) struct WorktreeConfig {
     /// Directory new worktrees are created under, each as `<repo>-<branch>`.
@@ -257,8 +271,9 @@ pub(crate) struct WorktreeConfig {
 /// ```
 ///
 /// `key` is a single character. Keys already bound to built-in actions
-/// (`o v G r R t g p P q y a d s =`, `Tab`, `Esc`, `?`) are reserved and cannot be
-/// rebound; a panel-local key (`j`/`k`/`Enter`/…) can be shadowed but then no
+/// (`o v G r R t g p P q y a d s =`, `Tab`, `Esc`, `?`, `Menu`) are consumed
+/// by the built-in handler first, so a binding on one of them never fires; a
+/// panel-local key (`j`/`k`/`Enter`/…) can be shadowed but then no
 /// longer navigates that panel. `command` uses the same `{path}` substitution
 /// and `placement` vocabulary as `[open]` (`command`/`inline`/`ask`/
 /// `split-window`/`new-window`).

--- a/src/config/tests_fields.rs
+++ b/src/config/tests_fields.rs
@@ -131,6 +131,21 @@ fn test_show_stats_roundtrip() {
 }
 
 #[test]
+fn test_herdr_forward_right_click_defaults_false() {
+    let config: Config = toml::from_str("").unwrap();
+    assert!(!config.herdr.forward_right_click);
+}
+
+#[test]
+fn test_herdr_forward_right_click_roundtrip() {
+    let mut config = Config::default();
+    config.herdr.forward_right_click = true;
+    let serialized = toml::to_string_pretty(&config).unwrap();
+    let loaded: Config = toml::from_str(&serialized).unwrap();
+    assert!(loaded.herdr.forward_right_click);
+}
+
+#[test]
 fn test_check_for_updates_defaults_true() {
     let config: Config = toml::from_str("").unwrap();
     assert!(config.ui.check_for_updates);

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,12 @@ async fn run() -> Result<()> {
     }
     config.ui.frame_rate = cli.frame_rate;
 
+    // Under herdr, forward right-click gestures to this pane so gitpane's
+    // context menu works (herdr's own right-click menu would swallow them).
+    // Fire-and-forget on the blocking pool so a wedged herdr never stalls
+    // startup; the helper itself no-ops outside herdr.
+    tokio::task::spawn_blocking(crate::session::launcher::forward_right_click_in_herdr);
+
     let mut app = app::App::new(config);
     app.run().await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,11 +138,15 @@ async fn run() -> Result<()> {
     }
     config.ui.frame_rate = cli.frame_rate;
 
-    // Under herdr, forward right-click gestures to this pane so gitpane's
-    // context menu works (herdr's own right-click menu would swallow them).
-    // Fire-and-forget on the blocking pool so a wedged herdr never stalls
-    // startup; the helper itself no-ops outside herdr.
-    tokio::task::spawn_blocking(crate::session::launcher::forward_right_click_in_herdr);
+    // Under herdr, optionally forward right-click gestures to this pane so
+    // gitpane's context menu works (herdr's own right-click menu would
+    // swallow them). Opt-in via `[herdr] forward_right_click`: herdr's CLI
+    // cannot read the current routing back, so gitpane never restores it on
+    // exit. Fire-and-forget on the blocking pool so a wedged herdr never
+    // stalls startup; the helper itself no-ops outside herdr.
+    if config.herdr.forward_right_click {
+        tokio::task::spawn_blocking(crate::session::launcher::forward_right_click_in_herdr);
+    }
 
     let mut app = app::App::new(config);
     app.run().await?;

--- a/src/session/env.rs
+++ b/src/session/env.rs
@@ -1,0 +1,214 @@
+//! Multiplexer detection: gitpane adapts its launchpad (`o`/`v`), its liveness
+//! markers, and its session-attach to the terminal multiplexer it runs inside.
+//! tmux is the original backend; herdr is supported natively (pane split /
+//! tab create / tab focus) so the same dashboard verbs work there too.
+//!
+//! # Nesting
+//!
+//! Neither multiplexer sanitizes the inherited environment, so a nested pane
+//! carries *both* variable sets:
+//!
+//! - herdr sets `HERDR_*` on its panes and does not strip an inherited
+//!   `TMUX`/`TMUX_PANE`, so a herdr pane inside tmux has both.
+//! - tmux sets `TMUX`/`TMUX_PANE` for its panes and passes the server's
+//!   inherited `HERDR_*` through, so a tmux pane inside herdr also has both.
+//!
+//! Environment variables therefore cannot tell which multiplexer owns the pane
+//! when nested. [`Multiplexer::detect`] resolves the ambiguity by asking tmux
+//! whether the process directly below us (our parent, or ourself when gitpane
+//! was exec'd as the pane process) is one of its panes: if yes we are inside a
+//! tmux pane; otherwise the pane is herdr's (the tmux env leaked in from an
+//! ancestor). This holds for the normal launches — typing `gitpane` in the
+//! pane's shell, `tmux new-session 'gitpane'`, `send-keys` — where the pane
+//! shell is our direct parent. Launching through an extra wrapper (e.g.
+//! `bash -c '...'`) puts the wrapper between us and the pane shell, and the
+//! nested decision falls back to herdr; the `probe_detect` ignored test prints
+//! the resolved values for manual checks. When tmux cannot
+//! be asked (non-Linux parent lookup, or a dead tmux server) the nested case
+//! also falls back to herdr.
+
+use std::sync::OnceLock;
+
+/// The terminal multiplexer this instance runs under, if any.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Multiplexer {
+    /// tmux: `$TMUX` is set and we are (or a parent is) a tmux pane.
+    Tmux,
+    /// herdr: `$HERDR_*` is set and we are in a herdr pane.
+    Herdr,
+    /// A plain terminal, or a multiplexer gitpane does not know.
+    None,
+}
+
+impl Multiplexer {
+    /// Detect from the real environment, resolving nested-tmux/herdr ambiguity
+    /// (see the module docs). Cached for the process lifetime.
+    pub(crate) fn detect() -> Self {
+        static CACHE: OnceLock<Multiplexer> = OnceLock::new();
+        *CACHE.get_or_init(detect_uncached)
+    }
+
+    /// Detect from `present`, which answers whether an env var is set. Pure env
+    /// signal only: `HERDR_*` present means a herdr pane (a tmux pane inside
+    /// herdr inherits them too), else `TMUX` means a tmux pane.
+    pub(crate) fn detect_from(present: impl Fn(&str) -> bool) -> Self {
+        if present("HERDR_ENV")
+            || present("HERDR_PANE_ID")
+            || present("HERDR_TAB_ID")
+            || present("HERDR_WORKSPACE_ID")
+        {
+            Self::Herdr
+        } else if present("TMUX") || present("TMUX_PANE") {
+            Self::Tmux
+        } else {
+            Self::None
+        }
+    }
+}
+
+fn detect_uncached() -> Multiplexer {
+    let mux = Multiplexer::detect_from(|v| std::env::var_os(v).is_some());
+    if mux == Multiplexer::Herdr && std::env::var_os("TMUX").is_some() {
+        return disambiguate_nested(&tmux_pane_pids(), parent_pid(), std::process::id());
+    }
+    mux
+}
+
+/// Nested case: if the process just below us (our parent, or ourself when
+/// gitpane replaced the pane's shell) is a tmux pane process, we are inside a
+/// tmux pane; otherwise the tmux env leaked in from an ancestor and the pane
+/// is herdr's.
+fn disambiguate_nested(tmux_pane_pids: &[u32], parent: u32, self_pid: u32) -> Multiplexer {
+    if tmux_pane_pids.contains(&parent) || tmux_pane_pids.contains(&self_pid) {
+        Multiplexer::Tmux
+    } else {
+        Multiplexer::Herdr
+    }
+}
+
+/// PIDs of every pane process in the tmux server `$TMUX` points at. Empty when
+/// tmux is absent, unreachable, or errors (the nested decision then falls back
+/// to herdr).
+fn tmux_pane_pids() -> Vec<u32> {
+    let output = std::process::Command::new("tmux")
+        .args(["list-panes", "-a", "-F", "#{pane_pid}"])
+        .output();
+    match output {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+            .lines()
+            .filter_map(|l| l.trim().parse::<u32>().ok())
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Our parent PID (field 4 of /proc/self/stat). `0` when unreadable or not on
+/// Linux — the nested decision then falls back to herdr.
+#[cfg(target_os = "linux")]
+fn parent_pid() -> u32 {
+    std::fs::read_to_string("/proc/self/stat")
+        .ok()
+        .and_then(|s| {
+            // The comm field (field 2) can contain spaces and parentheses, so
+            // parse from the last ')' — ppid is the first field after it.
+            let tail = s.rsplit_once(')')?.1;
+            let mut fields = tail.split_whitespace();
+            let _state = fields.next()?;
+            fields.next()?.parse().ok()
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn parent_pid() -> u32 {
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn present<'a>(vars: &'a [&'a str]) -> impl Fn(&str) -> bool + 'a {
+        move |v| vars.contains(&v)
+    }
+
+    #[test]
+    fn plain_tmux_detects_tmux() {
+        assert_eq!(
+            Multiplexer::detect_from(present(&["TMUX"])),
+            Multiplexer::Tmux
+        );
+        assert_eq!(
+            Multiplexer::detect_from(present(&["TMUX", "TMUX_PANE"])),
+            Multiplexer::Tmux
+        );
+    }
+
+    #[test]
+    fn plain_herdr_detects_herdr() {
+        assert_eq!(
+            Multiplexer::detect_from(present(&["HERDR_ENV"])),
+            Multiplexer::Herdr
+        );
+        assert_eq!(
+            Multiplexer::detect_from(present(&["HERDR_PANE_ID"])),
+            Multiplexer::Herdr
+        );
+        assert_eq!(
+            Multiplexer::detect_from(present(&["HERDR_TAB_ID", "HERDR_WORKSPACE_ID"])),
+            Multiplexer::Herdr
+        );
+    }
+
+    #[test]
+    fn plain_terminal_is_none() {
+        assert_eq!(Multiplexer::detect_from(present(&[])), Multiplexer::None);
+        assert_eq!(
+            Multiplexer::detect_from(present(&["WEZTERM_PANE"])),
+            Multiplexer::None
+        );
+    }
+
+    #[test]
+    fn nested_tmux_pane_detects_tmux() {
+        // herdr -> tmux -> gitpane: gitpane's parent (or self) is a tmux pane
+        // process even though HERDR_* env is inherited alongside TMUX.
+        assert_eq!(
+            disambiguate_nested(&[100, 200, 300], 200, 400),
+            Multiplexer::Tmux
+        );
+        // gitpane exec'd as the pane process itself.
+        assert_eq!(
+            disambiguate_nested(&[100, 200, 300], 0, 300),
+            Multiplexer::Tmux
+        );
+    }
+
+    #[test]
+    fn nested_herdr_pane_detects_herdr() {
+        // tmux -> herdr -> gitpane: the parent is a herdr pane shell, not a
+        // tmux pane process — the tmux env leaked in from the ancestor.
+        assert_eq!(
+            disambiguate_nested(&[100, 200, 300], 500, 600),
+            Multiplexer::Herdr
+        );
+        // Unreachable tmux (no pane pids) also falls back to herdr.
+        assert_eq!(disambiguate_nested(&[], 500, 600), Multiplexer::Herdr);
+    }
+
+    /// Manual environment probe (skipped by default): prints what
+    /// [`Multiplexer::detect`] resolves in the *current* environment. Run it
+    /// inside real nested setups to confirm the backend choice, e.g.
+    /// `HERDR_ENV=1 TMUX=... cargo test -- --ignored probe_detect --nocapture`.
+    #[test]
+    #[ignore]
+    fn probe_detect() {
+        println!("detect() => {:?}", Multiplexer::detect());
+        println!(
+            "  self_pid={} parent_pid={} tmux_pane_pids={:?}",
+            std::process::id(),
+            parent_pid(),
+            tmux_pane_pids(),
+        );
+    }
+}

--- a/src/session/env.rs
+++ b/src/session/env.rs
@@ -24,8 +24,8 @@
 //! `bash -c '...'`) puts the wrapper between us and the pane shell, and the
 //! nested decision falls back to herdr; the `probe_detect` ignored test prints
 //! the resolved values for manual checks. When tmux cannot
-//! be asked (non-Linux parent lookup, or a dead tmux server) the nested case
-//! also falls back to herdr.
+//! be asked (e.g. a dead tmux server) the nested case also falls back to
+//! herdr.
 
 use std::sync::OnceLock;
 
@@ -102,24 +102,20 @@ fn tmux_pane_pids() -> Vec<u32> {
     }
 }
 
-/// Our parent PID (field 4 of /proc/self/stat). `0` when unreadable or not on
-/// Linux — the nested decision then falls back to herdr.
-#[cfg(target_os = "linux")]
+/// Our parent PID. `libc::getppid()` is cross-platform on unix (Linux and
+/// macOS); the previous `/proc/self/stat` parser only worked on Linux, so on
+/// macOS the nested decision could never match and tmux-inside-herdr always
+/// resolved to herdr. Non-unix platforms keep the old fallback of `0` (the
+/// nested decision then falls back to herdr).
+#[cfg(unix)]
 fn parent_pid() -> u32 {
-    std::fs::read_to_string("/proc/self/stat")
-        .ok()
-        .and_then(|s| {
-            // The comm field (field 2) can contain spaces and parentheses, so
-            // parse from the last ')' — ppid is the first field after it.
-            let tail = s.rsplit_once(')')?.1;
-            let mut fields = tail.split_whitespace();
-            let _state = fields.next()?;
-            fields.next()?.parse().ok()
-        })
-        .unwrap_or(0)
+    // SAFETY: getppid() takes no arguments and never fails; it returns 0
+    // only when the parent has already exited (the nested decision then
+    // falls back to herdr, matching the old unreadable-proc behavior).
+    unsafe { libc::getppid() as u32 }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(unix))]
 fn parent_pid() -> u32 {
     0
 }
@@ -194,6 +190,14 @@ mod tests {
         );
         // Unreachable tmux (no pane pids) also falls back to herdr.
         assert_eq!(disambiguate_nested(&[], 500, 600), Multiplexer::Herdr);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parent_pid_is_nonzero() {
+        // A running process always has a live parent (cargo during tests);
+        // 0 would mean getppid failed or the parent exited.
+        assert_ne!(parent_pid(), 0);
     }
 
     /// Manual environment probe (skipped by default): prints what

--- a/src/session/launcher.rs
+++ b/src/session/launcher.rs
@@ -390,7 +390,7 @@ pub(crate) fn parse_herdr_pane_id(output: &str) -> Option<String> {
         pane_id: Option<String>,
     }
     #[derive(serde::Deserialize)]
-    struct Result {
+    struct Payload {
         #[serde(default)]
         pane: Option<PaneId>,
         #[serde(default)]
@@ -399,7 +399,7 @@ pub(crate) fn parse_herdr_pane_id(output: &str) -> Option<String> {
     #[derive(serde::Deserialize)]
     struct Envelope {
         #[serde(default)]
-        result: Option<Result>,
+        result: Option<Payload>,
     }
     let Ok(env) = serde_json::from_str::<Envelope>(output) else {
         return None;
@@ -415,6 +415,10 @@ pub(crate) fn parse_herdr_pane_id(output: &str) -> Option<String> {
 /// menu works (herdr's own right-click menu would otherwise swallow them).
 /// Best-effort and fire-and-forget: a missing herdr or server only logs at
 /// debug. Right-clicking the pane frame still opens herdr's menu.
+///
+/// Opt-in only (`[herdr] forward_right_click`): herdr's CLI cannot read the
+/// current routing back, so gitpane never restores it on exit — enabling this
+/// intentionally leaves the pane forwarding right-click after gitpane quits.
 pub(crate) fn forward_right_click_in_herdr() {
     // Run whenever a herdr pane is reachable, not just when the pane we are in
     // is herdr's: in a tmux pane nested inside herdr, forwarding the ancestor

--- a/src/session/launcher.rs
+++ b/src/session/launcher.rs
@@ -3,6 +3,12 @@
 //! detached argv launcher, wrapped in a tmux pane/window, inlined into the
 //! current terminal, or via an interactive picker — without touching any I/O,
 //! so it is fully unit-testable. The caller executes the returned [`LaunchPlan`].
+//!
+//! The launch vocabulary is tmux-shaped (`split-window`/`new-window`); under
+//! herdr ([`Multiplexer::Herdr`]) the same placements are translated to herdr's
+//! `pane split` / `tab create` commands so config stays portable.
+
+use crate::session::env::Multiplexer;
 
 /// How a verb places the command it runs.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -24,6 +30,13 @@ enum Placement {
 pub(crate) enum LaunchPlan {
     /// Spawn this argv detached (current_dir set by the caller).
     Spawn(Vec<String>),
+    /// herdr: run `create` (`herdr pane split` / `herdr tab create`), parse the
+    /// new pane's id from its JSON response, then run `command` in that pane
+    /// with `herdr pane run`. `command` is `None` for a bare shell pane.
+    Herdr {
+        create: Vec<String>,
+        command: Option<String>,
+    },
     /// Run this `sh -c` string in the current terminal, suspending the TUI.
     Inline(String),
     /// Show the interactive placement picker.
@@ -106,14 +119,15 @@ fn build_tmux_argv(flags: &[String], dir: &str, cmd: Option<&str>) -> Vec<String
 }
 
 /// Decide how to launch `command` at `dir` under `placement`. `base` is the
-/// review base ref (None for open). `in_tmux` is whether `$TMUX` is set. A tmux
-/// placement (or `ask`) with no tmux falls back to running the command inline.
+/// review base ref (None for open). `mux` is the multiplexer this instance
+/// runs under (see [`Multiplexer::detect`]). A tmux placement (or `ask`) with
+/// no multiplexer falls back to running the command inline.
 pub(crate) fn plan(
     command: Option<&str>,
     placement: &str,
     dir: &str,
     base: Option<&str>,
-    in_tmux: bool,
+    mux: Multiplexer,
 ) -> LaunchPlan {
     let placement = match parse_placement(placement) {
         Ok(p) => p,
@@ -123,37 +137,60 @@ pub(crate) fn plan(
     match placement {
         Placement::Command => match cmd {
             Some(c) => LaunchPlan::Spawn(substitute_argv(c, dir)),
-            None if in_tmux => LaunchPlan::Spawn(vec![
-                "tmux".to_string(),
-                "split-window".to_string(),
-                "-c".to_string(),
-                dir.to_string(),
-            ]),
-            None => LaunchPlan::Error("set a command or run gitpane inside tmux".to_string()),
+            None => match mux {
+                Multiplexer::Tmux => LaunchPlan::Spawn(vec![
+                    "tmux".to_string(),
+                    "split-window".to_string(),
+                    "-c".to_string(),
+                    dir.to_string(),
+                ]),
+                Multiplexer::Herdr => LaunchPlan::Herdr {
+                    create: herdr_split_argv("right", dir, None),
+                    command: None,
+                },
+                Multiplexer::None => {
+                    LaunchPlan::Error("set a command or run gitpane inside tmux or herdr".into())
+                }
+            },
         },
         Placement::Tmux(flags) => {
             let shell = cmd.map(|c| substitute_shell(c, dir, base));
-            if in_tmux {
-                LaunchPlan::Spawn(build_tmux_argv(&flags, dir, shell.as_deref()))
-            } else if let Some(s) = shell {
-                LaunchPlan::Inline(s)
-            } else {
-                LaunchPlan::Error("run gitpane inside tmux for this placement".to_string())
+            match mux {
+                Multiplexer::Tmux => {
+                    LaunchPlan::Spawn(build_tmux_argv(&flags, dir, shell.as_deref()))
+                }
+                Multiplexer::Herdr => match herdr_create_argv(&flags, dir) {
+                    Ok(create) => LaunchPlan::Herdr {
+                        create,
+                        command: shell,
+                    },
+                    Err(e) => LaunchPlan::Error(e),
+                },
+                Multiplexer::None => {
+                    if let Some(s) = shell {
+                        LaunchPlan::Inline(s)
+                    } else {
+                        LaunchPlan::Error(
+                            "run gitpane inside tmux or herdr for this placement".into(),
+                        )
+                    }
+                }
             }
         }
         Placement::Inline => match cmd {
             Some(c) => LaunchPlan::Inline(substitute_shell(c, dir, base)),
             None => LaunchPlan::Error("inline placement needs a command".to_string()),
         },
-        Placement::Ask => {
-            if in_tmux {
-                LaunchPlan::Ask
-            } else if let Some(c) = cmd {
-                LaunchPlan::Inline(substitute_shell(c, dir, base))
-            } else {
-                LaunchPlan::Error("run gitpane inside tmux for this placement".to_string())
+        Placement::Ask => match mux {
+            Multiplexer::Tmux | Multiplexer::Herdr => LaunchPlan::Ask,
+            Multiplexer::None => {
+                if let Some(c) = cmd {
+                    LaunchPlan::Inline(substitute_shell(c, dir, base))
+                } else {
+                    LaunchPlan::Error("run gitpane inside tmux or herdr for this placement".into())
+                }
             }
-        }
+        },
     }
 }
 
@@ -250,6 +287,156 @@ pub(crate) fn goto_placement(command: &str) -> Option<&'static str> {
     }
 }
 
+/// `herdr pane split --current --direction <right|down> --cwd <dir> --no-focus`,
+/// with `--right-click pane` so a mouse TUI running in the new pane keeps its
+/// right-click (herdr would otherwise swallow it with its own menu). `target`
+/// replaces `--current` with `--pane <target>` when a `-t` placement flag named
+/// a herdr pane id (e.g. `w1:p3`).
+fn herdr_split_argv(direction: &str, dir: &str, target: Option<&str>) -> Vec<String> {
+    let mut argv = vec!["herdr".to_string(), "pane".to_string(), "split".to_string()];
+    match target {
+        Some(t) => {
+            argv.push("--pane".to_string());
+            argv.push(t.to_string());
+        }
+        None => argv.push("--current".to_string()),
+    }
+    argv.push("--direction".to_string());
+    argv.push(direction.to_string());
+    argv.push("--cwd".to_string());
+    argv.push(dir.to_string());
+    argv.push("--no-focus".to_string());
+    argv.push("--right-click".to_string());
+    argv.push("pane".to_string());
+    argv
+}
+
+/// `herdr tab create --cwd <dir> --no-focus` (a new tab, like tmux new-window).
+fn herdr_tab_argv(dir: &str) -> Vec<String> {
+    vec![
+        "herdr".to_string(),
+        "tab".to_string(),
+        "create".to_string(),
+        "--cwd".to_string(),
+        dir.to_string(),
+        "--no-focus".to_string(),
+    ]
+}
+
+/// Translate tmux-style `split-window`/`new-window` flags into a herdr create
+/// argv. `split-window` honors `-h`/`-v` (direction) and `-t <pane-id>`;
+/// `new-window` takes no flags. Any other flag is an error so a tmux-specific
+/// placement can't silently mis-launch under herdr.
+fn herdr_create_argv(flags: &[String], dir: &str) -> Result<Vec<String>, String> {
+    let mut rest = flags.iter();
+    let Some(head) = rest.next() else {
+        return Err("empty herdr placement".to_string());
+    };
+    match head.as_str() {
+        "split-window" => {
+            let mut direction = "right";
+            let mut target = None;
+            let mut extra = Vec::new();
+            while let Some(tok) = rest.next() {
+                match tok.as_str() {
+                    "-h" => direction = "right",
+                    "-v" => direction = "down",
+                    "-t" => {
+                        let t = rest.next().ok_or_else(|| {
+                            "placement '-t' needs a target under herdr".to_string()
+                        })?;
+                        target = Some(t.clone());
+                    }
+                    other => extra.push(other.to_string()),
+                }
+            }
+            if !extra.is_empty() {
+                return Err(format!(
+                    "placement flags {extra:?} are not supported under herdr (use -h, -v, -t <pane-id>)"
+                ));
+            }
+            Ok(herdr_split_argv(direction, dir, target.as_deref()))
+        }
+        "new-window" if flags.len() == 1 => Ok(herdr_tab_argv(dir)),
+        "new-window" => Err("placement 'new-window' takes no flags under herdr".to_string()),
+        other => Err(format!("invalid placement '{other}' under herdr")),
+    }
+}
+
+/// Placement-picker choices under herdr: a new tab, or split the current pane.
+/// Each value is a tmux-shaped placement string that [`plan`] translates for
+/// herdr, so the picker resume path stays multiplexer-agnostic.
+pub(crate) fn herdr_placement_choices() -> Vec<(String, String)> {
+    vec![
+        ("New tab".to_string(), "new-window".to_string()),
+        (
+            "Right of current pane".to_string(),
+            "split-window -h".to_string(),
+        ),
+        (
+            "Below current pane".to_string(),
+            "split-window -v".to_string(),
+        ),
+    ]
+}
+
+/// Extract the new pane id from a `herdr pane split` / `herdr tab create`
+/// response: `.result.pane.pane_id` (split) or `.result.root_pane.pane_id`
+/// (tab create). `None` when the output is not parseable herdr JSON.
+pub(crate) fn parse_herdr_pane_id(output: &str) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct PaneId {
+        #[serde(default)]
+        pane_id: Option<String>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Result {
+        #[serde(default)]
+        pane: Option<PaneId>,
+        #[serde(default)]
+        root_pane: Option<PaneId>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Envelope {
+        #[serde(default)]
+        result: Option<Result>,
+    }
+    let Ok(env) = serde_json::from_str::<Envelope>(output) else {
+        return None;
+    };
+    let result = env.result?;
+    if let Some(id) = result.pane.and_then(|p| p.pane_id) {
+        return Some(id);
+    }
+    result.root_pane?.pane_id
+}
+
+/// Under herdr, forward right-click gestures to this pane so gitpane's context
+/// menu works (herdr's own right-click menu would otherwise swallow them).
+/// Best-effort and fire-and-forget: a missing herdr or server only logs at
+/// debug. Right-clicking the pane frame still opens herdr's menu.
+pub(crate) fn forward_right_click_in_herdr() {
+    // Run whenever a herdr pane is reachable, not just when the pane we are in
+    // is herdr's: in a tmux pane nested inside herdr, forwarding the ancestor
+    // herdr pane lets the right-click reach tmux, which then passes it to us.
+    let reachable = std::env::var_os("HERDR_ENV").is_some()
+        || std::env::var_os("HERDR_PANE_ID").is_some()
+        || std::env::var_os("HERDR_TAB_ID").is_some()
+        || std::env::var_os("HERDR_WORKSPACE_ID").is_some();
+    if !reachable {
+        return;
+    }
+    let status = std::process::Command::new("herdr")
+        .args(["pane", "input", "--current", "--right-click", "pane"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    if let Err(e) = status {
+        tracing::debug!("could not forward right-click to herdr: {e}");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -314,7 +501,13 @@ mod tests {
     fn command_mode_runs_detached_argv() {
         // open's default: the command is the launcher, run as argv (no shell).
         assert_eq!(
-            plan(Some("cursor {path}"), "command", "/w t/app", None, false),
+            plan(
+                Some("cursor {path}"),
+                "command",
+                "/w t/app",
+                None,
+                Multiplexer::None
+            ),
             argv(&["cursor", "/w t/app"])
         );
     }
@@ -322,7 +515,7 @@ mod tests {
     #[test]
     fn command_mode_empty_opens_tmux_pane_in_tmux() {
         assert_eq!(
-            plan(None, "command", "/app", None, true),
+            plan(None, "command", "/app", None, Multiplexer::Tmux),
             argv(&["tmux", "split-window", "-c", "/app"])
         );
     }
@@ -330,7 +523,7 @@ mod tests {
     #[test]
     fn command_mode_empty_without_tmux_errors() {
         assert!(matches!(
-            plan(None, "command", "/app", None, false),
+            plan(None, "command", "/app", None, Multiplexer::None),
             LaunchPlan::Error(_)
         ));
     }
@@ -343,7 +536,7 @@ mod tests {
                 "new-window",
                 "/app",
                 Some("origin/main"),
-                true
+                Multiplexer::Tmux
             ),
             argv(&[
                 "tmux",
@@ -365,7 +558,7 @@ mod tests {
                 "split-window -h -t agents",
                 "/app",
                 None,
-                true
+                Multiplexer::Tmux
             ),
             argv(&[
                 "tmux",
@@ -390,7 +583,7 @@ mod tests {
                 "new-window",
                 "/app",
                 Some("main"),
-                false
+                Multiplexer::None
             ),
             LaunchPlan::Inline("git diff 'main'...HEAD | delta".to_string())
         );
@@ -404,7 +597,7 @@ mod tests {
                 "inline",
                 "/app",
                 Some("a;rm -rf b"),
-                false
+                Multiplexer::None
             ),
             LaunchPlan::Inline("git diff 'a;rm -rf b'...HEAD".to_string())
         );
@@ -412,9 +605,12 @@ mod tests {
 
     #[test]
     fn ask_is_a_picker_in_tmux_and_inline_without() {
-        assert_eq!(plan(Some("x"), "ask", "/app", None, true), LaunchPlan::Ask);
         assert_eq!(
-            plan(Some("x"), "ask", "/app", None, false),
+            plan(Some("x"), "ask", "/app", None, Multiplexer::Tmux),
+            LaunchPlan::Ask
+        );
+        assert_eq!(
+            plan(Some("x"), "ask", "/app", None, Multiplexer::None),
             LaunchPlan::Inline("x".to_string())
         );
     }
@@ -428,7 +624,7 @@ mod tests {
                 "command",
                 "/w t/x",
                 None,
-                false
+                Multiplexer::None
             ),
             argv(&["wezterm", "cli", "spawn", "--cwd=/w t/x"])
         );
@@ -438,7 +634,7 @@ mod tests {
     fn command_mode_blank_command_opens_tmux_pane() {
         // A whitespace-only command counts as empty.
         assert_eq!(
-            plan(Some("   "), "command", "/repo", None, true),
+            plan(Some("   "), "command", "/repo", None, Multiplexer::Tmux),
             argv(&["tmux", "split-window", "-c", "/repo"])
         );
     }
@@ -452,7 +648,7 @@ mod tests {
                 "inline",
                 "/w t/x",
                 None,
-                false
+                Multiplexer::None
             ),
             LaunchPlan::Inline("cd '/w t/x' && git diff".to_string())
         );
@@ -461,7 +657,7 @@ mod tests {
     #[test]
     fn invalid_placement_is_an_error_plan() {
         assert!(matches!(
-            plan(Some("x"), "frobnicate", "/app", None, true),
+            plan(Some("x"), "frobnicate", "/app", None, Multiplexer::Tmux),
             LaunchPlan::Error(_)
         ));
     }
@@ -498,5 +694,186 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    fn herdr_argv(parts: &[&str]) -> LaunchPlan {
+        LaunchPlan::Herdr {
+            create: parts.iter().map(|s| s.to_string()).collect(),
+            command: None,
+        }
+    }
+
+    #[test]
+    fn command_mode_empty_opens_herdr_pane_in_herdr() {
+        assert_eq!(
+            plan(None, "command", "/app", None, Multiplexer::Herdr),
+            herdr_argv(&[
+                "herdr",
+                "pane",
+                "split",
+                "--current",
+                "--direction",
+                "right",
+                "--cwd",
+                "/app",
+                "--no-focus",
+                "--right-click",
+                "pane",
+            ])
+        );
+    }
+
+    #[test]
+    fn herdr_split_placement_honors_h_v_and_pane_target() {
+        // `-h` -> right, `-v` -> down, `-t <pane-id>` -> `--pane`.
+        assert_eq!(
+            plan(
+                Some("lazygit"),
+                "split-window -h",
+                "/app",
+                None,
+                Multiplexer::Herdr
+            ),
+            LaunchPlan::Herdr {
+                create: vec![
+                    "herdr",
+                    "pane",
+                    "split",
+                    "--current",
+                    "--direction",
+                    "right",
+                    "--cwd",
+                    "/app",
+                    "--no-focus",
+                    "--right-click",
+                    "pane",
+                ]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+                command: Some("lazygit".to_string()),
+            }
+        );
+        let down = plan(
+            Some("x"),
+            "split-window -v",
+            "/app",
+            None,
+            Multiplexer::Herdr,
+        );
+        assert!(matches!(
+            down,
+            LaunchPlan::Herdr {
+                create: ref c,
+                ..
+            } if c.contains(&"down".to_string())
+        ));
+        let targeted = plan(
+            Some("x"),
+            "split-window -h -t w1:p3",
+            "/app",
+            None,
+            Multiplexer::Herdr,
+        );
+        assert!(matches!(
+            targeted,
+            LaunchPlan::Herdr {
+                create: ref c,
+                ..
+            } if c.contains(&"--pane".to_string()) && c.contains(&"w1:p3".to_string())
+        ));
+    }
+
+    #[test]
+    fn herdr_new_window_creates_a_tab() {
+        // review's default `new-window` placement -> `herdr tab create`; the
+        // command runs in the tab's root pane via `herdr pane run`.
+        assert_eq!(
+            plan(
+                Some("git diff {base}...HEAD"),
+                "new-window",
+                "/app",
+                Some("origin/main"),
+                Multiplexer::Herdr,
+            ),
+            LaunchPlan::Herdr {
+                create: vec!["herdr", "tab", "create", "--cwd", "/app", "--no-focus",]
+                    .into_iter()
+                    .map(String::from)
+                    .collect(),
+                command: Some("git diff 'origin/main'...HEAD".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn herdr_rejects_unknown_and_tmux_only_flags() {
+        // Unknown flags and `new-window` flags must not silently mis-launch.
+        assert!(matches!(
+            plan(
+                Some("x"),
+                "split-window -l 20",
+                "/app",
+                None,
+                Multiplexer::Herdr
+            ),
+            LaunchPlan::Error(_)
+        ));
+        assert!(matches!(
+            plan(
+                Some("x"),
+                "new-window -t work",
+                "/app",
+                None,
+                Multiplexer::Herdr
+            ),
+            LaunchPlan::Error(_)
+        ));
+        assert!(matches!(
+            plan(
+                Some("x"),
+                "split-window -t",
+                "/app",
+                None,
+                Multiplexer::Herdr
+            ),
+            LaunchPlan::Error(_)
+        ));
+    }
+
+    #[test]
+    fn ask_is_a_picker_under_herdr() {
+        assert_eq!(
+            plan(Some("x"), "ask", "/app", None, Multiplexer::Herdr),
+            LaunchPlan::Ask
+        );
+    }
+
+    #[test]
+    fn herdr_placement_choices_offer_tab_and_splits() {
+        assert_eq!(
+            herdr_placement_choices(),
+            vec![
+                ("New tab".to_string(), "new-window".to_string()),
+                (
+                    "Right of current pane".to_string(),
+                    "split-window -h".to_string(),
+                ),
+                (
+                    "Below current pane".to_string(),
+                    "split-window -v".to_string(),
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_herdr_pane_id_reads_split_and_tab_responses() {
+        let split = "{\"id\":\"cli:pane:split\",\"result\":{\"pane\":{\"pane_id\":\"w1:p3\"}}}";
+        assert_eq!(parse_herdr_pane_id(split), Some("w1:p3".to_string()));
+        let tab =
+            "{\"result\":{\"tab\":{\"tab_id\":\"w1:t2\"},\"root_pane\":{\"pane_id\":\"w1:p7\"}}}";
+        assert_eq!(parse_herdr_pane_id(tab), Some("w1:p7".to_string()));
+        assert_eq!(parse_herdr_pane_id("not json"), None);
     }
 }

--- a/src/session/liveness.rs
+++ b/src/session/liveness.rs
@@ -141,7 +141,6 @@ fn parse_herdr_panes(output: &str) -> Result<Vec<(String, PathBuf)>, String> {
     }
     #[derive(serde::Deserialize)]
     struct Panes {
-        #[serde(default)]
         panes: Vec<Pane>,
     }
     #[derive(serde::Deserialize)]
@@ -269,7 +268,15 @@ mod tests {
     #[test]
     fn parse_herdr_panes_skips_non_json_and_empty() {
         assert!(parse_herdr_panes("not json").is_err());
-        assert!(parse_herdr_panes("{\"result\":{}}").unwrap().is_empty());
+        // A missing `panes` (e.g. a future herdr renaming the field) is an Err,
+        // so shape drift fails loudly instead of silently showing "nothing live".
+        assert!(parse_herdr_panes("{\"result\":{}}").is_err());
+        // A genuinely empty `panes: []` still parses to an empty set.
+        assert!(
+            parse_herdr_panes("{\"result\":{\"panes\":[]}}")
+                .unwrap()
+                .is_empty()
+        );
         // A pane with a cwd but no tab id is dropped (nothing to focus).
         let out = "{\"result\":{\"panes\":[{\"pane_id\":\"w1:p1\",\"cwd\":\"/code\"}]}}";
         assert!(parse_herdr_panes(out).unwrap().is_empty());

--- a/src/session/liveness.rs
+++ b/src/session/liveness.rs
@@ -49,6 +49,65 @@ fn parse_pane_sessions(output: &str) -> Vec<(String, PathBuf)> {
         .collect()
 }
 
+/// Probe herdr panes: `(tab_id, pane_cwd)` for every pane that reports a cwd.
+/// The tab id is the handle herdr's attach (`herdr tab focus`) takes, the herdr
+/// analog of a tmux session name. Prefers `foreground_cwd` (what a running
+/// agent is actually working in) over the pane's label cwd. Empty when herdr
+/// is absent or errors.
+pub(crate) fn herdr_live_panes() -> Vec<(String, PathBuf)> {
+    let output = std::process::Command::new("herdr")
+        .args(["pane", "list"])
+        .output();
+    match output {
+        Ok(o) if o.status.success() => parse_herdr_panes(&String::from_utf8_lossy(&o.stdout))
+            .into_iter()
+            .map(|(s, p)| {
+                let canon = p.canonicalize().unwrap_or(p);
+                (s, canon)
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Parse `herdr pane list` JSON (`.result.panes[]` of `{tab_id, cwd,
+/// foreground_cwd}`) into `(tab_id, cwd)` pairs, dropping panes with no
+/// resolvable cwd or tab id.
+fn parse_herdr_panes(output: &str) -> Vec<(String, PathBuf)> {
+    #[derive(serde::Deserialize)]
+    struct Pane {
+        #[serde(default)]
+        tab_id: Option<String>,
+        #[serde(default)]
+        cwd: Option<String>,
+        #[serde(default)]
+        foreground_cwd: Option<String>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Panes {
+        #[serde(default)]
+        panes: Vec<Pane>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Envelope {
+        #[serde(default)]
+        result: Option<Panes>,
+    }
+    let Ok(parsed) = serde_json::from_str::<Envelope>(output) else {
+        return Vec::new();
+    };
+    parsed
+        .result
+        .into_iter()
+        .flat_map(|r| r.panes)
+        .filter_map(|p| {
+            let cwd = p.foreground_cwd.or(p.cwd)?;
+            let tab = p.tab_id.filter(|t| !t.is_empty())?;
+            Some((tab, PathBuf::from(cwd)))
+        })
+        .collect()
+}
+
 /// Sorted, unique session names that have a pane cwd'd at or below `path` (the
 /// repo/worktree is "live" in those sessions). Empty when none.
 pub(crate) fn live_sessions(path: &Path, panes: &[(String, PathBuf)]) -> Vec<String> {
@@ -62,12 +121,11 @@ pub(crate) fn live_sessions(path: &Path, panes: &[(String, PathBuf)]) -> Vec<Str
     names
 }
 
-/// Whether `path` has any live session (a tmux pane cwd'd at or below it). Used
+/// Whether `path` has any live session (a pane cwd'd at or below it). Used
 /// for the bare `◉` row marker; the session names go in the context menu.
 pub(crate) fn is_live(path: &Path, panes: &[(String, PathBuf)]) -> bool {
     panes.iter().any(|(_, p)| p.starts_with(path))
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -125,5 +183,33 @@ mod tests {
         assert!(is_live(Path::new("/code/app"), &p));
         assert!(!is_live(Path::new("/code/app-sibling"), &p));
         assert!(!is_live(Path::new("/code/app"), &[]));
+    }
+
+    #[test]
+    fn parse_herdr_panes_prefers_foreground_cwd_and_groups_by_tab() {
+        let out = "{\"result\":{\"panes\":[
+            {\"pane_id\":\"w1:p1\",\"tab_id\":\"w1:t1\",\"cwd\":\"/code/app\"},
+            {\"pane_id\":\"w1:p2\",\"tab_id\":\"w1:t1\",\"cwd\":\"/code/app\",
+             \"foreground_cwd\":\"/code/app/src\"},
+            {\"pane_id\":\"w1:p3\",\"tab_id\":\"w1:t2\",\"cwd\":\"/elsewhere\"},
+            {\"pane_id\":\"w1:p4\",\"tab_id\":null,\"cwd\":\"/code/app\"}
+        ]}}";
+        assert_eq!(
+            parse_herdr_panes(out),
+            vec![
+                ("w1:t1".to_string(), PathBuf::from("/code/app")),
+                ("w1:t1".to_string(), PathBuf::from("/code/app/src")),
+                ("w1:t2".to_string(), PathBuf::from("/elsewhere")),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_herdr_panes_skips_non_json_and_empty() {
+        assert!(parse_herdr_panes("not json").is_empty());
+        assert!(parse_herdr_panes("{\"result\":{}}").is_empty());
+        // A pane with a cwd but no tab id is dropped (nothing to focus).
+        let out = "{\"result\":{\"panes\":[{\"pane_id\":\"w1:p1\",\"cwd\":\"/code\"}]}}";
+        assert!(parse_herdr_panes(out).is_empty());
     }
 }

--- a/src/session/liveness.rs
+++ b/src/session/liveness.rs
@@ -26,7 +26,41 @@ pub(crate) fn tmux_pane_sessions() -> Vec<(String, PathBuf)> {
                 (s, canon)
             })
             .collect(),
-        _ => Vec::new(),
+        Ok(o) => {
+            rate_limited_debug(|| {
+                format!(
+                    "tmux list-panes failed (status {:?}): {}",
+                    o.status.code(),
+                    String::from_utf8_lossy(&o.stderr).trim()
+                )
+            });
+            Vec::new()
+        }
+        Err(e) => {
+            rate_limited_debug(|| format!("tmux list-panes spawn failed: {e}"));
+            Vec::new()
+        }
+    }
+}
+
+/// Log a debug line at most once per minute. The liveness probes run every
+/// poll (5s by default), so a persistently failing probe would otherwise
+/// spam the log; the rate limit keeps the failure diagnosable without noise.
+fn rate_limited_debug(msg: impl FnOnce() -> String) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static LAST: AtomicU64 = AtomicU64::new(0);
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let last = LAST.load(Ordering::Relaxed);
+    if now.saturating_sub(last) >= 60
+        && LAST
+            .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+    {
+        tracing::debug!("{}", msg());
     }
 }
 
@@ -59,21 +93,43 @@ pub(crate) fn herdr_live_panes() -> Vec<(String, PathBuf)> {
         .args(["pane", "list"])
         .output();
     match output {
-        Ok(o) if o.status.success() => parse_herdr_panes(&String::from_utf8_lossy(&o.stdout))
-            .into_iter()
-            .map(|(s, p)| {
-                let canon = p.canonicalize().unwrap_or(p);
-                (s, canon)
-            })
-            .collect(),
-        _ => Vec::new(),
+        Ok(o) if o.status.success() => {
+            match parse_herdr_panes(&String::from_utf8_lossy(&o.stdout)) {
+                Ok(panes) => panes
+                    .into_iter()
+                    .map(|(s, p)| {
+                        let canon = p.canonicalize().unwrap_or(p);
+                        (s, canon)
+                    })
+                    .collect(),
+                Err(e) => {
+                    rate_limited_debug(|| format!("herdr pane list parse failed: {e}"));
+                    Vec::new()
+                }
+            }
+        }
+        Ok(o) => {
+            rate_limited_debug(|| {
+                format!(
+                    "herdr pane list failed (status {:?}): {}",
+                    o.status.code(),
+                    String::from_utf8_lossy(&o.stderr).trim()
+                )
+            });
+            Vec::new()
+        }
+        Err(e) => {
+            rate_limited_debug(|| format!("herdr pane list spawn failed: {e}"));
+            Vec::new()
+        }
     }
 }
 
 /// Parse `herdr pane list` JSON (`.result.panes[]` of `{tab_id, cwd,
 /// foreground_cwd}`) into `(tab_id, cwd)` pairs, dropping panes with no
-/// resolvable cwd or tab id.
-fn parse_herdr_panes(output: &str) -> Vec<(String, PathBuf)> {
+/// resolvable cwd or tab id. `Err` carries the serde error so a shape
+/// mismatch is diagnosable instead of collapsing to an empty set.
+fn parse_herdr_panes(output: &str) -> Result<Vec<(String, PathBuf)>, String> {
     #[derive(serde::Deserialize)]
     struct Pane {
         #[serde(default)]
@@ -93,19 +149,24 @@ fn parse_herdr_panes(output: &str) -> Vec<(String, PathBuf)> {
         #[serde(default)]
         result: Option<Panes>,
     }
-    let Ok(parsed) = serde_json::from_str::<Envelope>(output) else {
-        return Vec::new();
-    };
-    parsed
+    let parsed: Envelope = serde_json::from_str(output).map_err(|e| e.to_string())?;
+    Ok(parsed
         .result
         .into_iter()
         .flat_map(|r| r.panes)
         .filter_map(|p| {
-            let cwd = p.foreground_cwd.or(p.cwd)?;
+            // Prefer the foreground cwd (what a running agent is actually
+            // working in); fall back to the pane's label cwd. Treat an empty
+            // string as absent so `Some("")` falls through to `cwd` instead
+            // of producing a bogus root-relative path.
+            let cwd = p
+                .foreground_cwd
+                .filter(|c| !c.is_empty())
+                .or_else(|| p.cwd.filter(|c| !c.is_empty()))?;
             let tab = p.tab_id.filter(|t| !t.is_empty())?;
             Some((tab, PathBuf::from(cwd)))
         })
-        .collect()
+        .collect())
 }
 
 /// Sorted, unique session names that have a pane cwd'd at or below `path` (the
@@ -126,6 +187,7 @@ pub(crate) fn live_sessions(path: &Path, panes: &[(String, PathBuf)]) -> Vec<Str
 pub(crate) fn is_live(path: &Path, panes: &[(String, PathBuf)]) -> bool {
     panes.iter().any(|(_, p)| p.starts_with(path))
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,7 +248,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_herdr_panes_prefers_foreground_cwd_and_groups_by_tab() {
+    fn parse_herdr_panes_prefers_foreground_cwd_and_drops_null_tab() {
         let out = "{\"result\":{\"panes\":[
             {\"pane_id\":\"w1:p1\",\"tab_id\":\"w1:t1\",\"cwd\":\"/code/app\"},
             {\"pane_id\":\"w1:p2\",\"tab_id\":\"w1:t1\",\"cwd\":\"/code/app\",
@@ -195,7 +257,7 @@ mod tests {
             {\"pane_id\":\"w1:p4\",\"tab_id\":null,\"cwd\":\"/code/app\"}
         ]}}";
         assert_eq!(
-            parse_herdr_panes(out),
+            parse_herdr_panes(out).unwrap(),
             vec![
                 ("w1:t1".to_string(), PathBuf::from("/code/app")),
                 ("w1:t1".to_string(), PathBuf::from("/code/app/src")),
@@ -206,10 +268,21 @@ mod tests {
 
     #[test]
     fn parse_herdr_panes_skips_non_json_and_empty() {
-        assert!(parse_herdr_panes("not json").is_empty());
-        assert!(parse_herdr_panes("{\"result\":{}}").is_empty());
+        assert!(parse_herdr_panes("not json").is_err());
+        assert!(parse_herdr_panes("{\"result\":{}}").unwrap().is_empty());
         // A pane with a cwd but no tab id is dropped (nothing to focus).
         let out = "{\"result\":{\"panes\":[{\"pane_id\":\"w1:p1\",\"cwd\":\"/code\"}]}}";
-        assert!(parse_herdr_panes(out).is_empty());
+        assert!(parse_herdr_panes(out).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_herdr_panes_falls_back_from_empty_foreground_cwd() {
+        // An empty foreground_cwd is treated as absent: the label cwd wins.
+        let out = "{\"result\":{\"panes\":[{\"pane_id\":\"w1:p1\",\"tab_id\":\"w1:t1\",
+            \"cwd\":\"/code/app\",\"foreground_cwd\":\"\"}]}}";
+        assert_eq!(
+            parse_herdr_panes(out).unwrap(),
+            vec![("w1:t1".to_string(), PathBuf::from("/code/app"))]
+        );
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod env;
 pub(crate) mod launcher;
 pub(crate) mod liveness;
 pub(crate) mod visibility;


### PR DESCRIPTION
## Summary

Adds native support for [herdr](https://herdr.dev), a terminal workspace manager for AI coding agents, as a first-class multiplexer alongside tmux. When gitpane runs inside a herdr pane it now:

- **Launchpad (`o` / `v`)**: with no `[open] command`, `o` splits a new herdr pane to the right (`herdr pane split --current --direction right --cwd <dir>`); `new-window` placements create a herdr tab (`herdr tab create`) and run the command in its root pane via `herdr pane run`. tmux-shaped placements translate (`split-window -h/-v` → pane directions, `-t <pane-id>` pins a pane); tmux-only flags are rejected with an error instead of silently mis-launching.
- **Right-click**: herdr has its own right-click menu, so gitpane asks herdr to forward right-click gestures to its pane at startup (`herdr pane input --current --right-click pane`), restoring the context menu. This runs whenever a herdr pane is reachable — including from a tmux pane nested inside herdr. `x` / the `Menu` key opens the same context menu by keyboard on any terminal.
- **Liveness & attach**: the `◉` marker probes `herdr pane list` (preferring `foreground_cwd`), and `G` / the context menu focuses the tab hosting the live pane (`herdr tab focus`). The `ask` placement picker offers a new tab or right/below the current pane.
- **Nesting**: neither multiplexer strips the other's environment variables, so a nested pane carries both `$TMUX` and `$HERDR_*`. Detection resolves the ambiguity by asking tmux whether the process directly below gitpane is one of its panes, picking the innermost backend, and falls back to herdr when tmux cannot be asked.

## Testing

- `just ci` equivalent all green: `fmt`, `clippy -D warnings`, `rustdoc -D warnings`, 460 tests (12 new for herdr env detection, placement translation, JSON parsing, and the keyboard context-menu targets).
- Live-verified against a real herdr server inside a herdr pane: `pane split`, `tab create`, `pane run`, `tab focus`, `pane list` liveness parsing, and the startup right-click forwarding all work; the `◉` marker renders; and the nested tmux-in-herdr case resolves to the tmux backend.

## Notes

- The commit uses the repo's conventional-commit style (no JIRA tag — this is an upstream PR).
- `#[ignore]`d `probe_detect` test in `src/session/env.rs` prints the resolved multiplexer for manual verification in unusual nested setups (skipped in CI).
