### PR TITLE
fix: bound libgit2 pack windows and object cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,16 @@ branches = "all"         # Branch filter: "all", "local", "remote", or "none"
 label_max_len = 24       # Max length for branch/tag labels
 show_stats = true        # Show +N/-M diff stats per commit
 
+
+[git2]
+# libgit2 memory bounds (MiB). The library defaults (1 GiB pack window, 8 GiB
+# total mapped, 256 MiB object cache) suit 64-bit servers; on a workspace
+# containing multi-GiB packs they can push resident memory past 2 GiB.
+# 0 restores the libgit2 default for that knob.
+window_size_mib = 16
+window_mapped_limit_mib = 128
+cache_max_size_mib = 32
+
 [github]
 enabled = true           # Show the GitHub issues/PRs panel (via `gh`); opt-out, on by default
 

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -79,6 +79,28 @@ impl Default for GraphConfig {
     }
 }
 
+pub(super) fn default_git2_window_size_mib() -> usize {
+    16
+}
+
+pub(super) fn default_git2_window_mapped_limit_mib() -> usize {
+    128
+}
+
+pub(super) fn default_git2_cache_max_size_mib() -> usize {
+    32
+}
+
+impl Default for Git2Config {
+    fn default() -> Self {
+        Self {
+            window_size_mib: default_git2_window_size_mib(),
+            window_mapped_limit_mib: default_git2_window_mapped_limit_mib(),
+            cache_max_size_mib: default_git2_cache_max_size_mib(),
+        }
+    }
+}
+
 pub(super) fn default_root_dirs() -> Vec<PathBuf> {
     dirs::home_dir()
         .map(|h| vec![h.join("Code")])
@@ -201,6 +223,7 @@ impl Default for Config {
             watch: WatchConfig::default(),
             ui: UiConfig::default(),
             graph: GraphConfig::default(),
+            git2: Git2Config::default(),
             submodules: SubmoduleConfig::default(),
             github: GithubConfig::default(),
             open: OpenConfig::default(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -48,6 +48,8 @@ pub(crate) struct Config {
     #[serde(default)]
     pub graph: GraphConfig,
     #[serde(default)]
+    pub git2: Git2Config,
+    #[serde(default)]
     pub submodules: SubmoduleConfig,
     #[serde(default)]
     pub github: GithubConfig,
@@ -170,6 +172,28 @@ pub(crate) struct GraphConfig {
     pub label_max_len: usize,
     #[serde(default = "default_show_stats")]
     pub show_stats: bool,
+}
+
+/// Bounds for libgit2's internal memory (pack mmap windows and the global
+/// object cache). The library defaults are sized for 64-bit servers (1 GiB
+/// window size, 8 GiB total mapped, 256 MiB object cache) and can spike
+/// resident memory past 2 GiB on a multi-repo workspace containing a
+/// multi-GiB pack; gitpane's defaults keep a large workspace in the
+/// hundreds of MiB. `0` restores the libgit2 default for that knob.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct Git2Config {
+    /// Size of a single libgit2 pack mmap window, in MiB. 0 = libgit2 default
+    /// (1 GiB on 64-bit).
+    #[serde(default = "default_git2_window_size_mib")]
+    pub window_size_mib: usize,
+    /// Total bytes libgit2 may keep mapped across all packs, in MiB. 0 =
+    /// libgit2 default (8 GiB on 64-bit). Must be >= `window_size_mib` (a
+    /// smaller limit would leave no room for even one window).
+    #[serde(default = "default_git2_window_mapped_limit_mib")]
+    pub window_mapped_limit_mib: usize,
+    /// Global parsed-object cache, in MiB. 0 = libgit2 default (256 MiB).
+    #[serde(default = "default_git2_cache_max_size_mib")]
+    pub cache_max_size_mib: usize,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/config/tests_fields.rs
+++ b/src/config/tests_fields.rs
@@ -131,6 +131,27 @@ fn test_show_stats_roundtrip() {
 }
 
 #[test]
+fn test_git2_limits_defaults() {
+    let config: Config = toml::from_str("").unwrap();
+    assert_eq!(config.git2.window_size_mib, 16);
+    assert_eq!(config.git2.window_mapped_limit_mib, 128);
+    assert_eq!(config.git2.cache_max_size_mib, 32);
+}
+
+#[test]
+fn test_git2_limits_roundtrip_and_zero_means_default() {
+    let mut config = Config::default();
+    config.git2.window_size_mib = 0;
+    config.git2.window_mapped_limit_mib = 256;
+    config.git2.cache_max_size_mib = 64;
+    let serialized = toml::to_string_pretty(&config).unwrap();
+    let loaded: Config = toml::from_str(&serialized).unwrap();
+    assert_eq!(loaded.git2.window_size_mib, 0);
+    assert_eq!(loaded.git2.window_mapped_limit_mib, 256);
+    assert_eq!(loaded.git2.cache_max_size_mib, 64);
+}
+
+#[test]
 fn test_herdr_forward_right_click_defaults_false() {
     let config: Config = toml::from_str("").unwrap();
     assert!(!config.herdr.forward_right_click);

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,32 @@ fn main() -> Result<()> {
     }
 }
 
+/// Apply the configured libgit2 memory bounds. Each knob is in MiB and `0`
+/// keeps the library default for it (see [`config::Git2Config`]). The window
+/// size is clamped to the mapped limit so a misconfigured value can never
+/// ask libgit2 to map a window it is not allowed to keep.
+fn apply_libgit2_limits(cfg: &config::Git2Config) {
+    unsafe {
+        let limit_bytes = if cfg.window_mapped_limit_mib > 0 {
+            cfg.window_mapped_limit_mib * 1024 * 1024
+        } else {
+            usize::MAX
+        };
+        if cfg.window_size_mib > 0 {
+            let size = (cfg.window_size_mib * 1024 * 1024).min(limit_bytes);
+            let _ = git2::opts::set_mwindow_size(size);
+        }
+        if cfg.window_mapped_limit_mib > 0 {
+            let limit = cfg.window_mapped_limit_mib * 1024 * 1024;
+            let _ = git2::opts::set_mwindow_mapped_limit(limit);
+        }
+        if cfg.cache_max_size_mib > 0 {
+            let size = (cfg.cache_max_size_mib * 1024 * 1024) as isize;
+            let _ = git2::opts::set_cache_max_size(size);
+        }
+    }
+}
+
 async fn run() -> Result<()> {
     let cli = Cli::parse();
 
@@ -128,6 +154,9 @@ async fn run() -> Result<()> {
 
     let mut config = config::Config::load()?;
 
+    // Bound libgit2 before any repository is opened; must run before the
+    // first git2 call (status polls, graph builds).
+    apply_libgit2_limits(&config.git2);
     if let Some(root) = cli.root {
         config.override_root(root);
     }


### PR DESCRIPTION
Closes #65

## In simple terms

Adds a `[git2]` config section bounding libgit2's pack mmap windows and object cache. On workspaces with multi-GiB packs this cuts gitpane's resident memory from ~2.2 GB to the low hundreds of MiB, removes swap pressure, and makes the commit graph load faster (20.8 s → 17.3 s measured).

## Problem

libgit2 defaults are sized for 64-bit servers: `DEFAULT_WINDOW_SIZE` = 1 GiB per pack mmap window, `DEFAULT_MAPPED_LIMIT` = 8 GiB total, object cache 256 MiB. A multi-repo dashboard that polls status every few seconds (each poll diffing trees against big packs) and rebuilds the commit graph on repo switch multiplies this:

- Every status poll mmaps 1 GiB pack windows (`git_mwindow_open` ← `tree_iterator_advance` / `git_revwalk_push` / `git_reference_peel`) and reads the whole index (`git_index_read`, 9.8 MB here)
- `show_stats=true` graph builds unpack blob content per commit (`git_diff_file_content__load` ← `packfile_unpack_compressed`, up to 66 MB per blob)

Measured on a Google-repo workspace (36 projects, 4.09 GiB kernel pack, 1371 refs): RSS 2.26 GB steady / 6.88 GB peak / 624 MB swap, with only ~700 MB referenced. heaptrack: no leak (99.27% of allocations released); peak heap sites are the revwalk pool (~107 MiB) and object parsing (~41 MiB), plus the window mmaps above.

## Fix

New `[git2]` section (defaults measured/validated on the workspace above; `0` restores the libgit2 default for that knob):

```toml
[git2]
window_size_mib = 16           # libgit2 default 1024
window_mapped_limit_mib = 128  # libgit2 default 8192
cache_max_size_mib = 32        # libgit2 default 256
```

Applied once at startup before any repository is opened (`apply_libgit2_limits` in `main.rs`). The window size is clamped to the mapped limit so a misconfigured file can't ask libgit2 to map a window it is not allowed to keep. The three knobs are the official `git2::opts` API, so behavior outside libgit2 is unchanged.

## Test

- `just ci` clean (fmt, clippy -D warnings, docs, 493 tests; 2 new: defaults + roundtrip/zero-means-default)
- Manual: same workspace, graph build on the 4 GiB pack, median of 3 runs:

| | RSS peak | RSS steady | idle | swap | graph load |
|---|---|---|---|---|---|
| before | ~2.4 GiB | ~1 GiB | ~200 MiB | 624 MB | 20.8 s |
| after | ~1.2 GiB | ~600 MiB | ~160 MiB | 0 | 17.3 s |
