### PR TITLE
feat(graph): collapse a tracked upstream into its local branch filter entry

### DIFF
--- a/src/components/git_graph/mod.rs
+++ b/src/components/git_graph/mod.rs
@@ -387,7 +387,7 @@ impl GitGraph {
             rows.iter()
                 .flat_map(|row| row.labels.iter())
                 .filter(|label| !label.is_tag && !label.is_stash)
-                .map(|label| label.name.clone()),
+                .map(|label| label.catalog_name.clone()),
         );
         self.filter_authors
             .extend(rows.iter().map(|row| row.author.clone()));

--- a/src/components/git_graph/tests.rs
+++ b/src/components/git_graph/tests.rs
@@ -167,6 +167,7 @@ fn test_search_no_results() {
 fn make_label(name: &str) -> BranchLabel {
     BranchLabel {
         name: name.to_string(),
+        catalog_name: name.to_string(),
         is_head: false,
         is_remote: false,
         is_worktree: false,

--- a/src/git/graph/mod.rs
+++ b/src/git/graph/mod.rs
@@ -19,6 +19,11 @@ const PALETTE_SIZE: usize = 6;
 #[derive(Clone, Debug)]
 pub(crate) struct BranchLabel {
     pub name: String,
+    /// Name shown in the branch filter picker. A local branch and the
+    /// remote-tracking branch it tracks (its upstream) share one catalog name,
+    /// so they collapse to a single filter entry and selecting it walks from
+    /// both tips. Most labels use their own `name` as the catalog name.
+    pub catalog_name: String,
     pub is_head: bool,
     pub is_remote: bool,
     pub is_worktree: bool,
@@ -163,7 +168,7 @@ impl GraphBuilder {
                         !label.is_tag
                             && !label.is_stash
                             && options.filters.refs.includes(label)
-                            && branches.contains(&label.name)
+                            && branches.contains(&label.catalog_name)
                     })
                 })
                 .map(|(oid, _)| *oid)
@@ -181,7 +186,7 @@ impl GraphBuilder {
         if let Some(branches) = &options.filters.branches {
             for labels in ref_map.values_mut() {
                 labels.retain(|label| {
-                    label.is_tag || label.is_stash || branches.contains(&label.name)
+                    label.is_tag || label.is_stash || branches.contains(&label.catalog_name)
                 });
             }
             ref_map.retain(|_, labels| !labels.is_empty());
@@ -268,7 +273,7 @@ impl GraphBuilder {
             .values()
             .flat_map(|labels| labels.iter())
             .filter(|label| !label.is_tag && !label.is_stash)
-            .map(|label| label.name.clone())
+            .map(|label| label.catalog_name.clone())
             .collect::<BTreeSet<_>>();
         Ok(names.into_iter().collect())
     }

--- a/src/git/graph/refs.rs
+++ b/src/git/graph/refs.rs
@@ -19,6 +19,48 @@ pub(super) fn resolve_refs(
         .and_then(|r| r.shorthand().ok().map(String::from));
     let wt_branches = collect_worktree_branches(repo);
 
+    // Map a remote-tracking branch's short name (e.g. `origin/main`) to the
+    // local branch that tracks it, so a merged catalog entry can collapse a
+    // local↔upstream pair into one. Only `All` collects both sides, so only
+    // that mode merges; a remote-only view keeps each remote branch distinct.
+    let mut upstream_to_local: HashMap<String, String> = HashMap::new();
+    if *filter == BranchFilter::All
+        && let Ok(branches) = repo.branches(Some(BranchType::Local))
+    {
+        // Collect every local branch that tracks each remote-tracking ref, so a
+        // collapse is only applied when it is unambiguous.
+        let mut tracking: HashMap<String, Vec<String>> = HashMap::new();
+        for branch_result in branches {
+            let Ok((branch, _)) = branch_result else {
+                continue;
+            };
+            let Ok(Some(name)) = branch.name() else {
+                continue;
+            };
+            let Ok(upstream) = branch.upstream() else {
+                continue;
+            };
+            // Only remote-tracking upstreams merge; a branch tracking
+            // another local branch must stay two distinct entries.
+            if !upstream.get().is_remote() {
+                continue;
+            }
+            let Some(up_name) = upstream.name().ok().flatten() else {
+                continue;
+            };
+            tracking
+                .entry(up_name.to_string())
+                .or_default()
+                .push(name.to_string());
+        }
+        // Collapse only when exactly one local branch tracks the upstream; if two
+        // locals share the same remote, keep the remote distinct instead of guessing.
+        for (up_name, locals) in tracking {
+            if let [single] = locals.as_slice() {
+                upstream_to_local.insert(up_name, single.clone());
+            }
+        }
+    }
     let mut map: HashMap<Oid, Vec<BranchLabel>> = HashMap::new();
 
     let branch_types: Vec<BranchType> = match filter {
@@ -50,9 +92,18 @@ pub(super) fn resolve_refs(
             let is_head =
                 !is_remote && head_oid == Some(target) && head_name.as_deref() == Some(&name);
             let is_worktree = !is_remote && wt_branches.contains(&name);
+            let catalog_name = if is_remote {
+                upstream_to_local
+                    .get(&name)
+                    .cloned()
+                    .unwrap_or_else(|| name.clone())
+            } else {
+                name.clone()
+            };
 
             map.entry(target).or_default().push(BranchLabel {
                 name,
+                catalog_name,
                 is_head,
                 is_remote,
                 is_worktree,
@@ -81,6 +132,7 @@ pub(super) fn resolve_refs(
             if let Some(oid) = oid {
                 map.entry(oid).or_default().push(BranchLabel {
                     name: name.to_string(),
+                    catalog_name: name.to_string(),
                     is_head: false,
                     is_remote: false,
                     is_worktree: false,
@@ -125,6 +177,7 @@ pub(super) fn merge_stash_labels(repo: &mut Repository, map: &mut HashMap<Oid, V
         };
         map.entry(parent_oid).or_default().push(BranchLabel {
             name: format!("stash@{{{index}}}"),
+            catalog_name: format!("stash@{{{index}}}"),
             is_head: false,
             is_remote: false,
             is_worktree: false,

--- a/src/git/graph/tests.rs
+++ b/src/git/graph/tests.rs
@@ -19,6 +19,17 @@ fn create_commit_as(
         .unwrap()
 }
 
+/// Create a commit object without updating any ref, so two divergent children
+/// of the same parent can be built without first-parent/HEAD fast-forward
+/// conflicts. The caller points refs at the returned oid explicitly.
+fn create_commit_no_ref(repo: &Repository, message: &str, parents: &[&git2::Commit]) -> Oid {
+    let sig = Signature::now("Test", "test@test.com").unwrap();
+    let tree_id = repo.index().unwrap().write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo.commit(None, &sig, &sig, message, &tree, parents)
+        .unwrap()
+}
+
 #[test]
 fn branch_filter_walks_from_the_selected_branch() {
     let tmp = TempDir::new().unwrap();
@@ -748,4 +759,220 @@ fn test_segments_multi_commit_branch() {
     assert_eq!(segments.len(), 1);
     assert_eq!(segments[0].row_indices, vec![2, 3]);
     assert_eq!(segments[0].id, oid_d.to_string());
+}
+
+#[test]
+fn merged_catalog_collapses_tracked_upstream_into_local_name() {
+    let tmp = TempDir::new().unwrap();
+    let repo = Repository::init(tmp.path()).unwrap();
+
+    let root_oid = create_commit(&repo, "root", &[]);
+    let root = repo.find_commit(root_oid).unwrap();
+    repo.branch("main", &root, false).unwrap();
+
+    // A commit only on the remote-tracking ref (ahead of local `main`).
+    let remote_oid = create_commit(&repo, "remote-new", &[&root]);
+    repo.reference("refs/remotes/origin/main", remote_oid, true, "test setup")
+        .unwrap();
+    repo.remote("origin", "https://example.com/repo.git")
+        .unwrap();
+
+    let mut main_branch = repo.find_branch("main", git2::BranchType::Local).unwrap();
+    main_branch.set_upstream(Some("origin/main")).unwrap();
+
+    let names = GraphBuilder::branch_names(tmp.path(), &crate::config::BranchFilter::All).unwrap();
+    assert!(names.iter().any(|n| n == "main"), "got: {names:?}");
+    assert!(
+        !names.iter().any(|n| n == "origin/main"),
+        "tracked upstream must collapse into its local name; got: {names:?}"
+    );
+}
+
+#[test]
+fn selecting_merged_branch_walks_from_both_local_and_upstream_tips() {
+    let tmp = TempDir::new().unwrap();
+    let repo = Repository::init(tmp.path()).unwrap();
+
+    let root_oid = create_commit(&repo, "root", &[]);
+    let root = repo.find_commit(root_oid).unwrap();
+    repo.branch("main", &root, false).unwrap();
+
+    // `main` and `origin/main` diverge off `root`: each gets its own commit.
+    // Neither commit is reachable from the other tip, so each appears only if
+    // its own tip is used as a walk root.
+    let local_oid = create_commit_no_ref(&repo, "local-new", &[&root]);
+    repo.reference("refs/heads/main", local_oid, true, "test setup")
+        .unwrap();
+    let remote_oid = create_commit_no_ref(&repo, "remote-new", &[&root]);
+    repo.reference("refs/remotes/origin/main", remote_oid, true, "test setup")
+        .unwrap();
+    repo.remote("origin", "https://example.com/repo.git")
+        .unwrap();
+
+    let mut main_branch = repo.find_branch("main", git2::BranchType::Local).unwrap();
+    main_branch.set_upstream(Some("origin/main")).unwrap();
+
+    let options = GraphOptions {
+        filters: GraphFilters {
+            branches: Some(["main".to_string()].into_iter().collect()),
+            authors: None,
+            refs: GraphRefFilters::default(),
+        },
+        ..GraphOptions::default()
+    };
+    let rows = GraphBuilder::new().build(tmp.path(), &options).unwrap();
+
+    let messages: Vec<&str> = rows.iter().map(|r| r.message.as_str()).collect();
+    assert!(
+        messages.contains(&"local-new"),
+        "local tip must be a walk root (commit only on the local branch); got: {messages:?}"
+    );
+    assert!(
+        messages.contains(&"remote-new"),
+        "upstream tip must be a walk root (commit only on the remote); got: {messages:?}"
+    );
+}
+
+#[test]
+fn remote_filter_keeps_an_upstream_branch_distinct() {
+    let tmp = TempDir::new().unwrap();
+    let repo = Repository::init(tmp.path()).unwrap();
+
+    let root_oid = create_commit(&repo, "root", &[]);
+    let root = repo.find_commit(root_oid).unwrap();
+    repo.branch("main", &root, false).unwrap();
+
+    let remote_oid = create_commit(&repo, "remote-new", &[&root]);
+    repo.reference("refs/remotes/origin/main", remote_oid, true, "test setup")
+        .unwrap();
+    repo.remote("origin", "https://example.com/repo.git")
+        .unwrap();
+    let mut main_branch = repo.find_branch("main", git2::BranchType::Local).unwrap();
+    main_branch.set_upstream(Some("origin/main")).unwrap();
+
+    // In Remote-only mode the catalog must show the remote branch under its own
+    // name; the merge applies only when both sides are visible (All).
+    let names =
+        GraphBuilder::branch_names(tmp.path(), &crate::config::BranchFilter::Remote).unwrap();
+    assert!(
+        names.iter().any(|n| n == "origin/main"),
+        "remote branch must stay distinct in Remote-only mode; got: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n == "main"),
+        "local branches are not collected in Remote-only mode; got: {names:?}"
+    );
+}
+
+#[test]
+fn untracked_remote_branch_stays_distinct_from_any_local() {
+    let tmp = TempDir::new().unwrap();
+    let repo = Repository::init(tmp.path()).unwrap();
+
+    let root_oid = create_commit(&repo, "root", &[]);
+    let root = repo.find_commit(root_oid).unwrap();
+    repo.branch("main", &root, false).unwrap();
+
+    // `main` tracks `origin/main`; `origin/other` is tracked by nobody. The
+    // tracked pair must collapse to one entry, the untracked remote must stay
+    // distinct — and no invented collapsed entry may appear.
+    let tracked_oid = create_commit_no_ref(&repo, "tracked-tip", &[&root]);
+    repo.reference("refs/remotes/origin/main", tracked_oid, true, "test setup")
+        .unwrap();
+    let other_oid = create_commit_no_ref(&repo, "other-remote-tip", &[&root]);
+    repo.reference("refs/remotes/origin/other", other_oid, true, "test setup")
+        .unwrap();
+    repo.remote("origin", "https://example.com/repo.git")
+        .unwrap();
+
+    let mut main_branch = repo.find_branch("main", git2::BranchType::Local).unwrap();
+    main_branch.set_upstream(Some("origin/main")).unwrap();
+
+    let names = GraphBuilder::branch_names(tmp.path(), &crate::config::BranchFilter::All).unwrap();
+    assert!(
+        names.iter().any(|n| n == "origin/other"),
+        "untracked remote must stay distinct; got: {names:?}"
+    );
+    assert!(names.iter().any(|n| n == "main"), "got: {names:?}");
+    assert!(
+        !names.iter().any(|n| n == "origin/main"),
+        "tracked upstream must collapse into main; got: {names:?}"
+    );
+}
+
+#[test]
+fn merged_selection_respects_disabled_remote_refs() {
+    let tmp = TempDir::new().unwrap();
+    let repo = Repository::init(tmp.path()).unwrap();
+
+    let root_oid = create_commit(&repo, "root", &[]);
+    let root = repo.find_commit(root_oid).unwrap();
+    repo.branch("main", &root, false).unwrap();
+
+    let local_oid = create_commit_no_ref(&repo, "local-new", &[&root]);
+    repo.reference("refs/heads/main", local_oid, true, "test setup")
+        .unwrap();
+    let remote_oid = create_commit_no_ref(&repo, "remote-new", &[&root]);
+    repo.reference("refs/remotes/origin/main", remote_oid, true, "test setup")
+        .unwrap();
+    repo.remote("origin", "https://example.com/repo.git")
+        .unwrap();
+    let mut main_branch = repo.find_branch("main", git2::BranchType::Local).unwrap();
+    main_branch.set_upstream(Some("origin/main")).unwrap();
+
+    // Turn off remote refs: the merged selection must drop the upstream tip.
+    let refs = GraphRefFilters {
+        remote: false,
+        ..GraphRefFilters::default()
+    };
+    let options = GraphOptions {
+        filters: GraphFilters {
+            branches: Some(["main".to_string()].into_iter().collect()),
+            authors: None,
+            refs,
+        },
+        ..GraphOptions::default()
+    };
+    let rows = GraphBuilder::new().build(tmp.path(), &options).unwrap();
+    let messages: Vec<&str> = rows.iter().map(|r| r.message.as_str()).collect();
+    assert!(
+        messages.contains(&"local-new"),
+        "local tip must be walked; got: {messages:?}"
+    );
+    assert!(
+        !messages.contains(&"remote-new"),
+        "remote tip must be dropped when refs.remote is off; got: {messages:?}"
+    );
+}
+
+#[test]
+fn ambiguous_shared_upstream_keeps_remote_distinct() {
+    let tmp = TempDir::new().unwrap();
+    let repo = Repository::init(tmp.path()).unwrap();
+
+    let root_oid = create_commit(&repo, "root", &[]);
+    let root = repo.find_commit(root_oid).unwrap();
+    repo.branch("main", &root, false).unwrap();
+    repo.branch("dev", &root, false).unwrap();
+
+    let remote_oid = create_commit(&repo, "remote-tip", &[&root]);
+    repo.reference("refs/remotes/origin/main", remote_oid, true, "test setup")
+        .unwrap();
+    repo.remote("origin", "https://example.com/repo.git")
+        .unwrap();
+
+    // Both `main` and `dev` track the SAME upstream `origin/main`. The collapse
+    // is ambiguous, so the remote must stay its own distinct catalog entry.
+    let mut main_branch = repo.find_branch("main", git2::BranchType::Local).unwrap();
+    main_branch.set_upstream(Some("origin/main")).unwrap();
+    let mut dev_branch = repo.find_branch("dev", git2::BranchType::Local).unwrap();
+    dev_branch.set_upstream(Some("origin/main")).unwrap();
+
+    let names = GraphBuilder::branch_names(tmp.path(), &crate::config::BranchFilter::All).unwrap();
+    assert!(
+        names.iter().any(|n| n == "origin/main"),
+        "ambiguous shared upstream must stay distinct; got: {names:?}"
+    );
+    assert!(names.iter().any(|n| n == "main"), "got: {names:?}");
+    assert!(names.iter().any(|n| n == "dev"), "got: {names:?}");
 }

--- a/src/git/graph_render.rs
+++ b/src/git/graph_render.rs
@@ -376,6 +376,7 @@ mod tests {
     fn label(name: &str, is_head: bool, is_remote: bool, is_worktree: bool) -> BranchLabel {
         BranchLabel {
             name: name.to_string(),
+            catalog_name: name.to_string(),
             is_head,
             is_remote,
             is_worktree,
@@ -589,6 +590,7 @@ mod tests {
         let theme = GraphTheme::default();
         let labels = vec![BranchLabel {
             name: "v1.0.0".to_string(),
+            catalog_name: "v1.0.0".to_string(),
             is_head: false,
             is_remote: false,
             is_worktree: false,
@@ -610,6 +612,7 @@ mod tests {
         let theme = GraphTheme::default();
         let labels = vec![BranchLabel {
             name: "stash@{0}".to_string(),
+            catalog_name: "stash@{0}".to_string(),
             is_head: false,
             is_remote: false,
             is_worktree: false,


### PR DESCRIPTION
A local branch that tracks a remote-tracking branch (e.g. `main` tracks `origin/main`) now appears once in the branch filter instead of twice. Selecting it walks the graph from both the local tip and the upstream tip, so commits fetched from the remote show up even when the view is narrowed to that branch. Local-only and remote-only branch filters are unchanged.