### PR TITLE
fix: stabilize untracked directory status

### DIFF
--- a/src/git/status/mod.rs
+++ b/src/git/status/mod.rs
@@ -216,7 +216,7 @@ pub(crate) fn query_status(
     path: &Path,
     sub_cfg: &SubmoduleConfig,
 ) -> color_eyre::Result<RepoStatus> {
-    query_status_inner(path, false, false, sub_cfg)
+    query_status_inner(path, false, sub_cfg)
 }
 
 /// Status query with `git fetch` first. Used by explicit user refresh (`r` key).
@@ -224,13 +224,15 @@ pub(crate) fn query_status_with_fetch(
     path: &Path,
     sub_cfg: &SubmoduleConfig,
 ) -> color_eyre::Result<RepoStatus> {
-    query_status_inner(path, true, true, sub_cfg)
+    // Keep untracked directories compact, matching local-poll and
+    // watcher-triggered queries. Otherwise a fetch refresh expands every file
+    // only for the next local refresh to collapse it again.
+    query_status_inner(path, true, sub_cfg)
 }
 
 fn query_status_inner(
     path: &Path,
     fetch: bool,
-    recurse_untracked_dirs: bool,
     sub_cfg: &SubmoduleConfig,
 ) -> color_eyre::Result<RepoStatus> {
     let mut repo = Repository::open(path)?;
@@ -275,7 +277,7 @@ fn query_status_inner(
         submodules,
         has_dirty_submodules,
         has_unpushed_submodules,
-    } = collect_change_summary(&repo, path, recurse_untracked_dirs, sub_cfg)?;
+    } = collect_change_summary(&repo, path, false, sub_cfg)?;
 
     // Collect linked worktree details (excludes the main working tree)
     let worktree_info = collect_worktree_info(&repo, sub_cfg);

--- a/src/git/status/tests_basic.rs
+++ b/src/git/status/tests_basic.rs
@@ -61,34 +61,20 @@ fn test_untracked_file_detected() {
 }
 
 #[test]
-fn test_background_status_does_not_recurse_untracked_dirs() {
+fn test_status_queries_keep_untracked_dirs_compact() {
     let (tmp, _repo) = init_temp_repo();
     fs::create_dir_all(tmp.path().join("nested")).unwrap();
     fs::write(tmp.path().join("nested/file.txt"), "new").unwrap();
+    fs::write(tmp.path().join("nested/another.txt"), "new").unwrap();
 
     let status = query_status(tmp.path(), &SubmoduleConfig::default()).unwrap();
     assert!(status.is_dirty);
-    assert!(
-        status
-            .files
-            .iter()
-            .any(|f| f.status == FileStatus::Untracked)
-    );
-    assert!(
-        !status
-            .files
-            .iter()
-            .any(|f| f.path == Path::new("nested/file.txt"))
-    );
+    assert_eq!(status.files.len(), 1);
+    assert_eq!(status.files[0].path, Path::new("nested"));
+    assert_eq!(status.files[0].status, FileStatus::Untracked);
 
-    let recursive =
-        query_status_inner(tmp.path(), false, true, &SubmoduleConfig::default()).unwrap();
-    assert!(
-        recursive
-            .files
-            .iter()
-            .any(|f| f.path == Path::new("nested/file.txt"))
-    );
+    let fetched = query_status_with_fetch(tmp.path(), &SubmoduleConfig::default()).unwrap();
+    assert_eq!(fetched.files, status.files);
 }
 
 #[test]


### PR DESCRIPTION
Closes #63

## In simple terms

The Changes pane now keeps a newly added directory in one stable form during all refreshes. It no longer flashes between the directory and every file inside it.

## Problem

Local and watcher refreshes represented untracked directories as one compact row, but fetch-based refreshes expanded every file. The periodic refreshes repeatedly replaced one representation with the other.

## Fix

Use the compact untracked-directory status representation for fetch-based refreshes as well. The status-query implementation no longer accepts a recursion mode, preventing future refresh paths from producing a different shape.

## Test

- Added a regression test that creates two files in an untracked directory and verifies local and fetch-backed queries return the same single compact entry.
- `just ci` (fmt, clippy, rustdoc warnings, 492 tests)
- Two independent audits of the refresh paths and regression test coverage.