### PR TITLE
test: cover merged filter traversal modes and picker catalog propagation

### DIFF
--- a/src/components/git_graph/mod.rs
+++ b/src/components/git_graph/mod.rs
@@ -272,6 +272,10 @@ impl GitGraph {
             // before either terminal action below is sent.
             let guard = GraphLoadGuard::new(load_gen, tx.clone());
             let builder = GraphBuilder::new();
+            // `branch_names` and `build` resolve refs independently, so a
+            // fetch or upstream change landing between the two calls can
+            // briefly leave the picker catalog inconsistent with the built
+            // graph. Accepted: the next reload re-derives both together.
             if let Ok(branches) = GraphBuilder::branch_names(&path, &options.branch_filter) {
                 let _ = tx.send(Action::GraphFilterBranchesLoaded {
                     generation: load_gen,

--- a/src/components/git_graph/tests.rs
+++ b/src/components/git_graph/tests.rs
@@ -176,6 +176,26 @@ fn make_label(name: &str) -> BranchLabel {
     }
 }
 
+#[test]
+fn picker_catalog_uses_catalog_names_not_display_names() {
+    let mut graph = GitGraph::new(std::sync::Arc::new(crate::theme::Theme::default()));
+    let mut row = mock_row("abc1234", "tip", "Alice");
+    // Local `main` plus its tracked upstream displayed as `origin/main` but
+    // collapsed to the `main` catalog entry.
+    let mut remote = make_label("origin/main");
+    remote.catalog_name = "main".to_string();
+    remote.is_remote = true;
+    row.labels = vec![make_label("main"), remote];
+    graph.set_rows(vec![row]);
+
+    let branches = graph.filter_branches();
+    assert_eq!(
+        branches,
+        vec!["main".to_string()],
+        "picker must expose collapsed catalog names only"
+    );
+}
+
 const OID_M: &str = "1111111111111111111111111111111111111111";
 const OID_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const OID_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";

--- a/src/git/graph/mod.rs
+++ b/src/git/graph/mod.rs
@@ -8,6 +8,8 @@ mod refs;
 mod segments;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_filters;
 
 use refs::{merge_stash_labels, resolve_refs};
 
@@ -23,6 +25,13 @@ pub(crate) struct BranchLabel {
     /// remote-tracking branch it tracks (its upstream) share one catalog name,
     /// so they collapse to a single filter entry and selecting it walks from
     /// both tips. Most labels use their own `name` as the catalog name.
+    ///
+    /// Catalog identity is a plain string, so a local branch literally named
+    /// like a remote shorthand (a local `origin/topic` next to an untracked
+    /// remote `origin/topic`) shares one entry and selecting it walks both
+    /// tips. This predates the upstream collapse (filter matching was always
+    /// string-based); the upgrade path is ref-qualified identities
+    /// (`refs/heads/...` vs `refs/remotes/...`) with separate display names.
     pub catalog_name: String,
     pub is_head: bool,
     pub is_remote: bool,

--- a/src/git/graph/tests.rs
+++ b/src/git/graph/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use git2::{Repository, Signature};
 use tempfile::TempDir;
 
-fn create_commit(repo: &Repository, message: &str, parents: &[&git2::Commit]) -> Oid {
+pub(super) fn create_commit(repo: &Repository, message: &str, parents: &[&git2::Commit]) -> Oid {
     create_commit_as(repo, message, "Test", parents)
 }
 
@@ -22,7 +22,11 @@ fn create_commit_as(
 /// Create a commit object without updating any ref, so two divergent children
 /// of the same parent can be built without first-parent/HEAD fast-forward
 /// conflicts. The caller points refs at the returned oid explicitly.
-fn create_commit_no_ref(repo: &Repository, message: &str, parents: &[&git2::Commit]) -> Oid {
+pub(super) fn create_commit_no_ref(
+    repo: &Repository,
+    message: &str,
+    parents: &[&git2::Commit],
+) -> Oid {
     let sig = Signature::now("Test", "test@test.com").unwrap();
     let tree_id = repo.index().unwrap().write_tree().unwrap();
     let tree = repo.find_tree(tree_id).unwrap();

--- a/src/git/graph/tests_filters.rs
+++ b/src/git/graph/tests_filters.rs
@@ -1,0 +1,154 @@
+//! Follow-up coverage for the merged local↔upstream branch filter entry:
+//! traversal modes (upstream-only refs, first-parent) and multi-remote
+//! collapse resolution. See the base cases in `tests.rs`.
+
+use super::tests::{create_commit, create_commit_no_ref};
+use super::*;
+use git2::Repository;
+use tempfile::TempDir;
+
+/// Init a repo where local `main` and `origin/main` diverge off `root`:
+/// `local-new` is only on the local branch, `remote-new` only on the
+/// remote-tracking ref, and `main` tracks `origin/main`.
+fn diverged_tracked_repo(tmp: &TempDir) -> Repository {
+    let repo = Repository::init(tmp.path()).unwrap();
+
+    let root_oid = create_commit(&repo, "root", &[]);
+    {
+        let root = repo.find_commit(root_oid).unwrap();
+        repo.branch("main", &root, false).unwrap();
+
+        let local_oid = create_commit_no_ref(&repo, "local-new", &[&root]);
+        repo.reference("refs/heads/main", local_oid, true, "test setup")
+            .unwrap();
+        let remote_oid = create_commit_no_ref(&repo, "remote-new", &[&root]);
+        repo.reference("refs/remotes/origin/main", remote_oid, true, "test setup")
+            .unwrap();
+        repo.remote("origin", "https://example.com/repo.git")
+            .unwrap();
+    }
+
+    {
+        let mut main_branch = repo.find_branch("main", git2::BranchType::Local).unwrap();
+        main_branch.set_upstream(Some("origin/main")).unwrap();
+    }
+    repo
+}
+
+fn select_main(refs: GraphRefFilters, first_parent: bool) -> GraphOptions {
+    GraphOptions {
+        filters: GraphFilters {
+            branches: Some(["main".to_string()].into_iter().collect()),
+            authors: None,
+            refs,
+        },
+        first_parent,
+        ..GraphOptions::default()
+    }
+}
+
+#[test]
+fn merged_selection_with_local_refs_disabled_walks_only_the_upstream() {
+    let tmp = TempDir::new().unwrap();
+    diverged_tracked_repo(&tmp);
+
+    let refs = GraphRefFilters {
+        local: false,
+        ..GraphRefFilters::default()
+    };
+    let rows = GraphBuilder::new()
+        .build(tmp.path(), &select_main(refs, false))
+        .unwrap();
+
+    let messages: Vec<&str> = rows.iter().map(|r| r.message.as_str()).collect();
+    assert!(
+        messages.contains(&"remote-new"),
+        "upstream tip must still be walked; got: {messages:?}"
+    );
+    assert!(
+        !messages.contains(&"local-new"),
+        "local tip must be dropped when refs.local is off; got: {messages:?}"
+    );
+}
+
+#[test]
+fn merged_selection_under_first_parent_keeps_both_tips_as_roots() {
+    let tmp = TempDir::new().unwrap();
+    let repo = diverged_tracked_repo(&tmp);
+
+    // Merge a side commit into local `main` so first-parent simplification has
+    // a second-parent chain to drop.
+    let root = repo
+        .find_reference("refs/remotes/origin/main")
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .parents()
+        .next()
+        .unwrap();
+    let side_oid = create_commit_no_ref(&repo, "side-branch", &[&root]);
+    let side = repo.find_commit(side_oid).unwrap();
+    let local_tip = repo
+        .find_reference("refs/heads/main")
+        .unwrap()
+        .peel_to_commit()
+        .unwrap();
+    let merge_oid = create_commit_no_ref(&repo, "merge-side", &[&local_tip, &side]);
+    repo.reference("refs/heads/main", merge_oid, true, "test setup")
+        .unwrap();
+
+    let rows = GraphBuilder::new()
+        .build(tmp.path(), &select_main(GraphRefFilters::default(), true))
+        .unwrap();
+
+    let messages: Vec<&str> = rows.iter().map(|r| r.message.as_str()).collect();
+    assert!(
+        messages.contains(&"merge-side") && messages.contains(&"local-new"),
+        "local first-parent chain must be walked; got: {messages:?}"
+    );
+    assert!(
+        messages.contains(&"remote-new"),
+        "upstream tip must stay a root under first-parent; got: {messages:?}"
+    );
+    assert!(
+        !messages.contains(&"side-branch"),
+        "second-parent chain must be simplified away; got: {messages:?}"
+    );
+}
+
+#[test]
+fn same_leaf_name_on_two_remotes_collapses_each_into_its_own_local() {
+    let tmp = TempDir::new().unwrap();
+    let repo = Repository::init(tmp.path()).unwrap();
+
+    let root_oid = create_commit(&repo, "root", &[]);
+    let root = repo.find_commit(root_oid).unwrap();
+    repo.branch("main", &root, false).unwrap();
+    repo.branch("mirror", &root, false).unwrap();
+
+    // Two remotes both carry a `main` leaf; `main` tracks origin's, `mirror`
+    // tracks backup's. Each collapse must resolve by exact upstream name.
+    repo.reference("refs/remotes/origin/main", root_oid, true, "test setup")
+        .unwrap();
+    repo.reference("refs/remotes/backup/main", root_oid, true, "test setup")
+        .unwrap();
+    repo.remote("origin", "https://example.com/repo.git")
+        .unwrap();
+    repo.remote("backup", "https://example.com/backup.git")
+        .unwrap();
+
+    let mut main_branch = repo.find_branch("main", git2::BranchType::Local).unwrap();
+    main_branch.set_upstream(Some("origin/main")).unwrap();
+    let mut mirror_branch = repo.find_branch("mirror", git2::BranchType::Local).unwrap();
+    mirror_branch.set_upstream(Some("backup/main")).unwrap();
+
+    let names = GraphBuilder::branch_names(tmp.path(), &crate::config::BranchFilter::All).unwrap();
+    assert!(names.iter().any(|n| n == "main"), "got: {names:?}");
+    assert!(names.iter().any(|n| n == "mirror"), "got: {names:?}");
+    assert!(
+        !names
+            .iter()
+            .any(|n| n == "origin/main" || n == "backup/main"),
+        "each tracked upstream must collapse into its own local; got: {names:?}"
+    );
+}


### PR DESCRIPTION
Closes #57

## In simple terms

No visible change: this hardens the new single-entry branch filter (a branch and its remote copy shown as one item) with tests for the modes the original PR did not cover, and writes down two known edge cases in the code.

## Problem

The tracked-upstream collapse from #55 landed with tests for the main modes only. Untested: a merged selection with local refs disabled, first-parent simplification over a merged selection, the same branch leaf name on two remotes, and the picker deriving its entries from catalog names. Two pre-existing limitations (string catalog identity can collide with an unusually named local branch, and `branch_names`/`build` resolve refs independently) were undocumented.

## Fix

A `tests_filters` module beside the existing graph tests (`tests.rs` sits near the 1000-line file limit) reuses its commit helpers, plus a component picker test where a label's display name differs from its catalog name. Both limitations are documented as code comments at the `catalog_name` field and the `branch_names` call site rather than fixed: ref-qualified identities and a single ref snapshot are not worth the refactor until they bite.

## Test

`just ci` passes locally (fmt, clippy `-D warnings`, docs, full suite): 476 tests, 4 new, all asserting walk-root behavior or picker output rather than internals.
