### PR TITLE
fix: sync repo membership across running instances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,6 +759,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +948,7 @@ dependencies = [
  "crossterm 0.29.0",
  "directories",
  "dirs",
+ "fs2",
  "futures",
  "git2",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,8 @@ serde_json = "1"
 libc = "0.2"
 wait-timeout = "0.2.1"
 arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
+fs2 = "0.4"
+tempfile = "3"
 
 [dev-dependencies]
 tokio = { version = "1.23.1", features = ["full", "test-util"] }
-tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ gitpane resolves its config file in this order (first existing file wins):
 
 If no file is found at any candidate path, gitpane uses the built in defaults (`root_dirs = ["~/Code"]`, `scan_depth = 2`). When saving after loading a file, gitpane writes back to the loaded path. When saving from defaults, it writes to `$GITPANE_CONFIG`, `$XDG_CONFIG_HOME/gitpane/config.toml`, `~/.config/gitpane/config.toml`, or the platform native location, in that order.
 
+Running instances using the same config share repo additions and removals. Visible panes refresh within about a second; sleeping panes refresh when they wake. Each instance keeps its selection and its `--root` or `--cwd` override. Set `[ui] sync_repos = false` to disable live synchronization, or use `gitpane --no-sync-repos` for one pane. An opted-out pane keeps its own repo view while running, but its changes still save to the shared config. Use a separate `GITPANE_CONFIG` file for a separate persistent repo list.
+
 gitpane logs the resolved path at startup (`tracing` info level on stderr).
 
 ```toml
@@ -285,6 +287,7 @@ doze_after_secs = 120         # Input-idle seconds before a visible pane stops p
                               # under tmux Doze; outside tmux this gates everything until input wakes it)
 
 [ui]
+sync_repos = true            # Refresh additions/removals from other running instances
 frame_rate = 10              # Terminal refresh rate (fps)
 check_for_updates = true     # Check for new versions on startup
 update_position = "top-right" # Update notification position ("top-right" or "top-left")

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -41,6 +41,9 @@ poll_fetch_secs = 30
 discovery_cooldown_secs = 5
 
 [ui]
+# Share additions and removals with other running instances. Use
+# --no-sync-repos to disable this for one pane only.
+sync_repos = true
 # Terminal refresh rate in frames per second (default: 10)
 frame_rate = 10
 

--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -781,6 +781,7 @@ impl App {
                                 Some((format!("save failed: {e}"), Instant::now()));
                         } else {
                             self.success_message = Some((format!("theme: {name}"), Instant::now()));
+                            self.handle_repo_admin(Action::DiscoverNewRepos)?;
                         }
                     }
                     Err(e) => {

--- a/src/app/config_sync.rs
+++ b/src/app/config_sync.rs
@@ -1,0 +1,197 @@
+use super::*;
+
+impl App {
+    pub(super) fn refresh_shared_membership(&mut self) -> Result<()> {
+        self.last_config_check = Some(Instant::now());
+        if self.config.reload_membership()? {
+            self.handle_repo_admin(Action::DiscoverNewRepos)?;
+            self.action_tx.send(Action::Render)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn sync_shared_config(&mut self) {
+        if let Err(e) = self.refresh_shared_membership() {
+            self.error_message = Some((format!("config sync failed: {e}"), Instant::now()));
+            let _ = self.action_tx.send(Action::Render);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> (tempfile::TempDir, App, App) {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config {
+            root_dirs: vec![],
+            write_target_override: Some(dir.path().join("config.toml")),
+            ..Config::default()
+        };
+        config.save().unwrap();
+        let first = App::new(config.clone());
+        let second = App::new(config);
+        (dir, first, second)
+    }
+
+    #[tokio::test]
+    async fn another_pane_receives_additions_and_removals_on_tick() {
+        let (dir, mut first, mut second) = setup();
+        let path = dir.path().join("repo");
+        git2::Repository::init(&path).unwrap();
+        let path = path.canonicalize().unwrap();
+        first
+            .handle_repo_admin(Action::AddRepo(path.clone()))
+            .unwrap();
+        second.handle_event(Event::Tick).unwrap();
+        assert_eq!(second.repo_list.repos[0].path, path);
+        first
+            .handle_repo_admin(Action::RemoveRepo(RepoId(path)))
+            .unwrap();
+        second.last_config_check = None;
+        second.handle_event(Event::Tick).unwrap();
+        assert!(second.repo_list.repos.is_empty());
+        assert!(second.repo_list.selected_repo().is_none());
+    }
+
+    #[tokio::test]
+    async fn removal_of_discovered_repo_propagates_on_focus() {
+        let (dir, mut first, mut second) = setup();
+        let path = dir.path().join("repo");
+        git2::Repository::init(&path).unwrap();
+        let path = path.canonicalize().unwrap();
+        for app in [&mut first, &mut second] {
+            app.config.root_dirs = vec![dir.path().to_path_buf()];
+            app.handle_repo_admin(Action::DiscoverNewRepos).unwrap();
+        }
+        first
+            .handle_repo_admin(Action::RemoveRepo(RepoId(path)))
+            .unwrap();
+        second.handle_event(Event::FocusGained).unwrap();
+        assert!(second.repo_list.repos.is_empty());
+        assert!(second.config.excluded_repos.contains(&"repo".to_string()));
+    }
+
+    #[tokio::test]
+    async fn sleeping_pane_refreshes_shared_membership_on_wake() {
+        let (dir, mut first, mut second) = setup();
+        let path = dir.path().join("repo");
+        git2::Repository::init(&path).unwrap();
+        second
+            .handle_event(Event::Power(PowerState::DeepSleep))
+            .unwrap();
+        first
+            .handle_repo_admin(Action::AddRepo(path.clone()))
+            .unwrap();
+        assert!(second.repo_list.repos.is_empty());
+        second
+            .handle_event(Event::Power(PowerState::Awake))
+            .unwrap();
+        assert_eq!(second.repo_list.repos[0].path, path.canonicalize().unwrap());
+    }
+
+    #[tokio::test]
+    async fn add_refreshes_stale_membership_before_saving() {
+        let (dir, mut first, mut second) = setup();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        git2::Repository::init(&a).unwrap();
+        git2::Repository::init(&b).unwrap();
+        first.handle_repo_admin(Action::AddRepo(a.clone())).unwrap();
+        second
+            .handle_repo_admin(Action::AddRepo(b.clone()))
+            .unwrap();
+        first.handle_event(Event::FocusGained).unwrap();
+        for app in [&first, &second] {
+            assert!(
+                app.repo_list
+                    .repos
+                    .iter()
+                    .any(|r| r.path == a.canonicalize().unwrap())
+            );
+            assert!(
+                app.repo_list
+                    .repos
+                    .iter()
+                    .any(|r| r.path == b.canonicalize().unwrap())
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_shared_config_blocks_add_and_surfaces_error() {
+        let (dir, mut first, _) = setup();
+        let path = dir.path().join("repo");
+        git2::Repository::init(&path).unwrap();
+        std::fs::write(dir.path().join("config.toml"), "bad = [").unwrap();
+        first.handle_repo_admin(Action::AddRepo(path)).unwrap();
+        assert!(first.repo_list.repos.is_empty());
+        assert!(
+            first
+                .error_message
+                .as_ref()
+                .unwrap()
+                .0
+                .contains("config sync failed")
+        );
+    }
+
+    #[tokio::test]
+    async fn opted_out_pane_keeps_its_view_even_when_saving_changes() {
+        for cli_override in [false, true] {
+            let (dir, mut first, mut second) = setup();
+            if cli_override {
+                second.config.runtime_no_sync_repos = true;
+            } else {
+                second.config.ui.sync_repos = false;
+            }
+            let a = dir.path().join("a");
+            let b = dir.path().join("b");
+            git2::Repository::init(&a).unwrap();
+            git2::Repository::init(&b).unwrap();
+            first.handle_repo_admin(Action::AddRepo(a.clone())).unwrap();
+            second.handle_event(Event::Tick).unwrap();
+            second.handle_event(Event::FocusGained).unwrap();
+            assert!(second.repo_list.repos.is_empty());
+            second
+                .handle_repo_admin(Action::AddRepo(b.clone()))
+                .unwrap();
+            assert_eq!(second.repo_list.repos.len(), 1);
+            assert_eq!(second.repo_list.repos[0].path, b.canonicalize().unwrap());
+            first.handle_event(Event::FocusGained).unwrap();
+            assert_eq!(first.repo_list.repos.len(), 2);
+        }
+    }
+
+    #[tokio::test]
+    async fn synchronization_preserves_selected_repo_and_status() {
+        let (dir, mut first, mut second) = setup();
+        let b = dir.path().join("b");
+        let a = dir.path().join("a");
+        git2::Repository::init(&a).unwrap();
+        git2::Repository::init(&b).unwrap();
+        first.handle_repo_admin(Action::AddRepo(b.clone())).unwrap();
+        second.handle_event(Event::FocusGained).unwrap();
+        second.repo_list.select_repo_row(0);
+        std::fs::write(b.join("untracked.txt"), "keep this status").unwrap();
+        second.repo_list.repos[0].status =
+            Some(crate::git::status::query_status(&b, &second.config.submodules).unwrap());
+        first.handle_repo_admin(Action::AddRepo(a)).unwrap();
+        second.handle_event(Event::FocusGained).unwrap();
+        assert_eq!(
+            second.repo_list.selected_repo().unwrap().path,
+            b.canonicalize().unwrap()
+        );
+        assert!(
+            second
+                .repo_list
+                .selected_repo()
+                .unwrap()
+                .status
+                .as_ref()
+                .unwrap()
+                .is_dirty
+        );
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -37,6 +37,7 @@ use crate::watcher::RepoWatcher;
 
 mod actions;
 mod actions_extra;
+mod config_sync;
 mod github;
 mod input;
 mod launch;
@@ -162,6 +163,7 @@ impl Drop for GitOpGuard {
 
 pub(crate) struct App {
     config: Config,
+    last_config_check: Option<Instant>,
     should_quit: bool,
     /// Second quit request: exit without waiting for in-flight git ops.
     force_quit: bool,
@@ -376,6 +378,7 @@ impl App {
 
         let mut app = Self {
             config,
+            last_config_check: None,
             should_quit: false,
             force_quit: false,
             repo_list: RepoList::new(repo_paths, roots, expand_worktrees, theme.clone()),
@@ -584,6 +587,15 @@ impl App {
 
             let path = entry.path.clone();
             self.git_graph.load_repo(path, &name);
+        } else {
+            self.file_list
+                .set_files(Vec::new(), "", RepoId(std::path::PathBuf::new()));
+            let options = self.git_graph.graph_options.clone();
+            self.git_graph = GitGraph::new(self.theme.clone());
+            self.git_graph.graph_options = options;
+            let _ = self
+                .git_graph
+                .register_action_handler(self.action_tx.clone());
         }
     }
     /// Replace the live theme on App and every component.
@@ -746,6 +758,12 @@ impl App {
                 self.action_tx.send(Action::Quit)?;
             }
             Event::Tick => {
+                if self
+                    .last_config_check
+                    .is_none_or(|last| last.elapsed() >= Duration::from_secs(1))
+                {
+                    self.sync_shared_config();
+                }
                 // Housekeeping only; the run loop renders after the drain
                 // whenever this tick flushed substantive background work.
                 self.action_tx.send(Action::Tick)?;
@@ -815,6 +833,7 @@ impl App {
                 self.action_tx.send(Action::PollFetch)?;
             }
             Event::FocusGained => {
+                self.sync_shared_config();
                 if let Some(entry) = self.repo_list.selected_repo() {
                     self.action_tx
                         .send(Action::RefreshRepo(RepoId(entry.path.clone())))?;
@@ -824,6 +843,7 @@ impl App {
                 let was_deep = self.power == PowerState::DeepSleep;
                 self.power = state;
                 if was_deep && state != PowerState::DeepSleep {
+                    self.sync_shared_config();
                     // Waking from deep sleep: the Tui's re-enabled local
                     // timer already fires an immediate PollLocal; here we
                     // replay a deferred root change and repaint the stale

--- a/src/app/repo_admin.rs
+++ b/src/app/repo_admin.rs
@@ -5,6 +5,14 @@ impl App {
     /// and filesystem-driven rescans. Split from `handle_action_rest` so
     /// each dispatch file stays under the line cap.
     pub(super) fn handle_repo_admin(&mut self, action: Action) -> Result<()> {
+        if matches!(
+            action,
+            Action::AddRepo(_) | Action::RemoveRepo(_) | Action::RescanRepos
+        ) && let Err(e) = self.refresh_shared_membership()
+        {
+            self.error_message = Some((format!("config sync failed: {e}"), Instant::now()));
+            return Ok(());
+        }
         match action {
             Action::OpenAddRepo => {
                 self.path_input.show();
@@ -34,12 +42,15 @@ impl App {
                             .file_name()
                             .map(|n| n.to_string_lossy().to_string())
                             .unwrap_or_else(|| path.to_string_lossy().to_string());
-                        self.config.add_pinned_repo(path.clone());
-                        if let Err(e) = self.config.save() {
+                        let mut config = self.config.clone();
+                        config.add_pinned_repo(path.clone());
+                        if let Err(e) = config.save() {
                             tracing::error!("Failed to save config: {}", e);
                             self.error_message =
                                 Some((format!("save failed: {e}"), Instant::now()));
+                            return Ok(());
                         }
+                        self.config = config;
                         let repo_id = RepoId(path.clone());
                         let display = self.repo_list.display_for(&path);
                         let gitlink = path.join(".git").is_file();
@@ -69,16 +80,12 @@ impl App {
             }
             Action::RemoveRepo(ref id) => {
                 if let Some(idx) = self.repo_list.resolve_index(id) {
-                    // Clean up tracking sets for the removed repo
-                    self.pending_status.remove(id);
-                    self.dirty_repos.remove(id);
-                    self.last_refresh.remove(id);
-                    self.refresh_scheduled.remove(id);
+                    let mut config = self.config.clone();
                     let entry = &self.repo_list.repos[idx];
-                    // Drop cached graph snapshots for the removed repo.
-                    self.git_graph.invalidate_repo(&entry.path);
                     // Remove from pinned if it was pinned
-                    self.config.pinned_repos.retain(|p| *p != entry.path);
+                    config
+                        .pinned_repos
+                        .retain(|p| p.canonicalize().unwrap_or_else(|_| p.clone()) != entry.path);
                     // Exclude only repos the walk can rediscover: it
                     // promotes real `.git` directories (including a plain
                     // repo nested inside another one) but never gitlink
@@ -95,10 +102,21 @@ impl App {
                     let name = entry.name.clone();
                     if under_root
                         && entry.path.join(".git").is_dir()
-                        && !self.config.excluded_repos.contains(&name)
+                        && !config.excluded_repos.contains(&name)
                     {
-                        self.config.excluded_repos.push(name);
+                        config.excluded_repos.push(name);
                     }
+                    if let Err(e) = config.save() {
+                        self.error_message = Some((format!("save failed: {e}"), Instant::now()));
+                        return Ok(());
+                    }
+                    self.config = config;
+                    self.pending_status.remove(id);
+                    self.dirty_repos.remove(id);
+                    self.last_refresh.remove(id);
+                    self.refresh_scheduled.remove(id);
+                    // Drop cached graph snapshots for the removed repo.
+                    self.git_graph.invalidate_repo(&entry.path);
                     // A removed repo can be the graph/changes panels' current
                     // path context (via "Open in graph"): drop it so the
                     // panels fall back to the selected repo.
@@ -108,10 +126,6 @@ impl App {
                         .is_some_and(|aw| aw.path.starts_with(&entry.path))
                     {
                         self.active_worktree = None;
-                    }
-                    if let Err(e) = self.config.save() {
-                        tracing::error!("Failed to save config: {}", e);
-                        self.error_message = Some((format!("save failed: {e}"), Instant::now()));
                     }
                     self.repo_list.repos.remove(idx);
                     // Fix selection
@@ -135,6 +149,13 @@ impl App {
                 self.sync_selection();
             }
             Action::RescanRepos => {
+                let mut config = self.config.clone();
+                config.excluded_repos.clear();
+                if let Err(e) = config.save() {
+                    self.error_message = Some((format!("save failed: {e}"), Instant::now()));
+                    return Ok(());
+                }
+                self.config = config;
                 // Clear tracking sets — old paths are stale after rescan
                 self.pending_status.clear();
                 self.dirty_repos.clear();
@@ -143,12 +164,6 @@ impl App {
                 // The repo set is rebuilt from scratch; cached graphs for
                 // vanished paths are dead weight.
                 self.git_graph.invalidate_graph_cache();
-                // Clear user-added exclusions, save, and re-discover repos
-                self.config.excluded_repos.clear();
-                if let Err(e) = self.config.save() {
-                    tracing::error!("Failed to save config: {}", e);
-                    self.error_message = Some((format!("save failed: {e}"), Instant::now()));
-                }
                 // The list is rebuilt from scratch, so carry the selection
                 // across by identity (a worktree subrow falls back to its
                 // parent repo row — the fresh list has no statuses yet).
@@ -222,6 +237,11 @@ impl App {
                 }
             }
             _ => {}
+        }
+        if matches!(action, Action::AddRepo(_) | Action::RemoveRepo(_)) {
+            // A concurrent writer may have contributed membership changes
+            // during save. Apply the merged set in this instance too.
+            self.handle_repo_admin(Action::DiscoverNewRepos)?;
         }
         Ok(())
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -480,8 +480,8 @@ fn mock_graph_row() -> crate::git::graph::GraphRow {
 /// Removing a pinned submodule must not pollute `excluded_repos`: the walk
 /// never rediscovers a repo nested inside another listed repo, and the bare
 /// name would substring-match unrelated paths forever after.
-#[test]
-fn removing_a_pinned_submodule_leaves_excluded_repos_untouched() {
+#[tokio::test]
+async fn removing_a_pinned_submodule_leaves_excluded_repos_untouched() {
     let tmp = tempfile::TempDir::new().unwrap();
     make_repo(tmp.path(), "parent");
     let sub = make_submodule_repo(tmp.path(), "parent", "sub");
@@ -562,8 +562,8 @@ fn confirm_remove_repo_asks_before_removing() {
 /// Removing the repo whose path is the panels' active context (set by "Open
 /// in graph" on a submodule) must drop that context, or the panels keep
 /// rendering a repo that is no longer listed.
-#[test]
-fn removing_the_active_context_repo_clears_active_worktree() {
+#[tokio::test]
+async fn removing_the_active_context_repo_clears_active_worktree() {
     let tmp = tempfile::TempDir::new().unwrap();
     make_repo(tmp.path(), "parent");
     let sub = make_repo(
@@ -702,8 +702,8 @@ fn sort_repos_keeps_pinned_submodules_under_their_parent() {
 /// A plain repo nested inside another listed repo (real `.git` directory) IS
 /// rediscovered by the walk, so removing it must still exclude it — only
 /// gitlink checkouts skip the exclusion.
-#[test]
-fn removing_a_nested_plain_repo_still_excludes_it() {
+#[tokio::test]
+async fn removing_a_nested_plain_repo_still_excludes_it() {
     let tmp = tempfile::TempDir::new().unwrap();
     make_repo(tmp.path(), "parent");
     let plain = make_repo(

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -209,6 +209,7 @@ impl Default for UiConfig {
             update_position: UpdatePosition::default(),
             show_liveness: default_show_liveness(),
             expand_worktrees: default_expand_worktrees(),
+            sync_repos: default_sync_repos(),
         }
     }
 }
@@ -236,14 +237,20 @@ impl Default for Config {
             theme: Theme::default(),
             runtime_theme_override: None,
             runtime_root_override: None,
+            runtime_no_sync_repos: false,
             loaded_path: None,
             write_target_override: None,
+            saved_snapshot: None,
         }
     }
 }
 
 pub(super) fn default_forward_right_click() -> bool {
     false
+}
+
+pub(super) fn default_sync_repos() -> bool {
+    true
 }
 
 impl Default for HerdrConfig {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,7 @@ use crate::theme::{LoadThemeError, Theme, load_theme};
 
 mod defaults;
 mod load;
+mod sync;
 mod terminal;
 #[cfg(test)]
 mod test_support;
@@ -35,6 +36,8 @@ pub(crate) struct Config {
     /// remove/exclude a repo, rescan, commit a theme).
     #[serde(skip)]
     pub runtime_root_override: Option<PathBuf>,
+    #[serde(skip)]
+    pub runtime_no_sync_repos: bool,
     #[serde(default)]
     pub excluded_repos: Vec<String>,
     #[serde(default)]
@@ -82,6 +85,9 @@ pub(crate) struct Config {
     pub(crate) loaded_path: Option<PathBuf>,
     #[serde(skip, default)]
     pub(crate) write_target_override: Option<PathBuf>,
+    /// Last accepted local values, used to merge only this instance's edits.
+    #[serde(skip)]
+    pub(crate) saved_snapshot: Option<toml::Value>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -152,6 +158,9 @@ pub(crate) struct UiConfig {
     /// many worktrees make the list too tall; `w` still toggles either way.
     #[serde(default = "default_expand_worktrees")]
     pub expand_worktrees: bool,
+    /// Refresh additions and removals made by other running instances.
+    #[serde(default = "default_sync_repos")]
+    pub sync_repos: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -333,7 +342,7 @@ impl Config {
         default_write_path(&RealEnv).unwrap_or_else(|| PathBuf::from("config.toml"))
     }
 
-    pub fn save(&self) -> Result<()> {
+    pub fn save(&mut self) -> Result<()> {
         // A test that saves without an explicit target would silently
         // overwrite the developer's real config (this happened: app tests
         // exercising AddRepo/RemoveRepo clobbered ~/.config/gitpane). Fail
@@ -390,6 +399,7 @@ impl Config {
         };
 
         config.resolve_theme(env);
+        config.saved_snapshot = Some(toml::Value::try_from(&config)?);
         Ok(config)
     }
 
@@ -452,7 +462,7 @@ impl Config {
         }
     }
 
-    pub(crate) fn save_with_env(&self, env: &dyn ConfigEnv) -> Result<()> {
+    pub(crate) fn save_with_env(&mut self, env: &dyn ConfigEnv) -> Result<()> {
         let config_path = self
             .write_target_override
             .clone()
@@ -460,12 +470,7 @@ impl Config {
             .or_else(|| default_write_path(env))
             .ok_or_else(|| eyre!("no writable config path available"))?;
 
-        if let Some(parent) = config_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let contents = toml::to_string_pretty(self)?;
-        std::fs::write(&config_path, contents)?;
-        Ok(())
+        self.save_to_path(&config_path)
     }
 
     /// Config files that exist on disk but are ignored because another file

--- a/src/config/sync.rs
+++ b/src/config/sync.rs
@@ -1,0 +1,295 @@
+use super::*;
+use std::{fs, io::Write, path::Path};
+
+impl Config {
+    pub(crate) fn sync_repos_enabled(&self) -> bool {
+        self.ui.sync_repos && !self.runtime_no_sync_repos
+    }
+
+    /// Reload shared repo membership without replacing session settings.
+    pub(crate) fn reload_membership(&mut self) -> Result<bool> {
+        if !self.sync_repos_enabled() {
+            return Ok(false);
+        }
+        // Constructed configs have no shared source until loaded or assigned
+        // an explicit persistence target.
+        if self.saved_snapshot.is_none()
+            && self.loaded_path.is_none()
+            && self.write_target_override.is_none()
+        {
+            return Ok(false);
+        }
+        let path = self
+            .write_target_override
+            .clone()
+            .or_else(|| self.loaded_path.clone())
+            .or_else(|| default_write_path(&RealEnv))
+            .ok_or_else(|| eyre!("no config path available"))?;
+        let Some(disk) = read_config(&path)? else {
+            return Ok(false);
+        };
+        let changed =
+            self.pinned_repos != disk.pinned_repos || self.excluded_repos != disk.excluded_repos;
+        // Only advance the baseline for fields adopted from disk. Other
+        // settings remain local, so an unrelated save preserves remote edits.
+        if let Some(snapshot) = self.saved_snapshot.as_mut() {
+            let value = toml::Value::try_from(&disk)?;
+            for key in ["pinned_repos", "excluded_repos"] {
+                snapshot[key] = value[key].clone();
+            }
+        }
+        self.pinned_repos = disk.pinned_repos;
+        self.excluded_repos = disk.excluded_repos;
+        Ok(changed)
+    }
+
+    pub(super) fn save_to_path(&mut self, path: &Path) -> Result<()> {
+        let parent = path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or(Path::new("."));
+        fs::create_dir_all(parent)?;
+        let resolved = match fs::canonicalize(path) {
+            Ok(path) => path,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => fs::canonicalize(parent)?.join(
+                path.file_name()
+                    .ok_or_else(|| eyre!("invalid config path"))?,
+            ),
+            Err(e) => return Err(e.into()),
+        };
+        let path = resolved.as_path();
+        let parent = path
+            .parent()
+            .ok_or_else(|| eyre!("invalid config parent"))?;
+        // Keep the lock inode stable while the config itself is replaced.
+        let mut lock_name = path.as_os_str().to_os_string();
+        lock_name.push(".lock");
+        let lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_name)?;
+        fs2::FileExt::lock_exclusive(&lock)?;
+        let local = toml::Value::try_from(&*self)?;
+        let mut merged = match read_config(path)? {
+            Some(disk) => toml::Value::try_from(disk)?,
+            None => local.clone(),
+        };
+        if let Some(base) = &self.saved_snapshot {
+            merge_changes(base, &local, &mut merged);
+        } else {
+            merged = local;
+        }
+        let adopted: Config = merged.clone().try_into()?;
+        let mut temp = tempfile::NamedTempFile::new_in(parent)?;
+        if let Ok(metadata) = fs::metadata(path) {
+            temp.as_file().set_permissions(metadata.permissions())?;
+        }
+        temp.write_all(toml::to_string_pretty(&merged)?.as_bytes())?;
+        temp.as_file().sync_all()?;
+        temp.persist(path)?;
+        if self.sync_repos_enabled() {
+            self.pinned_repos = adopted.pinned_repos;
+            self.excluded_repos = adopted.excluded_repos;
+        }
+        self.saved_snapshot = Some(toml::Value::try_from(&*self)?);
+        Ok(())
+    }
+}
+
+fn read_config(path: &Path) -> Result<Option<Config>> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    let mut config: Config = toml::from_str(&contents)?;
+    config.expand_tildes();
+    Ok(Some(config))
+}
+
+fn merge_changes(base: &toml::Value, local: &toml::Value, disk: &mut toml::Value) {
+    if base == local {
+        return;
+    }
+    if let (Some(base), Some(local), Some(disk)) =
+        (base.as_table(), local.as_table(), disk.as_table_mut())
+    {
+        for key in base.keys().filter(|key| !local.contains_key(*key)) {
+            disk.remove(key);
+        }
+        for (key, value) in local {
+            if base.get(key) == Some(value) {
+                continue;
+            }
+            match (base.get(key), disk.get_mut(key)) {
+                (Some(old), Some(current)) if key == "pinned_repos" || key == "excluded_repos" => {
+                    if let (Some(old), Some(new), Some(current)) =
+                        (old.as_array(), value.as_array(), current.as_array_mut())
+                    {
+                        current.retain(|v| !old.contains(v) || new.contains(v));
+                        for item in new {
+                            if !old.contains(item) && !current.contains(item) {
+                                current.push(item.clone());
+                            }
+                        }
+                    }
+                }
+                (Some(old), Some(current)) => merge_changes(old, value, current),
+                _ => {
+                    disk.insert(key.clone(), value.clone());
+                }
+            }
+        }
+    } else {
+        *disk = local.clone();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load(path: &Path) -> Config {
+        Config::load_with_env(&super::super::test_support::MockEnv {
+            gitpane_config: Some(path.to_path_buf()),
+            existing: [path.to_path_buf()].into(),
+            ..Default::default()
+        })
+        .unwrap()
+    }
+
+    fn setup() -> (tempfile::TempDir, Config) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "root_dirs = []\npinned_repos = ['/tmp/old']\n").unwrap();
+        let config = load(&path);
+        (dir, config)
+    }
+
+    #[test]
+    fn stale_saves_preserve_removals_additions_and_other_settings() {
+        let (dir, mut first) = setup();
+        let path = dir.path().join("config.toml");
+        let mut second = load(&path);
+        first.pinned_repos.clear();
+        first.theme_name = "muted".into();
+        first.save().unwrap();
+        second.pinned_repos.push("/tmp/new".into());
+        second.save().unwrap();
+        let disk = load(&path);
+        assert_eq!(disk.pinned_repos, vec![PathBuf::from("/tmp/new")]);
+        assert_eq!(disk.theme_name, "muted");
+        second.scan_depth = 7;
+        second.save().unwrap();
+        assert_eq!(load(&path).theme_name, "muted");
+        assert_eq!(load(&path).scan_depth, 7);
+    }
+
+    #[test]
+    fn concurrent_saves_preserve_independent_additions() {
+        let (dir, first) = setup();
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(4));
+        let threads: Vec<_> = (0..4)
+            .map(|i| {
+                let mut config = first.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    config.pinned_repos.push(format!("/tmp/repo-{i}").into());
+                    barrier.wait();
+                    config.save().unwrap();
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        let disk = load(&dir.path().join("config.toml"));
+        for i in 0..4 {
+            assert!(disk.pinned_repos.contains(&format!("/tmp/repo-{i}").into()));
+        }
+        assert!(disk.pinned_repos.contains(&PathBuf::from("/tmp/old")));
+    }
+
+    #[test]
+    fn optional_settings_can_be_cleared_without_stale_writers_restoring_them() {
+        let (dir, mut first) = setup();
+        let path = dir.path().join("config.toml");
+        first.open.command = Some("editor {path}".into());
+        first.save().unwrap();
+        let mut second = load(&path);
+        first.open.command = None;
+        first.save().unwrap();
+        assert!(load(&path).open.command.is_none());
+        second.open.placement = "new-window".into();
+        second.save().unwrap();
+        let disk = load(&path);
+        assert!(disk.open.command.is_none());
+        assert_eq!(disk.open.placement, "new-window");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn saving_through_a_symlink_preserves_the_link_and_shared_target() {
+        let (dir, mut first) = setup();
+        let path = dir.path().join("config.toml");
+        let alias = dir.path().join("alias.toml");
+        std::os::unix::fs::symlink(&path, &alias).unwrap();
+        let mut second = load(&alias);
+        first.pinned_repos.clear();
+        first.save().unwrap();
+        second.pinned_repos.push("/tmp/new".into());
+        second.save().unwrap();
+        assert!(alias.is_symlink());
+        assert_eq!(load(&path).pinned_repos, vec![PathBuf::from("/tmp/new")]);
+    }
+
+    #[test]
+    fn reload_preserves_runtime_overrides_and_remote_settings_on_save() {
+        let (dir, mut first) = setup();
+        let path = dir.path().join("config.toml");
+        let mut second = load(&path);
+        second.runtime_root_override = Some("/tmp/session".into());
+        second.runtime_theme_override = Some("muted".into());
+        first.pinned_repos.clear();
+        first.theme_name = "muted".into();
+        first.save().unwrap();
+        assert!(second.reload_membership().unwrap());
+        assert_eq!(second.runtime_root_override, Some("/tmp/session".into()));
+        assert_eq!(second.runtime_theme_override.as_deref(), Some("muted"));
+        second.save().unwrap();
+        let disk = load(&path);
+        assert!(disk.pinned_repos.is_empty());
+        assert!(disk.root_dirs.is_empty());
+        assert_eq!(disk.theme_name, "muted");
+    }
+
+    #[test]
+    fn invalid_config_is_reported_and_never_overwritten() {
+        let (dir, mut config) = setup();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "invalid = [").unwrap();
+        assert!(config.reload_membership().is_err());
+        assert!(config.save().is_err());
+        assert_eq!(config.pinned_repos, vec![PathBuf::from("/tmp/old")]);
+        assert_eq!(fs::read_to_string(path).unwrap(), "invalid = [");
+    }
+
+    #[test]
+    fn missing_config_can_be_created_and_then_shared() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new/config.toml");
+        let mut first = Config::load_with_env(&super::super::test_support::MockEnv {
+            gitpane_config: Some(path.clone()),
+            ..Default::default()
+        })
+        .unwrap();
+        let mut second = first.clone();
+        assert!(!second.reload_membership().unwrap());
+        first.pinned_repos.push("/tmp/new".into());
+        first.save().unwrap();
+        assert!(second.reload_membership().unwrap());
+        assert_eq!(second.pinned_repos, vec![PathBuf::from("/tmp/new")]);
+    }
+}

--- a/src/config/tests_fields.rs
+++ b/src/config/tests_fields.rs
@@ -8,6 +8,18 @@ use std::{
 };
 
 #[test]
+fn repo_sync_defaults_on_and_can_be_disabled_without_persisting_cli_override() {
+    let mut config: Config = toml::from_str("[ui]\nframe_rate = 30\n").unwrap();
+    assert!(config.sync_repos_enabled());
+    config.runtime_no_sync_repos = true;
+    assert!(!config.sync_repos_enabled());
+    let loaded: Config = toml::from_str(&toml::to_string(&config).unwrap()).unwrap();
+    assert!(loaded.sync_repos_enabled());
+    let disabled: Config = toml::from_str("[ui]\nsync_repos = false\n").unwrap();
+    assert!(!disabled.sync_repos_enabled());
+}
+
+#[test]
 fn test_default_config_has_code_root() {
     let config = Config::default();
     assert!(!config.root_dirs.is_empty());

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,9 @@ struct Cli {
 
     #[command(subcommand)]
     command: Option<Command>,
+    /// Keep this instance's repo view independent of other running instances
+    #[arg(long)]
+    no_sync_repos: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -153,6 +156,7 @@ async fn run() -> Result<()> {
     install_tracing()?;
 
     let mut config = config::Config::load()?;
+    config.runtime_no_sync_repos = cli.no_sync_repos;
 
     // Bound libgit2 before any repository is opened; must run before the
     // first git2 call (status polls, graph builds).
@@ -327,6 +331,14 @@ mod tests {
     fn cwd_is_optional() {
         let cli = Cli::try_parse_from(["gitpane"]).unwrap();
         assert!(!cli.cwd);
+    }
+
+    #[test]
+    fn repo_sync_can_be_disabled_for_one_pane() {
+        assert!(!Cli::try_parse_from(["gitpane"]).unwrap().no_sync_repos);
+        let cli = Cli::try_parse_from(["gitpane", "--no-sync-repos", "--cwd"]).unwrap();
+        assert!(cli.no_sync_repos);
+        assert!(cli.cwd);
     }
 
     #[test]


### PR DESCRIPTION
Closes #71

## In simple terms
Adding or removing a repository updates other running gitpane instances using the same config. Disable this for one pane with `--no-sync-repos`, or set `[ui] sync_repos = false`.

## Problem
Each instance retained its startup config, leaving other panes stale and allowing later saves to overwrite shared changes.

## Fix
Refresh shared membership on ticks, focus, and wake while preserving selection and session root overrides. Merge local edits under a file lock and replace config atomically. Opted-out panes retain their local view while saving their edits to the shared config.

## Test
`just ci` passed: 509 tests passed, 1 ignored. Added regression coverage for concurrent saves, membership changes, opt-out behavior, runtime overrides, malformed config, symlinks, optional settings, and selection/status preservation. Fresh review found no remaining blockers.
