### PR TITLE
fix: kill timed-out fetch as a process group to avoid orphaned ssh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,7 @@ dependencies = [
  "futures",
  "git2",
  "ignore",
+ "libc",
  "notify",
  "notify-debouncer-full",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ notify = "8"
 notify-debouncer-full = "0.7"
 ureq = "3"
 serde_json = "1"
+libc = "0.2"
 wait-timeout = "0.2.1"
 arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
 

--- a/src/git/status/mod.rs
+++ b/src/git/status/mod.rs
@@ -9,6 +9,8 @@ mod test_support;
 #[cfg(test)]
 mod tests_basic;
 #[cfg(test)]
+mod tests_fetch_kill;
+#[cfg(test)]
 mod tests_refs;
 #[cfg(test)]
 mod tests_submodule;

--- a/src/git/status/tests_fetch_kill.rs
+++ b/src/git/status/tests_fetch_kill.rs
@@ -1,0 +1,60 @@
+//! Tests for the process-group kill used by the fetch timeout path.
+//!
+//! `git fetch` spawns an `ssh` child for ssh remotes; killing only the git
+//! process leaves that ssh orphaned with its server-side connection alive.
+//! The fix spawns the fetch in its own process group and kills the group, so
+//! this test asserts that a process-group kill takes grandchildren down too.
+#![cfg(unix)]
+
+use super::worktree::kill_process_group;
+
+/// sh forks a `sleep` grandchild, prints its pid, then waits on it — the
+/// same parent/grandchild shape as `git fetch` + `ssh`.
+#[test]
+fn process_group_kill_takes_grandchildren() {
+    use std::io::BufRead;
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new("sh")
+        .arg("-c")
+        // sleep inherits sh's stdin but not the stdout pipe: only sh may
+        // write to it, so the pid line below is readable without waiting
+        // for sleep to exit.
+        .arg("sleep 60 2>/dev/null & echo $!; wait")
+        .process_group(0)
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn sh");
+
+    let mut line = String::new();
+    std::io::BufReader::new(child.stdout.take().expect("sh stdout"))
+        .read_line(&mut line)
+        .expect("read grandchild pid");
+    let grandchild: i32 = line.trim().parse().expect("grandchild pid");
+
+    // Sanity: the grandchild is alive before the kill.
+    assert_eq!(
+        unsafe { libc::kill(grandchild, 0) },
+        0,
+        "grandchild should be alive before the kill"
+    );
+
+    kill_process_group(&mut child);
+    let _ = child.wait();
+
+    // SIGKILL is immediate, but the orphaned grandchild is reaped by init,
+    // which may take a moment — poll for ESRCH with a generous bound.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let rc = unsafe { libc::kill(grandchild, 0) };
+        if rc == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "grandchild still alive or unreaped 5s after the process-group kill"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}

--- a/src/git/status/worktree.rs
+++ b/src/git/status/worktree.rs
@@ -63,25 +63,24 @@ pub(super) fn collect_worktree_info(
 /// Run `git fetch` with a 30-second timeout to update remote-tracking refs.
 /// Uses the CLI because git2 fetch doesn't support SSH agent / credential helpers
 /// out of the box. Returns `true` on success, `false` on failure/timeout.
+///
+/// The fetch runs in its own process group so a timeout kill takes the whole
+/// tree down with it: `git fetch` over SSH leaves a detached `ssh`
+/// (git-upload-pack) child behind if only the git process is killed, and that
+/// orphan keeps the server-side connection alive until the network gives up.
 pub(super) fn fetch_remote_silent(path: &Path) -> bool {
     use wait_timeout::ChildExt;
 
-    let child = std::process::Command::new("git")
-        .arg("-C")
-        .arg(path)
-        .arg("fetch")
-        .arg("--quiet")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn();
+    let child = fetch_child(path);
 
     match child {
         Ok(mut c) => {
             match c.wait_timeout(std::time::Duration::from_secs(30)) {
                 Ok(Some(status)) => status.success(),
                 Ok(None) => {
-                    // Timed out — kill the hung process
-                    let _ = c.kill();
+                    // Timed out — kill the whole process group (git + its ssh
+                    // children), not just git.
+                    kill_process_group(&mut c);
                     let _ = c.wait();
                     false
                 }
@@ -90,6 +89,51 @@ pub(super) fn fetch_remote_silent(path: &Path) -> bool {
         }
         Err(_) => false,
     }
+}
+
+/// Spawn `git fetch --quiet` with stdout/stderr discarded.
+///
+/// On unix the child gets its own process group so that a timeout kill can
+/// target the whole tree (git and every child it spawned, notably `ssh` for
+/// ssh remotes) instead of leaving orphans behind.
+fn fetch_child(path: &Path) -> std::io::Result<std::process::Child> {
+    let mut cmd = std::process::Command::new("git");
+    cmd.arg("-C")
+        .arg(path)
+        .arg("fetch")
+        .arg("--quiet")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // Own process group (pgid == pid) so kill_process_group can take
+        // git's children — the ssh client — down with it.
+        cmd.process_group(0);
+    }
+    cmd.spawn()
+}
+
+/// Kill the child and everything in its process group.
+///
+/// On unix the fetch child was spawned with `process_group(0)`, so its pgid
+/// equals its pid and this takes `git fetch` and its `ssh` child together.
+/// Non-unix platforms fall back to killing only the child itself (previous
+/// behavior).
+#[cfg(unix)]
+pub(super) fn kill_process_group(child: &mut std::process::Child) {
+    // SAFETY: child.id() is the pgid because fetch_child spawned it with
+    // process_group(0); SIGKILL cannot fail for a valid existing pgid, and a
+    // race where the group already exited is harmless (ESRCH is ignored).
+    let pgid = child.id() as i32;
+    unsafe {
+        libc::killpg(pgid, libc::SIGKILL);
+    }
+}
+
+#[cfg(not(unix))]
+pub(super) fn kill_process_group(child: &mut std::process::Child) {
+    let _ = child.kill();
 }
 
 /// Returns (ahead, behind) for HEAD relative to its publishing target.


### PR DESCRIPTION
## Problem

`git fetch` over SSH spawns an `ssh` child that runs `git-upload-pack` on the remote. The status poll's fetch timeout (`fetch_remote_silent` in `src/git/status/worktree.rs`) killed only the `git fetch` process itself:

```rust
Ok(None) => {
    // Timed out — kill the hung process
    let _ = c.kill();
    ...
```

The `ssh` child survives as an orphan, holding its TCP connection (and the server-side `git-upload-pack`) alive until the network eventually gives up — 10-25+ minutes later. On workspaces with slow SSH remotes (e.g. a Gerrit-hosted kernel repo where pack negotiation routinely exceeds 30s), every poll interval leaves another zombie, and they accumulate:

```
$ ps aux | grep git-upload-pack
... ssh -o SendEnv=GIT_PROTOCOL -p 29418 ... git-upload-pack '/cs/ext/kernel-6.1'   # orphan, PPID 1
... ssh -o SendEnv=GIT_PROTOCOL -p 29418 ... git-upload-pack '/cs/ext/kernel-6.1'   # orphan, PPID 1
... (one per timed-out poll)
```

## Fix

- Spawn the fetch in its own **process group** on unix (`process_group(0)`, pgid == child pid).
- On timeout, `SIGKILL` the whole group via `killpg` so the `ssh` child dies with `git`.
- Non-unix platforms keep the previous kill-only-the-child behavior.

## Test

Added `process_group_kill_takes_grandchildren` (`src/git/status/tests_fetch_kill.rs`): reproduces the `git fetch` + `ssh` parent/grandchild shape with `sh` + `sleep`, kills the group, and asserts the grandchild is reaped (ESRCH). Full suite: 461 passed, 0 failed; clippy and rustdoc clean with `-D warnings`.
