### PR TITLE
fix: address project audit findings before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
+      - name: Test release metadata validation
+        # Ubuntu provides Python 3.11+ for the stdlib tomllib parser.
+        run: python3 -B -m unittest discover -s scripts -p 'test_release_metadata.py'
+
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  validate:
+    name: Validate release metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate tag, Cargo versions, and release notes
+        # Ubuntu provides Python 3.11+ for the stdlib tomllib parser.
+        run: python3 scripts/release_metadata.py --tag "$GITHUB_REF_NAME"
+
   build:
     name: Build (${{ matrix.target }})
+    needs: validate
     strategy:
       matrix:
         include:
@@ -62,7 +74,7 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --locked --release --target ${{ matrix.target }}
 
       - name: Package (unix)
         if: matrix.archive == 'tar.gz'
@@ -98,28 +110,14 @@ jobs:
           merge-multiple: true
 
       - name: Extract CHANGELOG for this tag
-        id: changelog
+        # This job also runs on Ubuntu with Python 3.11+.
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          awk -v ver="$VERSION" '
-            $0 ~ "^## \\[" ver "\\]" { flag=1; print; next }
-            flag && /^## \[/ { exit }
-            flag { print }
-          ' CHANGELOG.md > release-notes.md
-          if [ ! -s release-notes.md ]; then
-            echo "No CHANGELOG section for $VERSION; falling back to a stub." >&2
-            echo "## ${VERSION}" > release-notes.md
-            echo "" >> release-notes.md
-            echo "See [CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/main/CHANGELOG.md) for details." >> release-notes.md
-          else
-            echo "" >> release-notes.md
-            echo "---" >> release-notes.md
-            echo "" >> release-notes.md
-            echo "Full changelog: https://github.com/${GITHUB_REPOSITORY}/blob/main/CHANGELOG.md" >> release-notes.md
-          fi
-          echo "----- release body -----"
+          python3 scripts/release_metadata.py --tag "$GITHUB_REF_NAME" --notes release-notes.md
+          echo "" >> release-notes.md
+          echo "---" >> release-notes.md
+          echo "" >> release-notes.md
+          echo "Full changelog: https://github.com/${GITHUB_REPOSITORY}/blob/main/CHANGELOG.md" >> release-notes.md
           cat release-notes.md
-          echo "------------------------"
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v3.0.2
@@ -149,7 +147,7 @@ jobs:
         # non-error; real failures (e.g. 403 auth) must fail the job.
         run: |
           set +e
-          cargo publish 2>&1 | tee "$RUNNER_TEMP/publish.log"
+          cargo publish --locked 2>&1 | tee "$RUNNER_TEMP/publish.log"
           status=${PIPESTATUS[0]}
           set -e
           if [ "$status" -eq 0 ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ map in [README.md#architecture](README.md#architecture). Key areas:
 - Test behavior and outcomes, not internals, and put tests next to the code they
   cover.
 - Prefer a pure, testable core: a function returns a plan or value, and a thin
-  caller performs the I/O (see `src/session/launcher.rs`).
+  caller performs the I/O (see `src/session/launcher/mod.rs`).
 - Validate or quote any user input that reaches a shell. argv launches avoid the
   shell entirely; `sh -c` paths quote every substituted value.
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ scan_depth = 2
 # Always show these repos at the top
 pinned_repos = ["~/Code/important-project"]
 
-# Skip repos matching these directory names
+# Skip matching path substrings. Use "path:/absolute/repo" for one exact repo.
 excluded_repos = ["node_modules", ".cargo", "target"]
 
 [watch]

--- a/scripts/release_metadata.py
+++ b/scripts/release_metadata.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Validate release metadata and extract its changelog (requires Python 3.11+)."""
+
+import argparse
+from pathlib import Path
+import re
+import sys
+
+if sys.version_info < (3, 11):
+    sys.exit("Release validation requires Python 3.11 or newer.")
+
+import tomllib
+
+
+def release_notes(root: Path, tag: str) -> str:
+    if not re.fullmatch(r"v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)", tag):
+        raise ValueError("release tag must have the form vX.Y.Z")
+    version = tag[1:]
+    with (root / "Cargo.toml").open("rb") as manifest_file:
+        package = tomllib.load(manifest_file)["package"]
+    if package.get("name") != "gitpane" or package.get("version") != version:
+        raise ValueError(f"Cargo.toml must declare gitpane version {version}")
+    with (root / "Cargo.lock").open("rb") as lock_file:
+        packages = tomllib.load(lock_file)["package"]
+    locked = [package for package in packages if package.get("name") == "gitpane"]
+    if len(locked) != 1 or locked[0].get("version") != version:
+        raise ValueError(f"Cargo.lock must contain exactly one gitpane package at version {version}")
+
+    lines = (root / "CHANGELOG.md").read_text(encoding="utf-8").splitlines()
+    starts = []
+    for index, line in enumerate(lines):
+        heading = re.fullmatch(r"## \[([^\]]+)\](?:[ \t].*)?", line)
+        if heading and heading[1] == version:
+            starts.append(index)
+    if len(starts) != 1:
+        raise ValueError(f"CHANGELOG.md must contain exactly one ## [{version}] section")
+    start = starts[0]
+    end = next(
+        (index for index in range(start + 1, len(lines))
+         if re.match(r"^##(?:[ \t]|$)", lines[index])),
+        len(lines),
+    )
+    body = lines[start + 1:end]
+    if not any(line.strip() and not re.match(r"^#{1,6}(?:[ \t]|$)", line) for line in body):
+        raise ValueError(f"CHANGELOG.md section {version} has no release notes")
+    return "\n".join(lines[start:end]).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--notes", type=Path, help="Write validated notes to this file")
+    args = parser.parse_args()
+    try:
+        notes = release_notes(args.root, args.tag)
+        if args.notes:
+            args.notes.write_text(notes, encoding="utf-8")
+        else:
+            print(notes, end="")
+    except (OSError, ValueError, KeyError, TypeError) as error:
+        print(f"Release validation failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_release_metadata.py
+++ b/scripts/test_release_metadata.py
@@ -1,0 +1,102 @@
+"""Behavioral checks for the release gate, using temporary release files."""
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("release_metadata.py")
+
+
+class ReleaseMetadataTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.write_versions("1.2.3", "1.2.3")
+        self.changelog = self.root / "CHANGELOG.md"
+        self.changelog.write_text(
+            "# Changelog\n\n## [Unreleased]\n\nFuture work.\n\n"
+            "## [1.2.3] - 2026-09-08\n\n### Fixed\n\n- Keep Unicode café readable.\n\n"
+            "## [1.2.2]\n\nOlder work.\n", encoding="utf-8"
+        )
+        self.notes = self.root / "release-notes.md"
+
+    def write_versions(self, manifest, locked):
+        (self.root / "Cargo.toml").write_text(
+            f'[package]\nname = "gitpane"\nversion = "{manifest}"\n', encoding="utf-8"
+        )
+        (self.root / "Cargo.lock").write_text(
+            f'version = 4\n[[package]]\nname = "gitpane"\nversion = "{locked}"\n',
+            encoding="utf-8",
+        )
+
+    def validate(self, tag="v1.2.3"):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(self.root),
+             "--tag", tag, "--notes", str(self.notes)],
+            capture_output=True, text=True, check=False,
+        )
+
+    def assert_rejected(self, result, expected):
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(expected, result.stderr)
+        self.assertFalse(self.notes.exists(), "invalid metadata produced release notes")
+
+    def test_valid_release_extracts_only_its_own_section(self):
+        result = self.validate()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        notes = self.notes.read_text(encoding="utf-8")
+        self.assertIn("## [1.2.3] - 2026-09-08", notes)
+        self.assertIn("café", notes)
+        self.assertNotIn("Future work", notes)
+        self.assertNotIn("Older work", notes)
+
+    def test_manifest_and_lock_versions_must_both_match_the_tag(self):
+        for manifest, locked in [("1.2.2", "1.2.3"), ("1.2.3", "1.2.2")]:
+            with self.subTest(manifest=manifest, locked=locked):
+                self.write_versions(manifest, locked)
+                self.assert_rejected(self.validate(), "version 1.2.3")
+
+    def test_only_stable_semantic_version_tags_are_accepted(self):
+        for tag in ["1.2.3", "v1x2x3", "v1.2", "v01.2.3", "v1.2.3-rc.1"]:
+            with self.subTest(tag=tag):
+                self.assert_rejected(self.validate(tag), "vX.Y.Z")
+
+    def test_changelog_version_dots_are_literal(self):
+        self.changelog.write_text("## [1x2x3]\n\nWrong release.\n", encoding="utf-8")
+        self.assert_rejected(self.validate(), "## [1.2.3]")
+
+    def test_missing_duplicate_and_empty_release_sections_are_rejected(self):
+        for changelog in [
+            "## [Unreleased]\n\nPending.\n",
+            "## [1.2.3]\n\nFirst.\n\n## [1.2.3]\n\nDuplicate.\n",
+            "## [1.2.3]\n\n\t\n## [1.2.2]\n\nOlder.\n",
+            "## [1.2.3]\n\n### Added\n\n### Fixed\n",
+        ]:
+            with self.subTest(changelog=changelog):
+                self.changelog.write_text(changelog, encoding="utf-8")
+                self.assert_rejected(self.validate(), "CHANGELOG.md")
+
+    def test_plain_paragraph_notes_without_categories_are_valid(self):
+        self.changelog.write_text("## [1.2.3]\n\nFix startup.\n", encoding="utf-8")
+        result = self.validate()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Fix startup.", self.notes.read_text(encoding="utf-8"))
+
+    def test_missing_or_duplicate_lock_packages_are_rejected(self):
+        package = '[[package]]\nname = "gitpane"\nversion = "1.2.3"\n'
+        for contents in ["version = 4\npackage = []\n", "version = 4\n" + package * 2]:
+            with self.subTest(contents=contents):
+                (self.root / "Cargo.lock").write_text(contents, encoding="utf-8")
+                self.assert_rejected(self.validate(), "Cargo.lock")
+
+    def test_malformed_manifest_fails_without_writing_notes(self):
+        (self.root / "Cargo.toml").write_text("[invalid", encoding="utf-8")
+        self.assert_rejected(self.validate(), "Release validation failed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -488,10 +488,11 @@ impl App {
                 self.picker.hide();
                 match self.pending_pick.take() {
                     Some(PendingPick::Launch(p)) => {
-                        let plan = crate::session::launcher::plan(
+                        let plan = crate::session::launcher::plan_with_target(
                             p.command.as_deref(),
                             value,
                             &p.dir.to_string_lossy(),
+                            &p.target.to_string_lossy(),
                             p.base.as_deref(),
                             self.mux,
                         );

--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -191,20 +191,15 @@ impl App {
             | Action::UnstageFile(ref id, ref path)
             | Action::DiscardFileConfirmed(ref id, ref path, _) => {
                 if let Some(dir) = self.file_op_dir(id) {
-                    let mut args: Vec<String> = match action {
-                        Action::StageFile(..) => vec!["add".into(), "-A".into()],
-                        Action::UnstageFile(..) => vec!["reset".into(), "-q".into()],
-                        Action::DiscardFileConfirmed(_, _, true) => {
-                            vec!["clean".into(), "-fdq".into()]
-                        }
-                        Action::DiscardFileConfirmed(_, _, false) => {
-                            vec!["restore".into(), "--staged".into(), "--worktree".into()]
-                        }
+                    use crate::git::file_ops::FileOperation;
+                    let operation = match action {
+                        Action::StageFile(..) => FileOperation::Stage,
+                        Action::UnstageFile(..) => FileOperation::Unstage,
+                        Action::DiscardFileConfirmed(_, _, true) => FileOperation::DeleteUntracked,
+                        Action::DiscardFileConfirmed(_, _, false) => FileOperation::Discard,
                         _ => unreachable!(),
                     };
-                    args.push("--".into());
-                    args.push(path.to_string_lossy().into_owned());
-                    self.spawn_git_op_in(dir, id.clone(), args);
+                    self.spawn_file_op(dir, id.clone(), path.clone(), operation);
                 }
             }
             Action::CopyFilePath(ref id, ref path) => {
@@ -551,50 +546,12 @@ impl App {
                         let fp = file_path.clone();
                         let tx = self.action_tx.clone();
                         tokio::task::spawn_blocking(move || {
-                            let output = std::process::Command::new("git")
-                                .arg("-C")
-                                .arg(&path)
-                                .arg("diff")
-                                .arg("HEAD")
-                                .arg("--")
-                                .arg(&fp)
-                                .output();
-                            match output {
-                                Ok(o) => {
-                                    let mut text = String::from_utf8_lossy(&o.stdout).to_string();
-                                    if text.is_empty() {
-                                        text = String::from_utf8_lossy(&{
-                                            std::process::Command::new("git")
-                                                .arg("-C")
-                                                .arg(&path)
-                                                .arg("diff")
-                                                .arg("--no-index")
-                                                .arg("/dev/null")
-                                                .arg(&fp)
-                                                .output()
-                                                .map(|o| o.stdout)
-                                                .unwrap_or_default()
-                                        })
-                                        .to_string();
-                                    }
-                                    if text.is_empty() {
-                                        text = "(no diff available)".to_string();
-                                    }
-                                    let _ = tx.send(Action::DiffLoaded {
-                                        generation: diff_gen,
-                                        content: text,
-                                    });
-                                }
-                                Err(e) => {
-                                    let _ = tx.send(Action::DiffLoaded {
-                                        generation: diff_gen,
-                                        content: format!(
-                                            "Failed to get diff: {}",
-                                            crate::git::describe_spawn_error(&e)
-                                        ),
-                                    });
-                                }
-                            }
+                            let content = crate::git::file_ops::diff(&path, &fp)
+                                .unwrap_or_else(|error| format!("Failed to get diff: {error}"));
+                            let _ = tx.send(Action::DiffLoaded {
+                                generation: diff_gen,
+                                content,
+                            });
                         });
                     }
                 }
@@ -744,8 +701,8 @@ impl App {
                     .chars()
                     .map(|c| if c == '\n' { ' ' } else { c })
                     .collect();
-                let truncated = if clean.len() > 120 {
-                    format!("{}...", &clean[..117])
+                let truncated = if clean.chars().count() > 120 {
+                    format!("{}...", clean.chars().take(117).collect::<String>())
                 } else {
                     clean
                 };

--- a/src/app/config_sync.rs
+++ b/src/app/config_sync.rs
@@ -70,7 +70,7 @@ mod tests {
             .unwrap();
         second.handle_event(Event::FocusGained).unwrap();
         assert!(second.repo_list.repos.is_empty());
-        assert!(second.config.excluded_repos.contains(&"repo".to_string()));
+        assert!(crate::git::scanner::discover_repos(&second.config).is_empty());
     }
 
     #[tokio::test]

--- a/src/app/github.rs
+++ b/src/app/github.rs
@@ -1,6 +1,7 @@
 use super::*;
 
-use crate::git::github::{self, GhItem};
+use crate::git::github;
+use std::sync::atomic::AtomicU64;
 
 /// How long a repo's fetched issue/PR data is considered fresh. Selection
 /// changes within this window reuse the cache instead of re-spawning `gh`.
@@ -11,7 +12,7 @@ const GITHUB_COOLDOWN: Duration = Duration::from_secs(60);
 const GITHUB_SELECT_DEBOUNCE: Duration = Duration::from_millis(400);
 
 /// Which issues/PRs the panel lists. Cycled with `c`; reset to `Open` on nav.
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub(super) enum GithubStateFilter {
     #[default]
     Open,
@@ -54,19 +55,71 @@ impl GithubStateFilter {
 pub(super) struct GithubState {
     /// `origin` parsed to `(owner, repo)`; `None` = not a github.com repo.
     owner_repo: Option<(String, String)>,
-    /// A `gh` fetch is currently in flight.
-    loading: bool,
-    /// Bumped per request so a late result for a superseded request is dropped.
-    generation: u64,
+    remote_checked_at: Option<Instant>,
+    snapshots: HashMap<GithubStateFilter, GithubSnapshot>,
+}
+
+#[derive(Default)]
+struct GithubSnapshot {
+    /// The request ID also identifies its filter through this snapshot.
+    loading: Option<u64>,
     /// When the last fetch attempt completed (drives the freshness cooldown).
     fetched_at: Option<Instant>,
-    issues: Vec<GhItem>,
-    prs: Vec<GhItem>,
-    /// Open-item count from the last `open`-filter fetch. Drives auto-show, and
-    /// stays put while the user browses closed/all so the panel doesn't collapse.
-    open_count: usize,
+    data: Option<github::GithubData>,
     /// First stderr line of the last failed fetch, if any.
     error: Option<String>,
+}
+
+impl GithubState {
+    /// Reserve one request per filter. IDs remain unique after a repository is
+    /// removed and re-added, so a response from its former cache cannot land.
+    fn begin_request(
+        &mut self,
+        filter: GithubStateFilter,
+        force: bool,
+        now: Instant,
+    ) -> Option<u64> {
+        static NEXT_REQUEST: AtomicU64 = AtomicU64::new(1);
+        let snapshot = self.snapshots.entry(filter).or_default();
+        if snapshot.loading.is_some()
+            || (!force
+                && snapshot
+                    .fetched_at
+                    .is_some_and(|at| now.saturating_duration_since(at) < GITHUB_COOLDOWN))
+        {
+            return None;
+        }
+        let generation = NEXT_REQUEST.fetch_add(1, Ordering::Relaxed);
+        snapshot.loading = Some(generation);
+        Some(generation)
+    }
+
+    fn complete_request(&mut self, generation: u64, result: Result<github::GithubData, String>) {
+        let Some(snapshot) = self
+            .snapshots
+            .values_mut()
+            .find(|s| s.loading == Some(generation))
+        else {
+            return;
+        };
+        snapshot.loading = None;
+        snapshot.fetched_at = Some(Instant::now());
+        match result {
+            Ok(data) => {
+                snapshot.data = Some(data);
+                snapshot.error = None;
+            }
+            Err(error) => snapshot.error = Some(error),
+        }
+    }
+
+    fn open_count(&self) -> usize {
+        self.snapshots
+            .get(&GithubStateFilter::Open)
+            .and_then(|snapshot| snapshot.data.as_ref())
+            .map(|data| data.issues.len() + data.prs.len())
+            .unwrap_or(0)
+    }
 }
 
 impl App {
@@ -93,7 +146,7 @@ impl App {
     fn selected_github_open_count(&self) -> usize {
         self.github_target()
             .and_then(|(id, _, _)| self.github_cache.get(&id))
-            .map(|s| s.open_count)
+            .map(GithubState::open_count)
             .unwrap_or(0)
     }
 
@@ -118,6 +171,7 @@ impl App {
         }
         self.github_forced = None;
         self.github_state_filter = GithubStateFilter::Open;
+        self.retarget_github_panel();
         self.github_select_gen = self.github_select_gen.wrapping_add(1);
         let generation = self.github_select_gen;
         let tx = self.action_tx.clone();
@@ -166,33 +220,31 @@ impl App {
         let Some((id, path, _)) = self.github_target() else {
             return;
         };
-        let state = self.github_state_filter.gh_state();
+        let filter = self.github_state_filter;
         let now = Instant::now();
         let entry = self.github_cache.entry(id.clone()).or_default();
-        if entry.loading {
-            return;
-        }
-        if !force
-            && let Some(at) = entry.fetched_at
-            && now.saturating_duration_since(at) < GITHUB_COOLDOWN
-        {
-            return;
-        }
         if entry.owner_repo.is_none() {
+            if !force
+                && entry
+                    .remote_checked_at
+                    .is_some_and(|at| now.saturating_duration_since(at) < GITHUB_COOLDOWN)
+            {
+                return;
+            }
             entry.owner_repo = github::github_owner_repo(&path);
+            entry.remote_checked_at = Some(now);
         }
         let Some((owner, repo)) = entry.owner_repo.clone() else {
             // Not a github.com repo: record the attempt so we don't re-probe the
             // remote on every settle, and never spawn `gh`.
-            entry.fetched_at = Some(now);
             return;
         };
-        entry.loading = true;
-        entry.generation = entry.generation.wrapping_add(1);
-        let generation = entry.generation;
+        let Some(generation) = entry.begin_request(filter, force, now) else {
+            return;
+        };
         let tx = self.action_tx.clone();
         tokio::task::spawn_blocking(move || {
-            let result = github::fetch(&owner, &repo, state);
+            let result = github::fetch(&owner, &repo, filter.gh_state());
             let _ = tx.send(Action::GitHubFetched {
                 repo_id: id,
                 generation,
@@ -209,26 +261,8 @@ impl App {
         generation: u64,
         result: Result<github::GithubData, String>,
     ) {
-        // Only an `open` fetch refreshes the auto-show count, so browsing
-        // closed/all leaves it untouched and the panel stays put.
-        let is_open_filter = self.github_state_filter == GithubStateFilter::Open;
         if let Some(entry) = self.github_cache.get_mut(&repo_id) {
-            if entry.generation != generation {
-                return;
-            }
-            entry.loading = false;
-            entry.fetched_at = Some(Instant::now());
-            match result {
-                Ok(data) => {
-                    if is_open_filter {
-                        entry.open_count = data.issues.len() + data.prs.len();
-                    }
-                    entry.issues = data.issues;
-                    entry.prs = data.prs;
-                    entry.error = None;
-                }
-                Err(e) => entry.error = Some(e),
-            }
+            entry.complete_request(generation, result);
         }
         if self.github_target().map(|t| t.0) == Some(repo_id) {
             self.refresh_github_panel();
@@ -237,6 +271,7 @@ impl App {
 
     /// Push the selected repo's cached state into the panel component.
     pub(super) fn refresh_github_panel(&mut self) {
+        self.retarget_github_panel();
         let Some((id, _, name)) = self.github_target() else {
             return;
         };
@@ -251,17 +286,36 @@ impl App {
         let label = self.github_state_filter.label();
         match self.github_cache.get(&id) {
             None => self.github_panel.set_loading(&name),
-            Some(s) if s.loading && s.fetched_at.is_none() => self.github_panel.set_loading(&name),
-            Some(s) if s.owner_repo.is_none() && s.fetched_at.is_some() => {
+            Some(s) if s.owner_repo.is_none() && s.remote_checked_at.is_some() => {
                 self.github_panel.set_not_github(&name)
             }
-            Some(s) if s.error.is_some() => self
-                .github_panel
-                .set_error(&name, s.error.clone().unwrap_or_default()),
-            Some(s) => self
-                .github_panel
-                .set_data(s.issues.clone(), s.prs.clone(), &name, label),
+            Some(s) => match s.snapshots.get(&self.github_state_filter) {
+                Some(snapshot) if snapshot.error.is_some() => self
+                    .github_panel
+                    .set_error(&name, snapshot.error.clone().unwrap_or_default()),
+                Some(GithubSnapshot {
+                    data: Some(data), ..
+                }) => {
+                    self.github_panel
+                        .set_data(data.issues.clone(), data.prs.clone(), &name, label)
+                }
+                _ => self.github_panel.set_loading(&name),
+            },
         }
+    }
+
+    /// Clear old rows and pending detail immediately when the target changes,
+    /// including two distinct repositories with the same display name.
+    fn retarget_github_panel(&mut self) {
+        let target = self.github_target();
+        self.github_panel.set_target(
+            target.as_ref().map(|(id, _, _)| id.clone()),
+            target
+                .as_ref()
+                .map(|(_, _, name)| name.as_str())
+                .unwrap_or(""),
+            self.github_state_filter.label(),
+        );
     }
 
     /// Cycle the panel's state filter (open → all → closed) and refetch. Sent by
@@ -281,5 +335,124 @@ impl App {
         for path in removed {
             self.github_cache.remove(&RepoId(path.clone()));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn data(title: &str, state: &str) -> github::GithubData {
+        github::GithubData {
+            issues: vec![github::GhItem {
+                number: 1,
+                title: title.into(),
+                state: state.into(),
+                is_draft: false,
+                author: "alice".into(),
+                updated_at: String::new(),
+                url: "https://github.com/owner/repo/issues/1".into(),
+                checks: None,
+            }],
+            prs: vec![],
+        }
+    }
+
+    #[test]
+    fn closed_response_does_not_become_open_data_after_navigation() {
+        let mut app = App::new(Config {
+            root_dirs: vec![],
+            ..Config::default()
+        });
+        let id = RepoId("/repo".into());
+        let mut cache = GithubState::default();
+        let request = cache
+            .begin_request(GithubStateFilter::Closed, false, Instant::now())
+            .unwrap();
+        app.github_cache.insert(id.clone(), cache);
+        app.github_state_filter = GithubStateFilter::Open;
+        app.github_fetched(id.clone(), request, Ok(data("Closed issue", "CLOSED")));
+        let cache = &app.github_cache[&id];
+        assert_eq!(
+            cache.open_count(),
+            0,
+            "closed response changed the open count"
+        );
+        assert_eq!(
+            cache.snapshots[&GithubStateFilter::Closed]
+                .data
+                .as_ref()
+                .unwrap()
+                .issues[0]
+                .title,
+            "Closed issue"
+        );
+    }
+
+    #[test]
+    fn filter_changes_load_independently_and_keep_out_of_order_responses_separate() {
+        let mut cache = GithubState::default();
+        let open = cache
+            .begin_request(GithubStateFilter::Open, false, Instant::now())
+            .unwrap();
+        let closed = cache
+            .begin_request(GithubStateFilter::Closed, false, Instant::now())
+            .unwrap();
+        cache.complete_request(closed, Ok(data("Closed issue", "CLOSED")));
+        assert_eq!(cache.open_count(), 0);
+        cache.complete_request(open, Ok(data("Open issue", "OPEN")));
+        assert_eq!(cache.open_count(), 1);
+        for (filter, title) in [
+            (GithubStateFilter::Open, "Open issue"),
+            (GithubStateFilter::Closed, "Closed issue"),
+        ] {
+            assert_eq!(
+                cache.snapshots[&filter].data.as_ref().unwrap().issues[0].title,
+                title
+            );
+        }
+    }
+
+    #[test]
+    fn fresh_closed_results_do_not_suppress_loading_open_results() {
+        let mut cache = GithubState::default();
+        let request = cache
+            .begin_request(GithubStateFilter::Closed, false, Instant::now())
+            .unwrap();
+        cache.complete_request(request, Ok(data("Closed issue", "CLOSED")));
+        let open = cache
+            .begin_request(GithubStateFilter::Open, false, Instant::now())
+            .unwrap();
+        cache.complete_request(open, Ok(data("Open issue", "OPEN")));
+        assert_eq!(cache.open_count(), 1);
+        assert!(
+            cache
+                .begin_request(GithubStateFilter::Open, false, Instant::now())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn readded_repository_rejects_response_from_its_previous_cache() {
+        let mut previous = GithubState::default();
+        let old_request = previous
+            .begin_request(GithubStateFilter::Open, false, Instant::now())
+            .unwrap();
+        let mut current = GithubState::default();
+        let request = current
+            .begin_request(GithubStateFilter::Open, false, Instant::now())
+            .unwrap();
+        current.complete_request(old_request, Ok(data("Old result", "OPEN")));
+        assert_eq!(current.open_count(), 0);
+        current.complete_request(request, Ok(data("Current result", "OPEN")));
+        assert_eq!(
+            current.snapshots[&GithubStateFilter::Open]
+                .data
+                .as_ref()
+                .unwrap()
+                .issues[0]
+                .title,
+            "Current result"
+        );
     }
 }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -134,7 +134,10 @@ impl App {
                 } else {
                     match self.focus {
                         FocusPanel::GitHub => self.focus = FocusPanel::Graph,
-                        FocusPanel::Graph => self.focus = FocusPanel::Changes,
+                        FocusPanel::Graph => {
+                            self.git_graph.close_detail();
+                            self.focus = FocusPanel::Changes;
+                        }
                         FocusPanel::Changes => self.focus = FocusPanel::Repos,
                         FocusPanel::Repos => self.action_tx.send(Action::Quit)?,
                     }
@@ -410,27 +413,11 @@ impl App {
                     // will only engage on MouseEventKind::Drag.
                 }
                 MouseEventKind::Drag(MouseButton::Left) if self.dragging_border.is_some() => {
-                    let rel = mouse_pos.saturating_sub(origin) as f64 / total as f64;
-                    let min_f = 3.0 / total as f64;
-                    match self.dragging_border {
-                        Some(0) => {
-                            self.border_frac[0] = rel.clamp(min_f, self.border_frac[1] - min_f);
-                        }
-                        Some(1) => {
-                            // Cap at the graph/github split when the panel is shown.
-                            let upper = if self.github_visible {
-                                self.border_frac[2]
-                            } else {
-                                1.0
-                            } - min_f;
-                            self.border_frac[1] = rel.clamp(self.border_frac[0] + min_f, upper);
-                        }
-                        Some(2) => {
-                            self.border_frac[2] =
-                                rel.clamp(self.border_frac[1] + min_f, 1.0 - min_f);
-                        }
-                        _ => {}
-                    }
+                    self.resize_panel_border(
+                        total,
+                        mouse_pos.saturating_sub(origin),
+                        self.dragging_border.unwrap(),
+                    );
                     return Ok(());
                 }
                 MouseEventKind::Up(MouseButton::Left) if self.dragging_border.is_some() => {

--- a/src/app/launch.rs
+++ b/src/app/launch.rs
@@ -19,6 +19,27 @@ impl App {
         refresh_id: RepoId,
         args: Vec<String>,
     ) {
+        self.spawn_prepared_git_op(exec_path, refresh_id, move |_| Ok(args));
+    }
+
+    pub(super) fn spawn_file_op(
+        &mut self,
+        exec_path: std::path::PathBuf,
+        refresh_id: RepoId,
+        selected: std::path::PathBuf,
+        operation: crate::git::file_ops::FileOperation,
+    ) {
+        self.spawn_prepared_git_op(exec_path, refresh_id, move |path| {
+            crate::git::file_ops::arguments(path, &selected, operation)
+        });
+    }
+
+    fn spawn_prepared_git_op(
+        &mut self,
+        exec_path: std::path::PathBuf,
+        refresh_id: RepoId,
+        prepare: impl FnOnce(&std::path::Path) -> Result<Vec<String>> + Send + 'static,
+    ) {
         if let Some(idx) = self.repo_list.resolve_index(&refresh_id) {
             self.repo_list.repos[idx].git_op = true;
         }
@@ -27,6 +48,15 @@ impl App {
         // start still counts this op as in flight.
         let guard = GitOpGuard::new(refresh_id.clone(), tx.clone());
         tokio::task::spawn_blocking(move || {
+            let args = match prepare(&exec_path) {
+                Ok(args) => args,
+                Err(error) => {
+                    guard.complete();
+                    let _ = tx.send(Action::Error(error.to_string()));
+                    let _ = tx.send(Action::RefreshRepo(refresh_id));
+                    return;
+                }
+            };
             let output = crate::git::process::run_git_op_capturing(&exec_path, &args);
             match output {
                 Ok(o) if o.status.success() => {
@@ -91,28 +121,43 @@ impl App {
         rel: &std::path::Path,
         tui: &mut Tui,
     ) -> Result<()> {
-        let Some(abs) = self.file_op_dir(id).map(|d| d.join(rel)) else {
+        let Some(request) = self.file_open_request(id, rel) else {
             return Ok(());
         };
-        if self.config.open.command.is_some() {
-            self.launch_open(abs, tui)?;
+        if request.command.is_some() {
+            self.launch_open_request(request, tui)?;
         } else {
             let opener = if cfg!(target_os = "macos") {
                 "open"
             } else {
                 "xdg-open"
             };
-            let cwd = abs
-                .parent()
-                .map(|p| p.to_path_buf())
-                .unwrap_or_else(|| abs.clone());
             self.os_open(
-                vec![opener.to_string(), abs.to_string_lossy().into_owned()],
-                cwd,
+                vec![
+                    opener.to_string(),
+                    request.target.to_string_lossy().into_owned(),
+                ],
+                request.dir,
                 "open",
             );
         }
         Ok(())
+    }
+
+    fn file_open_request(&self, id: &RepoId, rel: &std::path::Path) -> Option<PendingLaunch> {
+        let repo_dir = self.file_op_dir(id)?;
+        let target = repo_dir.join(rel);
+        let dir = target
+            .parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or(repo_dir);
+        Some(PendingLaunch {
+            dir,
+            target,
+            command: self.config.open.command.clone(),
+            base: None,
+            label: "open",
+        })
     }
 
     /// Reveal a changed file in the OS file manager: Finder selects it on macOS
@@ -287,18 +332,31 @@ impl App {
     }
     /// Open `path` via the `[open]` launcher (or the placement picker for "ask").
     pub(super) fn launch_open(&mut self, path: std::path::PathBuf, tui: &mut Tui) -> Result<()> {
-        let command = self.config.open.command.clone();
-        let plan = crate::session::launcher::plan(
-            command.as_deref(),
+        self.launch_open_request(
+            PendingLaunch {
+                dir: path.clone(),
+                target: path,
+                command: self.config.open.command.clone(),
+                base: None,
+                label: "open",
+            },
+            tui,
+        )
+    }
+
+    fn launch_open_request(&mut self, request: PendingLaunch, tui: &mut Tui) -> Result<()> {
+        let plan = crate::session::launcher::plan_with_target(
+            request.command.as_deref(),
             &self.config.open.placement,
-            &path.to_string_lossy(),
+            &request.dir.to_string_lossy(),
+            &request.target.to_string_lossy(),
             None,
             self.mux,
         );
         if matches!(plan, crate::session::launcher::LaunchPlan::Ask) {
-            self.start_placement_picker(path, command, None, "open");
+            self.start_placement_picker(request);
         } else {
-            self.run_launch_plan(plan, path, "open", tui)?;
+            self.run_launch_plan(plan, request.dir, "open", tui)?;
         }
         Ok(())
     }
@@ -324,7 +382,13 @@ impl App {
             self.mux,
         );
         if matches!(plan, crate::session::launcher::LaunchPlan::Ask) {
-            self.start_placement_picker(path, Some(command), None, "keybinding");
+            self.start_placement_picker(PendingLaunch {
+                dir: path.clone(),
+                target: path,
+                command: Some(command),
+                base: None,
+                label: "keybinding",
+            });
         } else {
             self.run_launch_plan(plan, path, "keybinding", tui)?;
         }
@@ -359,7 +423,13 @@ impl App {
             self.mux,
         );
         if matches!(plan, crate::session::launcher::LaunchPlan::Ask) {
-            self.start_placement_picker(path, Some(command), Some(base), "review");
+            self.start_placement_picker(PendingLaunch {
+                dir: path.clone(),
+                target: path,
+                command: Some(command),
+                base: Some(base),
+                label: "review",
+            });
         } else {
             self.run_launch_plan(plan, path, "review", tui)?;
         }
@@ -384,13 +454,7 @@ impl App {
     }
     /// Park a launch and open the placement picker (`placement = "ask"`), listing
     /// tmux windows as right-of/below targets, or herdr tabs/splits under herdr.
-    pub(super) fn start_placement_picker(
-        &mut self,
-        dir: std::path::PathBuf,
-        command: Option<String>,
-        base: Option<String>,
-        label: &'static str,
-    ) {
+    fn start_placement_picker(&mut self, request: PendingLaunch) {
         let choices = match self.mux {
             crate::session::env::Multiplexer::Herdr => {
                 crate::session::launcher::herdr_placement_choices()
@@ -399,12 +463,7 @@ impl App {
                 &crate::session::launcher::tmux_windows(),
             ),
         };
-        self.pending_pick = Some(PendingPick::Launch(PendingLaunch {
-            dir,
-            command,
-            base,
-            label,
-        }));
+        self.pending_pick = Some(PendingPick::Launch(request));
         self.picker.show("Open where?", choices);
     }
     /// Attach the live tmux session(s) for the currently selected row (the `G`
@@ -722,7 +781,79 @@ fn sanitize_stdout(stdout: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::sanitize_stdout;
+    use super::*;
+
+    fn file_open_app() -> (tempfile::TempDir, App, RepoId, std::path::PathBuf) {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        git2::Repository::init(&repo).unwrap();
+        let repo = repo.canonicalize().unwrap();
+        let file = repo.join("source file.rs");
+        std::fs::write(&file, "fn main() {}\n").unwrap();
+        let mut config = Config {
+            root_dirs: vec![temp.path().to_path_buf()],
+            ..Config::default()
+        };
+        config.open.command = Some("git hash-object {path}".into());
+        config.open.placement = "command".into();
+        (temp, App::new(config), RepoId(repo), file)
+    }
+
+    fn run_file_open(request: PendingLaunch, expected: &std::path::Path) {
+        let plan = crate::session::launcher::plan_with_target(
+            request.command.as_deref(),
+            "command",
+            &request.dir.to_string_lossy(),
+            &request.target.to_string_lossy(),
+            request.base.as_deref(),
+            crate::session::env::Multiplexer::None,
+        );
+        let crate::session::launcher::LaunchPlan::Spawn(argv) = plan else {
+            panic!("expected an argv launch")
+        };
+        let output = std::process::Command::new(&argv[0])
+            .args(&argv[1..])
+            .current_dir(&request.dir)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let expected_oid =
+            git2::Oid::hash_object(git2::ObjectType::Blob, &std::fs::read(expected).unwrap())
+                .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            expected_oid.to_string()
+        );
+        assert_eq!(request.dir, expected.parent().unwrap());
+    }
+
+    #[test]
+    fn configured_file_open_passes_file_to_editor_with_directory_cwd() {
+        let (_temp, app, id, file) = file_open_app();
+        let request = app
+            .file_open_request(&id, std::path::Path::new("source file.rs"))
+            .unwrap();
+        run_file_open(request, &file);
+    }
+
+    #[test]
+    fn placement_picker_preserves_file_target_and_directory_cwd() {
+        let (_temp, mut app, id, file) = file_open_app();
+        // Herdr choices are local data, so no real multiplexer is needed.
+        app.mux = crate::session::env::Multiplexer::Herdr;
+        let request = app
+            .file_open_request(&id, std::path::Path::new("source file.rs"))
+            .unwrap();
+        app.start_placement_picker(request);
+        let Some(PendingPick::Launch(request)) = app.pending_pick.take() else {
+            panic!("expected a parked file launch")
+        };
+        run_file_open(request, &file);
+    }
 
     #[test]
     fn sanitize_stdout_truncates_and_escapes_controls() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -282,6 +282,7 @@ struct ActiveWorktree {
 /// can be resumed with the chosen placement.
 struct PendingLaunch {
     dir: std::path::PathBuf,
+    target: std::path::PathBuf,
     command: Option<String>,
     base: Option<String>,
     label: &'static str,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1,6 +1,43 @@
 use super::*;
 
 impl App {
+    pub(super) fn normalize_panel_borders(&mut self, axis: u16, show_github: bool) {
+        if axis == 0 {
+            return;
+        }
+        let panels = if show_github { 4 } else { 3 };
+        let gap = 3.min(axis / panels);
+        let mut previous = 0;
+        for index in 0..panels - 1 {
+            let upper = axis - gap * (panels - index - 1);
+            let cell = ((self.border_frac[index as usize] * f64::from(axis)).round() as u16)
+                .clamp(previous + gap, upper);
+            self.border_frac[index as usize] = f64::from(cell) / f64::from(axis);
+            previous = cell;
+        }
+    }
+
+    pub(super) fn resize_panel_border(&mut self, axis: u16, position: u16, index: u8) {
+        if axis == 0 {
+            return;
+        }
+        self.normalize_panel_borders(axis, self.github_visible);
+        let panels = if self.github_visible { 4 } else { 3 };
+        let index = usize::from(index);
+        if index >= panels - 1 {
+            return;
+        }
+        let gap = 3.min(axis / panels as u16);
+        let cell = |i: usize| (self.border_frac[i] * f64::from(axis)).round() as u16;
+        let lower = if index == 0 { 0 } else { cell(index - 1) } + gap;
+        let upper = if index == panels - 2 {
+            axis
+        } else {
+            cell(index + 1)
+        } - gap;
+        self.border_frac[index] = f64::from(position.clamp(lower, upper)) / f64::from(axis);
+    }
+
     pub(super) fn clear_expired_messages(&mut self) -> bool {
         let had_error = self.error_message.is_some();
         let had_success = self.success_message.is_some();
@@ -40,19 +77,12 @@ impl App {
             self.focus = FocusPanel::Graph;
         }
 
-        // Keep the graph/github split right of the changes/graph split so the
-        // panel never inverts if the first two borders were dragged while the
-        // GitHub panel was hidden.
-        if show_github {
-            let axis = if self.horizontal_layout {
-                main_area.width
-            } else {
-                main_area.height
-            };
-            let min_gap = 3.0 / (axis.max(1) as f64);
-            self.border_frac[2] =
-                self.border_frac[2].clamp(self.border_frac[1] + min_gap, 1.0 - min_gap);
-        }
+        let axis = if self.horizontal_layout {
+            main_area.width
+        } else {
+            main_area.height
+        };
+        self.normalize_panel_borders(axis, show_github);
 
         let (repo_area, changes_area, graph_area, github_area) = if self.horizontal_layout {
             let w = main_area.width as f64;

--- a/src/app/repo_admin.rs
+++ b/src/app/repo_admin.rs
@@ -99,12 +99,12 @@ impl App {
                         let root = root.canonicalize().unwrap_or_else(|_| root.clone());
                         entry.path.starts_with(&root)
                     });
-                    let name = entry.name.clone();
+                    let exclusion = format!("path:{}", entry.path.display());
                     if under_root
                         && entry.path.join(".git").is_dir()
-                        && !config.excluded_repos.contains(&name)
+                        && !config.excluded_repos.contains(&exclusion)
                     {
-                        config.excluded_repos.push(name);
+                        config.excluded_repos.push(exclusion);
                     }
                     if let Err(e) = config.save() {
                         self.error_message = Some((format!("save failed: {e}"), Instant::now()));
@@ -128,6 +128,7 @@ impl App {
                         self.active_worktree = None;
                     }
                     self.repo_list.repos.remove(idx);
+                    self.prune_github_cache(std::slice::from_ref(&id.0));
                     // Fix selection
                     if self.repo_list.repos.is_empty() {
                         self.repo_list.state.select(None);

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+mod robustness;
 use crate::git::status::StashEntry;
 use std::path::Path;
 
@@ -720,7 +721,7 @@ fn removing_a_discovered_repo_still_excludes_it() {
     app.handle_repo_admin(Action::RemoveRepo(id)).unwrap();
 
     assert!(app.repo_list.repos.is_empty());
-    assert!(app.config.excluded_repos.contains(&"walker".to_string()));
+    assert!(crate::git::scanner::discover_repos(&app.config).is_empty());
 }
 
 /// `ConfirmRemoveRepo` only asks: the repo stays listed until the dialog's
@@ -920,7 +921,8 @@ async fn removing_a_nested_plain_repo_still_excludes_it() {
             .clone(),
     );
 
-    app.handle_repo_admin(Action::RemoveRepo(id)).unwrap();
+    app.handle_repo_admin(Action::RemoveRepo(id.clone()))
+        .unwrap();
 
-    assert!(app.config.excluded_repos.contains(&"side".to_string()));
+    assert!(!crate::git::scanner::discover_repos(&app.config).contains(&id.0));
 }

--- a/src/app/tests/robustness.rs
+++ b/src/app/tests/robustness.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+#[tokio::test]
+async fn removing_one_repository_preserves_namesakes_and_prefix_siblings() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let removed = make_repo(tmp.path(), "a/repo").canonicalize().unwrap();
+    let namesake = make_repo(tmp.path(), "b/repo").canonicalize().unwrap();
+    let sibling = make_repo(tmp.path(), "a/repo-copy").canonicalize().unwrap();
+    let config = Config {
+        root_dirs: vec![tmp.path().to_path_buf()],
+        scan_depth: 3,
+        write_target_override: Some(tmp.path().join("config.toml")),
+        ..Config::default()
+    };
+    let mut app = App::new(config);
+    assert_eq!(app.repo_list.repos.len(), 3);
+    app.handle_repo_admin(Action::RemoveRepo(RepoId(removed.clone())))
+        .unwrap();
+    app.handle_repo_admin(Action::DiscoverNewRepos).unwrap();
+    let paths: Vec<_> = app.repo_list.repos.iter().map(|r| r.path.clone()).collect();
+    assert!(!paths.contains(&removed));
+    assert!(paths.contains(&namesake));
+    assert!(paths.contains(&sibling));
+}
+
+#[test]
+fn leaving_graph_with_escape_rejects_pending_commit_details() {
+    let mut app = power_test_app();
+    app.focus = FocusPanel::Graph;
+    let generation = app.git_graph.current_detail_generation();
+    app.handle_key_event(KeyCode::Esc.into()).unwrap();
+    app.handle_action_rest(Action::CommitFilesLoaded {
+        generation,
+        oid: "abc1234".into(),
+        message: "late commit".into(),
+        files: vec![("M".into(), "late.txt".into())],
+    })
+    .unwrap();
+    assert!(!app.git_graph.has_detail());
+    assert_eq!(app.focus, FocusPanel::Changes);
+}
+
+#[test]
+fn error_messages_preserve_unicode_and_truncate_by_characters() {
+    let mut app = power_test_app();
+    for message in ["é".repeat(61), "界".repeat(121), "🙂\n".repeat(80)] {
+        app.handle_action_rest(Action::Error(message.clone()))
+            .unwrap();
+        let displayed = &app.error_message.as_ref().unwrap().0;
+        assert!(!displayed.contains('\n'));
+        assert!(displayed.chars().count() <= 120);
+        if message.chars().count() <= 120 {
+            assert_eq!(*displayed, message);
+        } else {
+            assert!(displayed.ends_with("..."));
+        }
+    }
+}
+
+#[test]
+fn panels_render_and_drag_after_shrinking_terminal() {
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+    let mut app = power_test_app();
+    app.config.github.enabled = true;
+    for show in [false, true] {
+        app.github_forced = Some(show);
+        for width in [0, 1, 3, 20, 80, 99, 100, 160] {
+            for height in 0..=22 {
+                app.border_frac = [0.3, 0.8, 0.9];
+                let mut terminal =
+                    ratatui::Terminal::new(ratatui::backend::TestBackend::new(width, height))
+                        .unwrap();
+                terminal.draw(|frame| app.draw(frame).unwrap()).unwrap();
+                for border in 0..if show { 3 } else { 2 } {
+                    app.dragging_border = Some(border);
+                    app.handle_mouse_event(MouseEvent {
+                        kind: MouseEventKind::Drag(MouseButton::Left),
+                        column: width / 2,
+                        row: height / 2,
+                        modifiers: KeyModifiers::NONE,
+                    })
+                    .unwrap();
+                    terminal.draw(|frame| app.draw(frame).unwrap()).unwrap();
+                    assert!(app.border_frac.iter().all(|v| v.is_finite()));
+                    assert!(app.border_frac[0] <= app.border_frac[1]);
+                    if show {
+                        assert!(app.border_frac[1] <= app.border_frac[2]);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/components/git_graph/component.rs
+++ b/src/components/git_graph/component.rs
@@ -58,10 +58,8 @@ impl Component for GitGraph {
                     return Ok(None);
                 }
                 KeyCode::Esc => {
-                    self.commit_detail = None;
-                    if std::mem::take(&mut self.needs_reload) {
-                        self.reload_graph();
-                    }
+                    self.close_detail();
+                    self.reload_pending();
                     return Ok(None);
                 }
                 KeyCode::Char('j') | KeyCode::Down => {
@@ -89,6 +87,10 @@ impl Component for GitGraph {
 
         // No detail open — normal graph navigation
         match key.code {
+            KeyCode::Esc => {
+                self.close_detail();
+                Ok(None)
+            }
             KeyCode::Char('n') => {
                 self.search_next();
                 Ok(None)
@@ -181,9 +183,7 @@ impl Component for GitGraph {
                             }
                             self.state.select(Some(idx));
                             self.commit_detail = None;
-                            if std::mem::take(&mut self.needs_reload) {
-                                self.reload_graph();
-                            }
+                            self.reload_pending();
                             // A single click selects the commit and opens its
                             // changed files (and, via CommitFilesLoaded, the
                             // highlighted file's diff), so no second click is

--- a/src/components/git_graph/mod.rs
+++ b/src/components/git_graph/mod.rs
@@ -20,6 +20,8 @@ mod component;
 #[cfg(test)]
 mod detail_review_tests;
 mod file_search;
+#[cfg(test)]
+mod regression_tests;
 mod render;
 #[cfg(test)]
 mod tests;
@@ -150,6 +152,9 @@ pub(crate) struct GitGraph {
     needs_reload: bool,
     /// True while a graph rebuild is running for the current repo.
     load_in_flight: bool,
+    /// Options captured by the current background build, independent of edits
+    /// made in the filter picker while its result is pending.
+    in_flight_key: Option<GraphCacheKey>,
     /// Consecutive aborted (panicked) builds since the last successful load.
     /// Bounds the auto-retry so a deterministically-panicking build can't
     /// replay forever under a watcher event storm.
@@ -214,6 +219,7 @@ impl GitGraph {
             horizontal_layout: false,
             needs_reload: false,
             load_in_flight: false,
+            in_flight_key: None,
             consecutive_aborts: 0,
             load_generation: 0,
             detail_generation: 0,
@@ -265,6 +271,7 @@ impl GitGraph {
         // previous repo, exactly as a fresh spawn would.
         if !force && let Some(cached) = self.graph_cache.get(&self.cache_key(&path)) {
             self.load_generation += 1;
+            self.in_flight_key = None;
             if !is_same_repo {
                 self.reset_view_state();
             }
@@ -287,6 +294,7 @@ impl GitGraph {
         let tx = tx.clone();
         let options = self.graph_options.clone();
         self.load_in_flight = true;
+        self.in_flight_key = Some(self.cache_key(&path));
         self.load_generation += 1;
         let load_gen = self.load_generation;
 
@@ -344,7 +352,7 @@ impl GitGraph {
     /// the cache-hit restore path, so both behave identically.
     fn reset_view_state(&mut self) {
         self.state.select(None);
-        self.commit_detail = None;
+        self.close_detail();
         self.needs_reload = false;
         self.consecutive_aborts = 0;
         self.search.clear();
@@ -392,11 +400,25 @@ impl GitGraph {
         self.error = Some(msg);
         self.loading = false;
         self.load_in_flight = false;
+        self.in_flight_key = None;
+        self.reload_pending();
     }
 
     pub fn set_rows(&mut self, mut rows: Vec<GraphRow>) {
+        if let Some(key) = self.in_flight_key.take()
+            && key != self.cache_key(&key.path)
+        {
+            self.load_in_flight = false;
+            self.needs_reload = false;
+            self.force_reload_repo(key.path, &self.repo_name.clone());
+            return;
+        }
         // Preserve selection position on refresh if possible
         let prev_selected = self.state.selected();
+        let selected_oid = self
+            .display_rows()
+            .get(prev_selected.unwrap_or(0))
+            .map(|row| row.oid);
         // Carry forward diff_stats from previous all_rows to avoid blink on refresh
         if !self.all_rows.is_empty() {
             let old_stats: std::collections::HashMap<git2::Oid, crate::git::graph::DiffStat> = self
@@ -439,16 +461,9 @@ impl GitGraph {
                 },
             );
         }
-        if !self.display_rows().is_empty() {
-            let idx = prev_selected
-                .map(|i| i.min(self.display_rows().len() - 1))
-                .unwrap_or(0);
-            self.state.select(Some(idx));
-        }
+        self.restore_selection(selected_oid, prev_selected);
 
-        if std::mem::take(&mut self.needs_reload) {
-            self.reload_graph();
-        }
+        self.reload_pending();
     }
 
     pub fn set_filter_branches(&mut self, branches: Vec<String>) {
@@ -514,6 +529,12 @@ impl GitGraph {
         self.commit_detail.is_some()
     }
 
+    pub(crate) fn close_detail(&mut self) {
+        self.commit_detail = None;
+        self.detail_generation = self.detail_generation.wrapping_add(1);
+        self.diff_select_generation = self.diff_select_generation.wrapping_add(1);
+    }
+
     pub fn set_needs_reload(&mut self) {
         self.needs_reload = true;
     }
@@ -533,6 +554,7 @@ impl GitGraph {
             return;
         }
         self.load_in_flight = false;
+        self.in_flight_key = None;
         self.loading = false;
         self.consecutive_aborts = self.consecutive_aborts.saturating_add(1);
 
@@ -544,9 +566,7 @@ impl GitGraph {
             return;
         }
 
-        if std::mem::take(&mut self.needs_reload) {
-            self.reload_graph();
-        }
+        self.reload_pending();
     }
 
     pub fn current_generation(&self) -> u64 {
@@ -683,6 +703,14 @@ impl GitGraph {
         }
     }
 
+    fn reload_pending(&mut self) {
+        if std::mem::take(&mut self.needs_reload)
+            && let Some(path) = self.repo_path.clone()
+        {
+            self.force_reload_repo(path, &self.repo_name.clone());
+        }
+    }
+
     /// Recompute segments and row_to_segment mapping from all_rows.
     fn recompute_segments(&mut self) {
         self.segments = crate::git::graph::compute_branch_segments(&self.all_rows);
@@ -707,8 +735,13 @@ impl GitGraph {
 
     /// Recompute `self.rows` from `self.all_rows`, collapsing groups.
     fn recompute_collapsed_rows(&mut self) {
+        let selected = self.state.selected();
+        let selected_oid = selected
+            .and_then(|i| self.display_rows().get(i))
+            .map(|row| row.oid);
         if self.collapsed_branches.is_empty() {
             self.rows.clear();
+            self.restore_selection(selected_oid, selected);
             return;
         }
 
@@ -754,6 +787,21 @@ impl GitGraph {
         }
 
         self.rows = rows;
+        self.restore_selection(selected_oid, selected);
+    }
+
+    fn restore_selection(&mut self, oid: Option<git2::Oid>, previous: Option<usize>) {
+        let rows = self.display_rows();
+        let selected = oid
+            .and_then(|oid| rows.iter().position(|row| row.oid == oid))
+            .or_else(|| (!rows.is_empty()).then(|| previous.unwrap_or(0).min(rows.len() - 1)));
+        self.state.select(selected);
+        self.update_search_matches();
+        if let Some(position) =
+            selected.and_then(|i| self.search.matches.iter().position(|&m| m == i))
+        {
+            self.search.current_match = Some(position);
+        }
     }
 
     pub fn selected_text(&self) -> Option<String> {

--- a/src/components/git_graph/regression_tests.rs
+++ b/src/components/git_graph/regression_tests.rs
@@ -1,0 +1,201 @@
+use super::*;
+use crate::components::Component;
+use git2::{Oid, Repository, Signature};
+use ratatui::{Terminal, backend::TestBackend};
+use tokio::sync::mpsc::UnboundedReceiver;
+
+fn commit(repo: &Repository, message: &str) -> Oid {
+    let signature = Signature::now("Alice", "alice@example.com").unwrap();
+    let tree_id = repo.index().unwrap().write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
+    repo.commit(
+        Some("HEAD"),
+        &signature,
+        &signature,
+        message,
+        &tree,
+        &parent.iter().collect::<Vec<_>>(),
+    )
+    .unwrap()
+}
+
+async fn next_rows(rx: &mut UnboundedReceiver<Action>) -> (u64, Vec<GraphRow>) {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            match rx.recv().await.expect("graph action channel closed") {
+                Action::GraphLoaded { generation, rows } => return (generation, rows),
+                Action::GraphError { message, .. } => panic!("{message}"),
+                _ => {}
+            }
+        }
+    })
+    .await
+    .expect("graph did not finish loading")
+}
+
+fn row(id: u8, message: &str) -> GraphRow {
+    let mut row = super::tests::mock_row("abcdef0", message, "Alice");
+    row.oid = Oid::from_bytes(&[id; 20]).unwrap();
+    row
+}
+
+#[test]
+fn side_by_side_message_keeps_words_readable() {
+    let mut graph = GitGraph::new(Arc::new(Theme::default()));
+    graph.load_repo("/repo".into(), "repo");
+    let _ = graph.set_commit_files("abcdef0".into(), "Fix authentication".into(), vec![]);
+    let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+    terminal
+        .draw(|frame| graph.draw(frame, frame.area()).unwrap())
+        .unwrap();
+    let buffer = terminal.backend().buffer();
+    let message = graph.msg_area;
+    let rendered = (message.y + 1..message.bottom().saturating_sub(1))
+        .map(|y| {
+            (message.x + 1..message.right().saturating_sub(1))
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        rendered.contains("Fix"),
+        "message loses readable words: {rendered:?}"
+    );
+}
+
+#[test]
+fn switching_repositories_rejects_pending_commit_details() {
+    let mut graph = GitGraph::new(Arc::new(Theme::default()));
+    graph.load_repo("/first".into(), "first");
+    graph.set_rows(vec![row(1, "first commit")]);
+    assert!(graph.open_selected_commit_files().is_some());
+    let pending_generation = graph.current_detail_generation();
+    graph.load_repo("/second".into(), "second");
+    if pending_generation == graph.current_detail_generation() {
+        let _ = graph.set_commit_files("abcdef0".into(), "first commit".into(), vec![]);
+    }
+    assert!(
+        !graph.has_detail(),
+        "old repository detail reopened after switching"
+    );
+}
+
+#[test]
+fn closing_commit_details_rejects_pending_reopens() {
+    let mut graph = GitGraph::new(Arc::new(Theme::default()));
+    graph.load_repo("/repo".into(), "repo");
+    graph.set_rows(vec![row(1, "first commit")]);
+    let _ = graph.set_commit_files("abcdef0".into(), "first commit".into(), vec![]);
+    assert!(graph.open_selected_commit_files().is_some());
+    let pending_generation = graph.current_detail_generation();
+    graph.handle_key_event(KeyCode::Esc.into()).unwrap();
+    if pending_generation == graph.current_detail_generation() {
+        let _ = graph.set_commit_files("abcdef0".into(), "first commit".into(), vec![]);
+    }
+    assert!(
+        !graph.has_detail(),
+        "closed detail reopened from an older request"
+    );
+}
+
+#[tokio::test]
+async fn changing_filters_during_load_applies_the_latest_filter() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = Repository::init(dir.path()).unwrap();
+    commit(&repo, "Alice commit");
+    let mut graph = GitGraph::new(Arc::new(Theme::default()));
+    graph.graph_options.show_stats = false;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    graph.register_action_handler(tx).unwrap();
+    graph.load_repo(dir.path().into(), "repo");
+    let (_, old_rows) = next_rows(&mut rx).await;
+    graph.set_filters(GraphFilters {
+        authors: Some(["Bob".into()].into()),
+        ..Default::default()
+    });
+    graph.set_rows(old_rows);
+    if graph.load_in_flight {
+        let (_, rows) = next_rows(&mut rx).await;
+        graph.set_rows(rows);
+    }
+    assert!(
+        graph.selected_commit_menu_data().is_none(),
+        "Bob filter retained Alice commit"
+    );
+    graph.load_repo("/other".into(), "other");
+    graph.load_repo(dir.path().into(), "repo");
+    assert!(
+        graph.selected_commit_menu_data().is_none(),
+        "cache restored unfiltered rows"
+    );
+}
+
+#[tokio::test]
+async fn refresh_requested_during_build_reads_new_commits() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = Repository::init(dir.path()).unwrap();
+    commit(&repo, "original");
+    let mut graph = GitGraph::new(Arc::new(Theme::default()));
+    graph.graph_options.show_stats = false;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    graph.register_action_handler(tx).unwrap();
+    graph.load_repo(dir.path().into(), "repo");
+    let (_, old_rows) = next_rows(&mut rx).await;
+    commit(&repo, "new commit");
+    graph.force_reload_repo(dir.path().into(), "repo");
+    graph.set_rows(old_rows);
+    if graph.load_in_flight {
+        let (_, rows) = next_rows(&mut rx).await;
+        graph.set_rows(rows);
+    }
+    graph.open_search();
+    for c in "new commit".chars() {
+        graph.handle_search_key(KeyCode::Char(c).into()).unwrap();
+    }
+    graph.handle_search_key(KeyCode::Enter.into()).unwrap();
+    assert_eq!(graph.selected_commit_menu_data().unwrap().2, "new commit");
+}
+
+#[test]
+fn refreshing_search_keeps_the_matching_commit_selected() {
+    let mut graph = GitGraph::new(Arc::new(Theme::default()));
+    graph.set_rows(vec![row(1, "old"), row(2, "needle")]);
+    graph.open_search();
+    for c in "needle".chars() {
+        graph.handle_search_key(KeyCode::Char(c).into()).unwrap();
+    }
+    graph.handle_search_key(KeyCode::Enter.into()).unwrap();
+    graph.set_rows(vec![row(3, "new"), row(1, "old"), row(2, "needle")]);
+    assert_eq!(graph.selected_commit_menu_data().unwrap().2, "needle");
+    graph.handle_key_event(KeyCode::Char('n').into()).unwrap();
+    assert_eq!(graph.selected_commit_menu_data().unwrap().2, "needle");
+}
+
+#[tokio::test]
+async fn refresh_requested_during_failed_build_retries_the_repository() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut graph = GitGraph::new(Arc::new(Theme::default()));
+    graph.graph_options.show_stats = false;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    graph.register_action_handler(tx).unwrap();
+    graph.load_repo(dir.path().into(), "repo");
+    let action = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let Action::GraphError { message, .. } = action else {
+        panic!("an uninitialized repository should report a graph error");
+    };
+    let repo = Repository::init(dir.path()).unwrap();
+    commit(&repo, "repository available");
+    graph.force_reload_repo(dir.path().into(), "repo");
+    graph.set_error(message);
+    let (_, rows) = next_rows(&mut rx).await;
+    graph.set_rows(rows);
+    assert_eq!(
+        graph.selected_commit_menu_data().unwrap().2,
+        "repository available"
+    );
+}

--- a/src/components/git_graph/render.rs
+++ b/src/components/git_graph/render.rs
@@ -22,7 +22,7 @@ impl GitGraph {
         // Feasible integer boundary positions for this axis (short axes leave
         // no room between the stored 0.40/0.65 borders, so clamp in cells).
         let [b0, b1, b2] = detail_cell_bounds(axis, self.detail_split);
-        if !self.msg_dragged {
+        if self.horizontal_layout && !self.msg_dragged {
             let line_count = detail.message.lines().count().max(1) as u16;
             let want = msg_auto_cells(line_count, axis);
             let min_cells = detail_min_cells(axis);

--- a/src/components/github_panel.rs
+++ b/src/components/github_panel.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use crate::action::Action;
 use crate::components::Component;
 use crate::git::github::{CheckState, GhItem, ItemDetail};
+use crate::repo_id::RepoId;
 use crate::theme::Theme;
 
 /// One selectable row: either an issue or a pull request.
@@ -41,6 +42,7 @@ pub(crate) struct GithubPanel {
     pr_count: usize,
     state: ListState,
     repo_name: String,
+    repo_id: Option<RepoId>,
     /// Filter label shown in the title ("open" / "all" / "closed").
     state_label: String,
     status: PanelStatus,
@@ -70,6 +72,7 @@ impl GithubPanel {
             pr_count: 0,
             state: ListState::default(),
             repo_name: String::new(),
+            repo_id: None,
             state_label: "open".to_string(),
             status: PanelStatus::Loading,
             focused: false,
@@ -90,6 +93,24 @@ impl GithubPanel {
         self.theme = theme;
     }
 
+    pub fn set_target(&mut self, repo_id: Option<RepoId>, repo_name: &str, state_label: &str) {
+        if self.repo_id != repo_id || self.state_label != state_label {
+            self.clear_content();
+            self.status = PanelStatus::Loading;
+        }
+        self.repo_id = repo_id;
+        self.repo_name = repo_name.to_string();
+        self.state_label = state_label.to_string();
+    }
+
+    fn clear_content(&mut self) {
+        self.rows.clear();
+        self.issue_count = 0;
+        self.pr_count = 0;
+        self.state.select(None);
+        self.close_detail();
+    }
+
     /// Replace the panel's data. Selection is preserved when the repo is
     /// unchanged (a refetch of the same repo), reset to the top otherwise.
     pub fn set_data(
@@ -101,6 +122,7 @@ impl GithubPanel {
     ) {
         let same_repo = self.repo_name == repo_name;
         let prev = self.state.selected();
+        self.reset_if_new(repo_name);
         self.state_label = state_label.to_string();
         self.issue_count = issues.len();
         self.pr_count = prs.len();
@@ -129,11 +151,13 @@ impl GithubPanel {
 
     pub fn set_not_github(&mut self, repo_name: &str) {
         self.reset_if_new(repo_name);
+        self.clear_content();
         self.status = PanelStatus::NotGithub;
     }
 
     pub fn set_error(&mut self, repo_name: &str, message: String) {
         self.reset_if_new(repo_name);
+        self.clear_content();
         self.status = PanelStatus::Error(message);
     }
 
@@ -142,11 +166,7 @@ impl GithubPanel {
     /// flicker while new data loads.
     fn reset_if_new(&mut self, repo_name: &str) {
         if self.repo_name != repo_name {
-            self.rows.clear();
-            self.issue_count = 0;
-            self.pr_count = 0;
-            self.state.select(None);
-            self.close_detail();
+            self.clear_content();
         }
         self.repo_name = repo_name.to_string();
     }
@@ -165,6 +185,7 @@ impl GithubPanel {
 
     /// Close the detail pane and reset its scroll.
     pub fn close_detail(&mut self) {
+        self.detail_generation = self.detail_generation.wrapping_add(1);
         self.detail = None;
         self.detail_loading = false;
         self.detail_error = None;
@@ -318,7 +339,7 @@ impl GithubPanel {
                 PanelStatus::Loading => "Loading\u{2026}",
                 PanelStatus::NotGithub => "No github.com remote",
                 PanelStatus::Error(e) => e.as_str(),
-                PanelStatus::Ready => "No open issues or PRs",
+                PanelStatus::Ready => "No matching issues or PRs",
             };
             let paragraph = Paragraph::new(msg)
                 .style(Style::default().fg(f.empty_text))
@@ -690,6 +711,85 @@ mod tests {
 
         p.close_detail();
         assert!(!p.has_detail(), "closing clears the pane");
+    }
+
+    #[test]
+    fn closing_detail_rejects_its_pending_response() {
+        let mut p = panel();
+        p.set_data(vec![item(1)], vec![], "repo", "open");
+        let Some(Action::ShowGithubItem { generation, .. }) =
+            p.handle_key_event(KeyCode::Enter.into()).unwrap()
+        else {
+            panic!("expected a detail request")
+        };
+        p.handle_key_event(KeyCode::Esc.into()).unwrap();
+        p.set_detail(generation, Ok(detail(1)));
+        assert!(!p.has_detail(), "late response reopened the closed detail");
+    }
+
+    #[test]
+    fn switching_to_cached_repo_clears_previous_detail() {
+        let mut p = panel();
+        p.set_data(vec![item(1)], vec![], "first", "open");
+        let Some(Action::ShowGithubItem { generation, .. }) =
+            p.handle_key_event(KeyCode::Enter.into()).unwrap()
+        else {
+            panic!("expected a detail request")
+        };
+        p.set_detail(generation, Ok(detail(1)));
+        p.set_data(vec![item(2)], vec![], "second", "open");
+        assert!(!p.has_detail(), "new repo retained previous detail");
+        assert!(p.selected_url().unwrap().ends_with("/2"));
+    }
+
+    #[test]
+    fn repositories_with_same_name_reject_previous_detail_responses() {
+        let mut p = panel();
+        p.set_target(Some(RepoId("/first/repo".into())), "repo", "open");
+        p.set_data(vec![item(1)], vec![], "repo", "open");
+        let Some(Action::ShowGithubItem { generation, .. }) =
+            p.handle_key_event(KeyCode::Enter.into()).unwrap()
+        else {
+            panic!("expected a detail request")
+        };
+        p.set_target(Some(RepoId("/second/repo".into())), "repo", "open");
+        p.set_data(vec![item(2)], vec![], "repo", "open");
+        p.set_detail(generation, Ok(detail(1)));
+        assert!(!p.has_detail());
+        assert!(p.selected_url().unwrap().ends_with("/2"));
+    }
+
+    #[test]
+    fn changing_filter_clears_rows_until_matching_results_arrive() {
+        let mut p = panel();
+        let id = Some(RepoId("/repo".into()));
+        p.set_target(id.clone(), "repo", "open");
+        p.set_data(vec![item(1)], vec![], "repo", "open");
+        p.set_target(id, "repo", "closed");
+        p.set_loading("repo");
+        assert!(p.selected_url().is_none());
+        assert!(p.handle_key_event(KeyCode::Enter.into()).unwrap().is_none());
+        p.set_data(vec![item(2)], vec![], "repo", "closed");
+        assert!(p.selected_url().unwrap().ends_with("/2"));
+    }
+
+    #[test]
+    fn failed_refresh_surfaces_error_and_disables_old_rows() {
+        let mut p = panel();
+        p.set_data(vec![item(1)], vec![], "repo", "open");
+        p.set_error("repo", "Authentication failed".into());
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, 10)).unwrap();
+        terminal.draw(|f| p.draw(f, f.area()).unwrap()).unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("Authentication failed"));
+        assert!(p.selected_url().is_none());
     }
 
     #[test]

--- a/src/git/commit_files.rs
+++ b/src/git/commit_files.rs
@@ -53,7 +53,7 @@ pub(crate) fn commit_file_diff(
     let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
 
     let mut opts = DiffOptions::new();
-    opts.pathspec(file_path);
+    opts.pathspec(file_path).disable_pathspec_match(true);
 
     let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&tree), Some(&mut opts))?;
 

--- a/src/git/file_ops.rs
+++ b/src/git/file_ops.rs
@@ -1,0 +1,105 @@
+use std::path::Path;
+
+#[derive(Clone, Copy)]
+pub(crate) enum FileOperation {
+    Stage,
+    Unstage,
+    Discard,
+    DeleteUntracked,
+    Diff,
+}
+
+pub(crate) fn arguments(
+    repo_path: &Path,
+    selected: &Path,
+    operation: FileOperation,
+) -> color_eyre::Result<Vec<String>> {
+    let words = match operation {
+        FileOperation::Stage => vec!["add", "-A"],
+        FileOperation::Unstage => vec!["reset", "-q"],
+        FileOperation::Discard => vec!["restore", "--staged", "--worktree"],
+        FileOperation::DeleteUntracked => vec!["clean", "-fdq"],
+        FileOperation::Diff => vec!["diff", "HEAD"],
+    };
+    let mut paths = vec![selected.to_path_buf()];
+    if !matches!(
+        operation,
+        FileOperation::DeleteUntracked | FileOperation::Stage
+    ) {
+        let repo = git2::Repository::open(repo_path)?;
+        let mut options = git2::StatusOptions::new();
+        options.include_untracked(true).renames_head_to_index(true);
+        let statuses = repo.statuses(Some(&mut options))?;
+        for entry in statuses.iter() {
+            let Some(delta) = entry.head_to_index() else {
+                continue;
+            };
+            if delta.status() != git2::Delta::Renamed || delta.new_file().path() != Some(selected) {
+                continue;
+            }
+            if let Some(old) = delta.old_file().path() {
+                if matches!(operation, FileOperation::Discard) {
+                    match std::fs::symlink_metadata(repo_path.join(old)) {
+                        Ok(_) => {
+                            return Err(color_eyre::eyre::eyre!(
+                                "Cannot discard rename: '{}' already exists. Move it aside first to preserve its contents.",
+                                old.display()
+                            ));
+                        }
+                        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(error) => return Err(error.into()),
+                    }
+                }
+                paths.push(old.to_path_buf());
+            }
+        }
+    }
+    let mut args = vec!["--literal-pathspecs".to_owned()];
+    args.extend(words.into_iter().map(str::to_owned));
+    args.push("--".into());
+    for path in paths {
+        let value = path.to_str().ok_or_else(|| {
+            color_eyre::eyre::eyre!("Cannot run file operation on a non-UTF-8 path")
+        })?;
+        args.push(value.to_owned());
+    }
+    Ok(args)
+}
+
+pub(crate) fn diff(repo_path: &Path, selected: &Path) -> color_eyre::Result<String> {
+    let repo = git2::Repository::open(repo_path)?;
+    let untracked = repo.status_file(selected)?.is_wt_new();
+    let mut command = std::process::Command::new("git");
+    command.arg("-C").arg(repo_path).current_dir(repo_path);
+    if untracked {
+        command
+            .args(["diff", "--no-index", "--", "/dev/null"])
+            .arg(selected);
+    } else {
+        let mut args = arguments(repo_path, selected, FileOperation::Diff)?;
+        if repo.head().is_err() {
+            // An unborn branch has an index but no HEAD tree yet.
+            if !repo.is_empty()? {
+                return Err(color_eyre::eyre::eyre!("Cannot resolve repository HEAD"));
+            }
+            args[2] = "--cached".to_owned();
+        }
+        command.args(args);
+    }
+    let output = command.output()?;
+    if !(output.status.success() || untracked && output.status.code() == Some(1)) {
+        return Err(color_eyre::eyre::eyre!(
+            "{}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let text = String::from_utf8_lossy(&output.stdout).into_owned();
+    Ok(if text.is_empty() {
+        "(no diff available)".into()
+    } else {
+        text
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/git/file_ops/tests.rs
+++ b/src/git/file_ops/tests.rs
@@ -1,0 +1,237 @@
+use super::*;
+use git2::Repository;
+
+fn git(path: &Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn fixture(names: &[&str]) -> (tempfile::TempDir, Repository) {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let repo = Repository::init(tmp.path()).unwrap();
+    let mut index = repo.index().unwrap();
+    for name in names {
+        std::fs::write(tmp.path().join(name), format!("original {name}\n")).unwrap();
+        index.add_path(Path::new(name)).unwrap();
+    }
+    index.write().unwrap();
+    let tree_id = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+        .unwrap();
+    drop(tree);
+    (tmp, repo)
+}
+
+fn apply(path: &Path, name: &str, operation: FileOperation) {
+    let args = arguments(path, Path::new(name), operation).unwrap();
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(&args)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{args:?}: {:?}: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn selected_pattern_filename_does_not_change_other_files_or_index_entries() {
+    for selected in ["*.txt", ":(glob)*.txt", "[ab].txt"] {
+        let (tmp, repo) = fixture(&[selected, "a.txt"]);
+        for name in [selected, "a.txt"] {
+            std::fs::write(tmp.path().join(name), format!("changed {name}\n")).unwrap();
+        }
+        apply(tmp.path(), selected, FileOperation::Stage);
+        assert!(
+            repo.status_file(Path::new(selected))
+                .unwrap()
+                .is_index_modified()
+        );
+        assert!(
+            !repo
+                .status_file(Path::new("a.txt"))
+                .unwrap()
+                .is_index_modified()
+        );
+        git(tmp.path(), &["add", "-A"]);
+        apply(tmp.path(), selected, FileOperation::Unstage);
+        assert!(
+            !repo
+                .status_file(Path::new(selected))
+                .unwrap()
+                .is_index_modified()
+        );
+        assert!(
+            repo.status_file(Path::new("a.txt"))
+                .unwrap()
+                .is_index_modified()
+        );
+        apply(tmp.path(), selected, FileOperation::Discard);
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join(selected)).unwrap(),
+            format!("original {selected}\n")
+        );
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("a.txt")).unwrap(),
+            "changed a.txt\n"
+        );
+        assert!(
+            repo.status_file(Path::new("a.txt"))
+                .unwrap()
+                .is_index_modified()
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn deleting_untracked_pattern_filename_preserves_other_files() {
+    let (tmp, _) = fixture(&["tracked"]);
+    for name in ["*.draft", "important.draft"] {
+        std::fs::write(tmp.path().join(name), "draft").unwrap();
+    }
+    apply(tmp.path(), "*.draft", FileOperation::DeleteUntracked);
+    assert!(!tmp.path().join("*.draft").exists());
+    assert!(tmp.path().join("important.draft").exists());
+}
+
+#[test]
+fn rename_actions_update_both_paths_and_preserve_other_staged_changes() {
+    for operation in [
+        FileOperation::Stage,
+        FileOperation::Unstage,
+        FileOperation::Discard,
+    ] {
+        let (tmp, repo) = fixture(&["old", "other"]);
+        git(tmp.path(), &["mv", "old", "new"]);
+        std::fs::write(tmp.path().join("new"), "edited after rename\n").unwrap();
+        std::fs::write(tmp.path().join("other"), "unrelated staged\n").unwrap();
+        git(tmp.path(), &["add", "other"]);
+        apply(tmp.path(), "new", operation);
+        let index = repo.index().unwrap();
+        assert!(
+            repo.status_file(Path::new("other"))
+                .unwrap()
+                .is_index_modified()
+        );
+        match operation {
+            FileOperation::Stage => {
+                assert!(index.get_path(Path::new("old"), 0).is_none());
+                assert!(!repo.status_file(Path::new("new")).unwrap().is_wt_modified());
+            }
+            FileOperation::Unstage => {
+                assert!(index.get_path(Path::new("old"), 0).is_some());
+                assert!(index.get_path(Path::new("new"), 0).is_none());
+                assert_eq!(
+                    std::fs::read_to_string(tmp.path().join("new")).unwrap(),
+                    "edited after rename\n"
+                );
+            }
+            FileOperation::Discard => {
+                assert!(index.get_path(Path::new("old"), 0).is_some());
+                assert!(index.get_path(Path::new("new"), 0).is_none());
+                assert!(!tmp.path().join("new").exists());
+                assert_eq!(
+                    std::fs::read_to_string(tmp.path().join("old")).unwrap(),
+                    "original old\n"
+                );
+            }
+            FileOperation::DeleteUntracked | FileOperation::Diff => unreachable!(),
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn selected_diff_excludes_other_pattern_matches_in_worktree_and_commit() {
+    let (tmp, repo) = fixture(&["*.txt", "other.txt"]);
+    for (name, text) in [("*.txt", "SELECTED"), ("other.txt", "UNRELATED")] {
+        std::fs::write(tmp.path().join(name), text).unwrap();
+    }
+    let text = diff(tmp.path(), Path::new("*.txt")).unwrap();
+    assert!(text.contains("SELECTED"));
+    assert!(!text.contains("UNRELATED"));
+    let head = repo.head().unwrap().target().unwrap().to_string();
+    let text = crate::git::commit_files::commit_file_diff(tmp.path(), &head, "*.txt").unwrap();
+    assert!(text.contains("original *.txt"));
+    assert!(!text.contains("original other.txt"));
+}
+
+#[test]
+fn untracked_diff_reads_from_selected_repository() {
+    let (tmp, _) = fixture(&["tracked"]);
+    std::fs::write(tmp.path().join("untracked"), "NEW CONTENT").unwrap();
+    assert!(
+        diff(tmp.path(), Path::new("untracked"))
+            .unwrap()
+            .contains("NEW CONTENT")
+    );
+}
+
+#[test]
+fn staging_rename_does_not_stage_a_recreated_source_file() {
+    let (tmp, repo) = fixture(&["old"]);
+    git(tmp.path(), &["mv", "old", "new"]);
+    std::fs::write(tmp.path().join("old"), "unrelated replacement").unwrap();
+    std::fs::write(tmp.path().join("new"), "updated destination").unwrap();
+    apply(tmp.path(), "new", FileOperation::Stage);
+    assert!(repo.status_file(Path::new("old")).unwrap().is_wt_new());
+    assert!(!repo.status_file(Path::new("new")).unwrap().is_wt_modified());
+}
+
+#[test]
+fn discarding_rename_refuses_to_overwrite_a_recreated_source() {
+    let (tmp, repo) = fixture(&["old"]);
+    git(tmp.path(), &["mv", "old", "new"]);
+    std::fs::write(tmp.path().join("old"), "unrelated replacement").unwrap();
+    let index_before = std::fs::read(repo.path().join("index")).unwrap();
+    let error = arguments(tmp.path(), Path::new("new"), FileOperation::Discard).unwrap_err();
+    assert!(error.to_string().contains("old"));
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("old")).unwrap(),
+        "unrelated replacement"
+    );
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("new")).unwrap(),
+        "original old\n"
+    );
+    assert_eq!(
+        std::fs::read(repo.path().join("index")).unwrap(),
+        index_before
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn discarding_rename_preserves_a_recreated_dangling_symlink() {
+    let (tmp, repo) = fixture(&["old"]);
+    git(tmp.path(), &["mv", "old", "new"]);
+    std::os::unix::fs::symlink("missing-target", tmp.path().join("old")).unwrap();
+    let index_before = std::fs::read(repo.path().join("index")).unwrap();
+    assert!(arguments(tmp.path(), Path::new("new"), FileOperation::Discard).is_err());
+    assert_eq!(
+        std::fs::read_link(tmp.path().join("old")).unwrap(),
+        Path::new("missing-target")
+    );
+    assert!(tmp.path().join("new").exists());
+    assert_eq!(
+        std::fs::read(repo.path().join("index")).unwrap(),
+        index_before
+    );
+}

--- a/src/git/file_ops/tests.rs
+++ b/src/git/file_ops/tests.rs
@@ -18,6 +18,10 @@ fn git(path: &Path, args: &[&str]) {
 fn fixture(names: &[&str]) -> (tempfile::TempDir, Repository) {
     let tmp = tempfile::TempDir::new().unwrap();
     let repo = Repository::init(tmp.path()).unwrap();
+    repo.config()
+        .unwrap()
+        .set_bool("core.autocrlf", false)
+        .unwrap();
     let mut index = repo.index().unwrap();
     for name in names {
         std::fs::write(tmp.path().join(name), format!("original {name}\n")).unwrap();

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod commit_files;
+pub(crate) mod file_ops;
 pub(crate) mod github;
 pub(crate) mod graph;
 pub(crate) mod graph_render;

--- a/src/git/scanner.rs
+++ b/src/git/scanner.rs
@@ -47,17 +47,20 @@ fn is_real_git_dir(dot_git: &Path) -> bool {
 }
 
 /// Whether a candidate repo path matches an `excluded_repos` pattern.
-/// Patterns match the repo's directory name or any path component.
+/// Legacy patterns match substrings; `path:` entries match one absolute path.
 fn is_excluded(repo_path: &Path, config: &Config) -> bool {
     let repo_name = repo_path
         .file_name()
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_default();
     let path_str = repo_path.to_string_lossy();
-    config
-        .excluded_repos
-        .iter()
-        .any(|pattern| repo_name == *pattern || path_str.contains(pattern))
+    config.excluded_repos.iter().any(|pattern| {
+        if let Some(exact) = pattern.strip_prefix("path:") {
+            repo_path == Path::new(exact)
+        } else {
+            repo_name == *pattern || path_str.contains(pattern)
+        }
+    })
 }
 
 /// Google `repo` (git-repo) managed workspace discovery.

--- a/src/git/status/change_summary.rs
+++ b/src/git/status/change_summary.rs
@@ -20,6 +20,16 @@ pub(super) fn collect_change_summary(
     recurse_untracked_dirs: bool,
     sub_cfg: &SubmoduleConfig,
 ) -> color_eyre::Result<ChangeSummary> {
+    if repo.is_bare() {
+        return Ok(ChangeSummary {
+            files: Vec::new(),
+            is_dirty: false,
+            has_submodules: false,
+            submodules: Vec::new(),
+            has_dirty_submodules: false,
+            has_unpushed_submodules: false,
+        });
+    }
     let mut opts = StatusOptions::new();
     opts.include_untracked(true)
         .recurse_untracked_dirs(recurse_untracked_dirs)
@@ -34,7 +44,15 @@ pub(super) fn collect_change_summary(
 
     for entry in statuses.iter() {
         let s = entry.status();
-        let file_path = PathBuf::from(entry.path().unwrap_or(""));
+        let file_path = entry
+            .index_to_workdir()
+            .and_then(|delta| delta.new_file().path().map(Path::to_path_buf))
+            .or_else(|| {
+                entry
+                    .head_to_index()
+                    .and_then(|delta| delta.new_file().path().map(Path::to_path_buf))
+            })
+            .ok_or_else(|| color_eyre::eyre::eyre!("Git status entry has no path"))?;
 
         let file_status = if s.is_conflicted() {
             FileStatus::Conflicted
@@ -48,7 +66,11 @@ pub(super) fn collect_change_summary(
             FileStatus::Deleted
         } else if s.is_index_renamed() || s.is_wt_renamed() {
             FileStatus::Renamed
-        } else if s.is_index_modified() || s.is_wt_modified() {
+        } else if s.is_index_modified()
+            || s.is_wt_modified()
+            || s.is_index_typechange()
+            || s.is_wt_typechange()
+        {
             FileStatus::Modified
         } else {
             continue;

--- a/src/git/status/mod.rs
+++ b/src/git/status/mod.rs
@@ -9,6 +9,8 @@ mod test_support;
 #[cfg(test)]
 mod tests_basic;
 #[cfg(test)]
+mod tests_changes;
+#[cfg(test)]
 mod tests_refs;
 #[cfg(test)]
 mod tests_submodule;

--- a/src/git/status/tests_changes.rs
+++ b/src/git/status/tests_changes.rs
@@ -1,0 +1,56 @@
+use super::test_support::{commit_index, init_temp_repo};
+use super::*;
+
+#[test]
+fn bare_repository_reports_head_without_worktree_changes() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let repo = Repository::init_bare(tmp.path()).unwrap();
+    let oid = commit_index(&repo, "bare commit");
+    let status = query_status(tmp.path(), &SubmoduleConfig::default()).unwrap();
+    assert_eq!(status.head_oid, Some(oid.to_string()));
+    assert!(!status.is_dirty);
+    assert!(status.files.is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn file_type_changes_remain_visible_before_and_after_staging() {
+    let (tmp, repo) = init_temp_repo();
+    std::fs::write(tmp.path().join("file"), "original").unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("file")).unwrap();
+    index.write().unwrap();
+    commit_index(&repo, "regular file");
+    std::fs::remove_file(tmp.path().join("file")).unwrap();
+    std::os::unix::fs::symlink("target", tmp.path().join("file")).unwrap();
+    for staged in [false, true] {
+        if staged {
+            index.add_path(Path::new("file")).unwrap();
+            index.write().unwrap();
+        }
+        let status = query_status(tmp.path(), &SubmoduleConfig::default()).unwrap();
+        assert!(status.is_dirty);
+        assert_eq!(status.files.len(), 1);
+        assert_eq!(status.files[0].status, FileStatus::Modified);
+        assert_eq!(status.files[0].staged, staged);
+        assert_eq!(status.files[0].unstaged, !staged);
+    }
+}
+
+#[test]
+fn staged_rename_displays_its_current_path() {
+    let (tmp, repo) = init_temp_repo();
+    std::fs::write(tmp.path().join("old"), "original").unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("old")).unwrap();
+    index.write().unwrap();
+    commit_index(&repo, "original");
+    std::fs::rename(tmp.path().join("old"), tmp.path().join("new")).unwrap();
+    index.remove_path(Path::new("old")).unwrap();
+    index.add_path(Path::new("new")).unwrap();
+    index.write().unwrap();
+    let status = query_status(tmp.path(), &SubmoduleConfig::default()).unwrap();
+    assert_eq!(status.files.len(), 1);
+    assert_eq!(status.files[0].path, Path::new("new"));
+    assert_eq!(status.files[0].status, FileStatus::Renamed);
+}

--- a/src/repo_id.rs
+++ b/src/repo_id.rs
@@ -1,5 +1,62 @@
 use std::path::PathBuf;
 
+/// Use the ordinary Windows spelling at process and watcher boundaries while
+/// keeping canonical repository identities unchanged. Other platforms borrow
+/// the original path.
+pub(crate) fn boundary_path(path: &std::path::Path) -> std::borrow::Cow<'_, std::path::Path> {
+    #[cfg(windows)]
+    {
+        use std::path::{Component, Prefix};
+        let mut components = path.components();
+        if let Some(Component::Prefix(prefix)) = components.next() {
+            let mut result = match prefix.kind() {
+                Prefix::VerbatimDisk(drive) => PathBuf::from(format!("{}:\\", char::from(drive))),
+                Prefix::VerbatimUNC(server, share) => {
+                    let mut value = std::ffi::OsString::from(r"\\");
+                    value.push(server);
+                    value.push(r"\");
+                    value.push(share);
+                    PathBuf::from(value)
+                }
+                _ => return std::borrow::Cow::Borrowed(path),
+            };
+            result.extend(components);
+            return std::borrow::Cow::Owned(result);
+        }
+    }
+    std::borrow::Cow::Borrowed(path)
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn process_paths_accept_canonical_drive_and_unc_spellings() {
+        for (canonical, ordinary) in [
+            (r"\\?\C:\repo\source file.rs", "C:/repo/source file.rs"),
+            (
+                r"\\?\UNC\server\share\repo\file",
+                r"\\server\share\repo\file",
+            ),
+        ] {
+            assert_eq!(
+                boundary_path(Path::new(canonical)).as_ref(),
+                Path::new(ordinary)
+            );
+        }
+        for path in [
+            r"relative\file",
+            r"C:\repo\file",
+            r"\\.\device",
+            r"\\?\Volume{abc}\file",
+        ] {
+            assert_eq!(boundary_path(Path::new(path)).as_ref(), Path::new(path));
+        }
+    }
+}
+
 /// Stable identity for a repository, based on its filesystem path.
 /// Unlike positional `usize` indices, a `RepoId` remains valid across
 /// repo list mutations (add, remove, sort, rescan).

--- a/src/session/launcher/mod.rs
+++ b/src/session/launcher/mod.rs
@@ -51,13 +51,35 @@ pub(crate) fn shell_single_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
-/// Build argv from a command template by replacing every `{path}` token with
-/// `dir` (one argv element per whitespace-split token, so the path is space-safe
-/// without quoting). Used for `Placement::Command` (no shell).
-fn substitute_argv(template: &str, dir: &str) -> Vec<String> {
+/// Expand placeholders in the original template only. Inserted paths and refs
+/// may themselves contain placeholder text, which must remain literal data.
+fn substitute_placeholders(template: &str, dir: &str, base: Option<&str>) -> String {
+    let mut output = String::new();
+    let mut cursor = 0;
+    for (offset, _) in template.match_indices('{') {
+        let replacement = if template[offset..].starts_with("{path}") {
+            Some(("{path}", dir))
+        } else if template[offset..].starts_with("{base}") {
+            base.map(|b| ("{base}", b))
+        } else {
+            None
+        };
+        if let Some((token, value)) = replacement {
+            output.push_str(&template[cursor..offset]);
+            output.push_str(value);
+            cursor = offset + token.len();
+        }
+    }
+    output.push_str(&template[cursor..]);
+    output
+}
+
+/// Build argv with path/base substitution after whitespace splitting, keeping
+/// each expanded value within its argument. No shell quoting is needed.
+fn substitute_argv(template: &str, dir: &str, base: Option<&str>) -> Vec<String> {
     template
         .split_whitespace()
-        .map(|tok| tok.replace("{path}", dir))
+        .map(|tok| substitute_placeholders(tok, dir, base))
         .collect()
 }
 
@@ -65,11 +87,8 @@ fn substitute_argv(template: &str, dir: &str) -> Vec<String> {
 /// shell-quoting each value so a path with spaces or a ref with shell
 /// metacharacters cannot break out of the command.
 fn substitute_shell(template: &str, dir: &str, base: Option<&str>) -> String {
-    let mut s = template.replace("{path}", &shell_single_quote(dir));
-    if let Some(b) = base {
-        s = s.replace("{base}", &shell_single_quote(b));
-    }
-    s
+    let base = base.map(shell_single_quote);
+    substitute_placeholders(template, &shell_single_quote(dir), base.as_deref())
 }
 
 /// Parse a placement string. `command`/`inline`/`ask` are keywords; anything
@@ -129,6 +148,19 @@ pub(crate) fn plan(
     base: Option<&str>,
     mux: Multiplexer,
 ) -> LaunchPlan {
+    plan_with_target(command, placement, dir, dir, base, mux)
+}
+
+/// Launch at `dir` while expanding `{path}` to `target`. Opening a file uses
+/// its parent as the placement's working directory and the file as the target.
+pub(crate) fn plan_with_target(
+    command: Option<&str>,
+    placement: &str,
+    dir: &str,
+    target: &str,
+    base: Option<&str>,
+    mux: Multiplexer,
+) -> LaunchPlan {
     let placement = match parse_placement(placement) {
         Ok(p) => p,
         Err(e) => return LaunchPlan::Error(e),
@@ -136,7 +168,7 @@ pub(crate) fn plan(
     let cmd = command.filter(|c| !c.trim().is_empty());
     match placement {
         Placement::Command => match cmd {
-            Some(c) => LaunchPlan::Spawn(substitute_argv(c, dir)),
+            Some(c) => LaunchPlan::Spawn(substitute_argv(c, target, base)),
             None => match mux {
                 Multiplexer::Tmux => LaunchPlan::Spawn(vec![
                     "tmux".to_string(),
@@ -154,7 +186,7 @@ pub(crate) fn plan(
             },
         },
         Placement::Tmux(flags) => {
-            let shell = cmd.map(|c| substitute_shell(c, dir, base));
+            let shell = cmd.map(|c| substitute_shell(c, target, base));
             match mux {
                 Multiplexer::Tmux => {
                     LaunchPlan::Spawn(build_tmux_argv(&flags, dir, shell.as_deref()))
@@ -178,14 +210,14 @@ pub(crate) fn plan(
             }
         }
         Placement::Inline => match cmd {
-            Some(c) => LaunchPlan::Inline(substitute_shell(c, dir, base)),
+            Some(c) => LaunchPlan::Inline(substitute_shell(c, target, base)),
             None => LaunchPlan::Error("inline placement needs a command".to_string()),
         },
         Placement::Ask => match mux {
             Multiplexer::Tmux | Multiplexer::Herdr => LaunchPlan::Ask,
             Multiplexer::None => {
                 if let Some(c) = cmd {
-                    LaunchPlan::Inline(substitute_shell(c, dir, base))
+                    LaunchPlan::Inline(substitute_shell(c, target, base))
                 } else {
                     LaunchPlan::Error("run gitpane inside tmux or herdr for this placement".into())
                 }
@@ -442,442 +474,4 @@ pub(crate) fn forward_right_click_in_herdr() {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn argv(parts: &[&str]) -> LaunchPlan {
-        LaunchPlan::Spawn(parts.iter().map(|s| s.to_string()).collect())
-    }
-
-    #[test]
-    fn goto_placement_infers_tab_or_window() {
-        assert_eq!(
-            goto_placement("wezterm cli spawn -- tmux attach -t {session}"),
-            Some("new tab")
-        );
-        assert_eq!(
-            goto_placement("kitten @ launch --type=tab tmux attach -t {session}"),
-            Some("new tab")
-        );
-        assert_eq!(
-            goto_placement("open -na Ghostty --args -e tmux attach -t {session}"),
-            Some("new window")
-        );
-        assert_eq!(goto_placement("tmux switch-client -t {session}"), None);
-    }
-
-    #[test]
-    fn goto_argv_substitutes_session() {
-        assert_eq!(
-            build_goto_argv("tmux switch-client -t {session}", "fairtrail"),
-            vec!["tmux", "switch-client", "-t", "fairtrail"]
-        );
-        assert_eq!(
-            build_goto_argv("wezterm cli spawn -- tmux attach -t {session}", "ft-rec"),
-            vec![
-                "wezterm", "cli", "spawn", "--", "tmux", "attach", "-t", "ft-rec"
-            ]
-        );
-    }
-
-    #[test]
-    fn parse_keywords_and_tmux_and_invalid() {
-        assert_eq!(parse_placement("command"), Ok(Placement::Command));
-        assert_eq!(parse_placement("inline"), Ok(Placement::Inline));
-        assert_eq!(parse_placement("ask"), Ok(Placement::Ask));
-        assert_eq!(
-            parse_placement("split-window -h -t agents"),
-            Ok(Placement::Tmux(
-                ["split-window", "-h", "-t", "agents"]
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect()
-            ))
-        );
-        assert!(parse_placement("kill-server").is_err());
-        assert!(parse_placement("-t other").is_err());
-        // A `;` would chain extra tmux commands — rejected even after a valid head.
-        assert!(parse_placement("split-window -h ; kill-server").is_err());
-        assert!(parse_placement("new-window;kill-server").is_err());
-    }
-
-    #[test]
-    fn command_mode_runs_detached_argv() {
-        // open's default: the command is the launcher, run as argv (no shell).
-        assert_eq!(
-            plan(
-                Some("cursor {path}"),
-                "command",
-                "/w t/app",
-                None,
-                Multiplexer::None
-            ),
-            argv(&["cursor", "/w t/app"])
-        );
-    }
-
-    #[test]
-    fn command_mode_empty_opens_tmux_pane_in_tmux() {
-        assert_eq!(
-            plan(None, "command", "/app", None, Multiplexer::Tmux),
-            argv(&["tmux", "split-window", "-c", "/app"])
-        );
-    }
-
-    #[test]
-    fn command_mode_empty_without_tmux_errors() {
-        assert!(matches!(
-            plan(None, "command", "/app", None, Multiplexer::None),
-            LaunchPlan::Error(_)
-        ));
-    }
-
-    #[test]
-    fn tmux_placement_wraps_in_sh_c() {
-        assert_eq!(
-            plan(
-                Some("git diff {base}...HEAD"),
-                "new-window",
-                "/app",
-                Some("origin/main"),
-                Multiplexer::Tmux
-            ),
-            argv(&[
-                "tmux",
-                "new-window",
-                "-c",
-                "/app",
-                "sh",
-                "-c",
-                "git diff 'origin/main'...HEAD"
-            ])
-        );
-    }
-
-    #[test]
-    fn tmux_placement_passes_flags_through() {
-        assert_eq!(
-            plan(
-                Some("lazygit"),
-                "split-window -h -t agents",
-                "/app",
-                None,
-                Multiplexer::Tmux
-            ),
-            argv(&[
-                "tmux",
-                "split-window",
-                "-h",
-                "-t",
-                "agents",
-                "-c",
-                "/app",
-                "sh",
-                "-c",
-                "lazygit"
-            ])
-        );
-    }
-
-    #[test]
-    fn tmux_placement_without_tmux_falls_back_to_inline() {
-        assert_eq!(
-            plan(
-                Some("git diff {base}...HEAD | delta"),
-                "new-window",
-                "/app",
-                Some("main"),
-                Multiplexer::None
-            ),
-            LaunchPlan::Inline("git diff 'main'...HEAD | delta".to_string())
-        );
-    }
-
-    #[test]
-    fn base_with_metacharacters_is_quoted() {
-        assert_eq!(
-            plan(
-                Some("git diff {base}...HEAD"),
-                "inline",
-                "/app",
-                Some("a;rm -rf b"),
-                Multiplexer::None
-            ),
-            LaunchPlan::Inline("git diff 'a;rm -rf b'...HEAD".to_string())
-        );
-    }
-
-    #[test]
-    fn ask_is_a_picker_in_tmux_and_inline_without() {
-        assert_eq!(
-            plan(Some("x"), "ask", "/app", None, Multiplexer::Tmux),
-            LaunchPlan::Ask
-        );
-        assert_eq!(
-            plan(Some("x"), "ask", "/app", None, Multiplexer::None),
-            LaunchPlan::Inline("x".to_string())
-        );
-    }
-
-    #[test]
-    fn command_mode_expands_embedded_path_token() {
-        // `{path}` inside a token expands too (one argv element, space-safe).
-        assert_eq!(
-            plan(
-                Some("wezterm cli spawn --cwd={path}"),
-                "command",
-                "/w t/x",
-                None,
-                Multiplexer::None
-            ),
-            argv(&["wezterm", "cli", "spawn", "--cwd=/w t/x"])
-        );
-    }
-
-    #[test]
-    fn command_mode_blank_command_opens_tmux_pane() {
-        // A whitespace-only command counts as empty.
-        assert_eq!(
-            plan(Some("   "), "command", "/repo", None, Multiplexer::Tmux),
-            argv(&["tmux", "split-window", "-c", "/repo"])
-        );
-    }
-
-    #[test]
-    fn shell_mode_quotes_path_token() {
-        // In shell modes, {path} is shell-quoted (it reaches `sh -c`).
-        assert_eq!(
-            plan(
-                Some("cd {path} && git diff"),
-                "inline",
-                "/w t/x",
-                None,
-                Multiplexer::None
-            ),
-            LaunchPlan::Inline("cd '/w t/x' && git diff".to_string())
-        );
-    }
-
-    #[test]
-    fn invalid_placement_is_an_error_plan() {
-        assert!(matches!(
-            plan(Some("x"), "frobnicate", "/app", None, Multiplexer::Tmux),
-            LaunchPlan::Error(_)
-        ));
-    }
-
-    #[test]
-    fn parse_tmux_windows_skips_malformed_lines() {
-        let out = "@0\tmain:0 editor\n@1\t\nno-tab-here\n@2\twork:2 logs\n";
-        assert_eq!(
-            parse_tmux_windows(out),
-            vec![
-                ("main:0 editor".to_string(), "@0".to_string()),
-                ("@1".to_string(), "@1".to_string()), // empty label -> target as label
-                ("work:2 logs".to_string(), "@2".to_string()),
-            ]
-        );
-    }
-
-    #[test]
-    fn placement_choices_use_space_free_window_id_target() {
-        // Even with a spaced label, the placement `-t` target is the window id,
-        // so the whitespace-split placement string stays valid.
-        let windows = vec![("my session:0 editor".to_string(), "@7".to_string())];
-        assert_eq!(
-            placement_choices(&windows),
-            vec![
-                ("New window".to_string(), "new-window".to_string()),
-                (
-                    "Right of my session:0 editor".to_string(),
-                    "split-window -h -t @7".to_string()
-                ),
-                (
-                    "Below my session:0 editor".to_string(),
-                    "split-window -v -t @7".to_string()
-                ),
-            ]
-        );
-    }
-
-    fn herdr_argv(parts: &[&str]) -> LaunchPlan {
-        LaunchPlan::Herdr {
-            create: parts.iter().map(|s| s.to_string()).collect(),
-            command: None,
-        }
-    }
-
-    #[test]
-    fn command_mode_empty_opens_herdr_pane_in_herdr() {
-        assert_eq!(
-            plan(None, "command", "/app", None, Multiplexer::Herdr),
-            herdr_argv(&[
-                "herdr",
-                "pane",
-                "split",
-                "--current",
-                "--direction",
-                "right",
-                "--cwd",
-                "/app",
-                "--no-focus",
-                "--right-click",
-                "pane",
-            ])
-        );
-    }
-
-    #[test]
-    fn herdr_split_placement_honors_h_v_and_pane_target() {
-        // `-h` -> right, `-v` -> down, `-t <pane-id>` -> `--pane`.
-        assert_eq!(
-            plan(
-                Some("lazygit"),
-                "split-window -h",
-                "/app",
-                None,
-                Multiplexer::Herdr
-            ),
-            LaunchPlan::Herdr {
-                create: vec![
-                    "herdr",
-                    "pane",
-                    "split",
-                    "--current",
-                    "--direction",
-                    "right",
-                    "--cwd",
-                    "/app",
-                    "--no-focus",
-                    "--right-click",
-                    "pane",
-                ]
-                .into_iter()
-                .map(String::from)
-                .collect(),
-                command: Some("lazygit".to_string()),
-            }
-        );
-        let down = plan(
-            Some("x"),
-            "split-window -v",
-            "/app",
-            None,
-            Multiplexer::Herdr,
-        );
-        assert!(matches!(
-            down,
-            LaunchPlan::Herdr {
-                create: ref c,
-                ..
-            } if c.contains(&"down".to_string())
-        ));
-        let targeted = plan(
-            Some("x"),
-            "split-window -h -t w1:p3",
-            "/app",
-            None,
-            Multiplexer::Herdr,
-        );
-        assert!(matches!(
-            targeted,
-            LaunchPlan::Herdr {
-                create: ref c,
-                ..
-            } if c.contains(&"--pane".to_string()) && c.contains(&"w1:p3".to_string())
-        ));
-    }
-
-    #[test]
-    fn herdr_new_window_creates_a_tab() {
-        // review's default `new-window` placement -> `herdr tab create`; the
-        // command runs in the tab's root pane via `herdr pane run`.
-        assert_eq!(
-            plan(
-                Some("git diff {base}...HEAD"),
-                "new-window",
-                "/app",
-                Some("origin/main"),
-                Multiplexer::Herdr,
-            ),
-            LaunchPlan::Herdr {
-                create: vec!["herdr", "tab", "create", "--cwd", "/app", "--no-focus",]
-                    .into_iter()
-                    .map(String::from)
-                    .collect(),
-                command: Some("git diff 'origin/main'...HEAD".to_string()),
-            }
-        );
-    }
-
-    #[test]
-    fn herdr_rejects_unknown_and_tmux_only_flags() {
-        // Unknown flags and `new-window` flags must not silently mis-launch.
-        assert!(matches!(
-            plan(
-                Some("x"),
-                "split-window -l 20",
-                "/app",
-                None,
-                Multiplexer::Herdr
-            ),
-            LaunchPlan::Error(_)
-        ));
-        assert!(matches!(
-            plan(
-                Some("x"),
-                "new-window -t work",
-                "/app",
-                None,
-                Multiplexer::Herdr
-            ),
-            LaunchPlan::Error(_)
-        ));
-        assert!(matches!(
-            plan(
-                Some("x"),
-                "split-window -t",
-                "/app",
-                None,
-                Multiplexer::Herdr
-            ),
-            LaunchPlan::Error(_)
-        ));
-    }
-
-    #[test]
-    fn ask_is_a_picker_under_herdr() {
-        assert_eq!(
-            plan(Some("x"), "ask", "/app", None, Multiplexer::Herdr),
-            LaunchPlan::Ask
-        );
-    }
-
-    #[test]
-    fn herdr_placement_choices_offer_tab_and_splits() {
-        assert_eq!(
-            herdr_placement_choices(),
-            vec![
-                ("New tab".to_string(), "new-window".to_string()),
-                (
-                    "Right of current pane".to_string(),
-                    "split-window -h".to_string(),
-                ),
-                (
-                    "Below current pane".to_string(),
-                    "split-window -v".to_string(),
-                ),
-            ]
-        );
-    }
-
-    #[test]
-    fn parse_herdr_pane_id_reads_split_and_tab_responses() {
-        let split = "{\"id\":\"cli:pane:split\",\"result\":{\"pane\":{\"pane_id\":\"w1:p3\"}}}";
-        assert_eq!(parse_herdr_pane_id(split), Some("w1:p3".to_string()));
-        let tab =
-            "{\"result\":{\"tab\":{\"tab_id\":\"w1:t2\"},\"root_pane\":{\"pane_id\":\"w1:p7\"}}}";
-        assert_eq!(parse_herdr_pane_id(tab), Some("w1:p7".to_string()));
-        assert_eq!(parse_herdr_pane_id("not json"), None);
-    }
-}
+mod tests;

--- a/src/session/launcher/mod.rs
+++ b/src/session/launcher/mod.rs
@@ -161,6 +161,11 @@ pub(crate) fn plan_with_target(
     base: Option<&str>,
     mux: Multiplexer,
 ) -> LaunchPlan {
+    let dir = crate::repo_id::boundary_path(std::path::Path::new(dir));
+    let target = crate::repo_id::boundary_path(std::path::Path::new(target));
+    let dir = dir.to_string_lossy();
+    let target = target.to_string_lossy();
+    let (dir, target) = (dir.as_ref(), target.as_ref());
     let placement = match parse_placement(placement) {
         Ok(p) => p,
         Err(e) => return LaunchPlan::Error(e),

--- a/src/session/launcher/tests.rs
+++ b/src/session/launcher/tests.rs
@@ -1,0 +1,534 @@
+use super::*;
+
+fn argv(parts: &[&str]) -> LaunchPlan {
+    LaunchPlan::Spawn(parts.iter().map(|s| s.to_string()).collect())
+}
+
+#[test]
+fn goto_placement_infers_tab_or_window() {
+    assert_eq!(
+        goto_placement("wezterm cli spawn -- tmux attach -t {session}"),
+        Some("new tab")
+    );
+    assert_eq!(
+        goto_placement("kitten @ launch --type=tab tmux attach -t {session}"),
+        Some("new tab")
+    );
+    assert_eq!(
+        goto_placement("open -na Ghostty --args -e tmux attach -t {session}"),
+        Some("new window")
+    );
+    assert_eq!(goto_placement("tmux switch-client -t {session}"), None);
+}
+
+#[test]
+fn goto_argv_substitutes_session() {
+    assert_eq!(
+        build_goto_argv("tmux switch-client -t {session}", "fairtrail"),
+        vec!["tmux", "switch-client", "-t", "fairtrail"]
+    );
+    assert_eq!(
+        build_goto_argv("wezterm cli spawn -- tmux attach -t {session}", "ft-rec"),
+        vec![
+            "wezterm", "cli", "spawn", "--", "tmux", "attach", "-t", "ft-rec"
+        ]
+    );
+}
+
+#[test]
+fn parse_keywords_and_tmux_and_invalid() {
+    assert_eq!(parse_placement("command"), Ok(Placement::Command));
+    assert_eq!(parse_placement("inline"), Ok(Placement::Inline));
+    assert_eq!(parse_placement("ask"), Ok(Placement::Ask));
+    assert_eq!(
+        parse_placement("split-window -h -t agents"),
+        Ok(Placement::Tmux(
+            ["split-window", "-h", "-t", "agents"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect()
+        ))
+    );
+    assert!(parse_placement("kill-server").is_err());
+    assert!(parse_placement("-t other").is_err());
+    // A `;` would chain extra tmux commands — rejected even after a valid head.
+    assert!(parse_placement("split-window -h ; kill-server").is_err());
+    assert!(parse_placement("new-window;kill-server").is_err());
+}
+
+#[test]
+fn command_mode_runs_detached_argv() {
+    // open's default: the command is the launcher, run as argv (no shell).
+    assert_eq!(
+        plan(
+            Some("cursor {path}"),
+            "command",
+            "/w t/app",
+            None,
+            Multiplexer::None
+        ),
+        argv(&["cursor", "/w t/app"])
+    );
+}
+
+#[test]
+fn file_launches_keep_the_parent_directory_separate_from_the_file_target() {
+    let dir = "/code/my repo";
+    let target = "/code/my repo/source.rs";
+    let command = "viewer '/code/my repo/source.rs'";
+    let cases = [
+        ("command", Multiplexer::None, argv(&["viewer", target])),
+        (
+            "inline",
+            Multiplexer::None,
+            LaunchPlan::Inline(command.into()),
+        ),
+        (
+            "split-window",
+            Multiplexer::Tmux,
+            argv(&["tmux", "split-window", "-c", dir, "sh", "-c", command]),
+        ),
+        (
+            "new-window",
+            Multiplexer::Herdr,
+            LaunchPlan::Herdr {
+                create: ["herdr", "tab", "create", "--cwd", dir, "--no-focus"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect(),
+                command: Some(command.into()),
+            },
+        ),
+    ];
+    for (placement, mux, expected) in cases {
+        assert_eq!(
+            plan_with_target(Some("viewer {path}"), placement, dir, target, None, mux),
+            expected,
+            "file launch with {placement} placement"
+        );
+    }
+}
+
+#[test]
+fn review_command_resolves_base_without_splitting_paths() {
+    assert_eq!(
+        plan(
+            Some("git difftool --dir-diff {base}...HEAD -- {path}"),
+            "command",
+            "/w t/repo",
+            Some("origin/main"),
+            Multiplexer::None
+        ),
+        argv(&[
+            "git",
+            "difftool",
+            "--dir-diff",
+            "origin/main...HEAD",
+            "--",
+            "/w t/repo"
+        ])
+    );
+}
+
+#[test]
+fn argv_substitution_preserves_placeholder_text_inside_values() {
+    assert_eq!(
+        plan(
+            Some("viewer {base} {path}"),
+            "command",
+            "/code/{base}",
+            Some("{path}"),
+            Multiplexer::None
+        ),
+        argv(&["viewer", "{path}", "/code/{base}"])
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_substitution_passes_paths_and_refs_as_literal_values() {
+    let path = "/code/{base}/a'b$(printf injected)";
+    let base = "feature'{path}$(printf injected)";
+    let LaunchPlan::Inline(command) = plan(
+        Some("printf '%s\\n' {path} {base}"),
+        "inline",
+        path,
+        Some(base),
+        Multiplexer::None,
+    ) else {
+        panic!("inline placement must produce a shell command");
+    };
+    let output = std::process::Command::new("sh")
+        .args(["-c", &command])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        format!("{path}\n{base}\n")
+    );
+}
+
+#[test]
+fn command_mode_empty_opens_tmux_pane_in_tmux() {
+    assert_eq!(
+        plan(None, "command", "/app", None, Multiplexer::Tmux),
+        argv(&["tmux", "split-window", "-c", "/app"])
+    );
+}
+
+#[test]
+fn command_mode_empty_without_tmux_errors() {
+    assert!(matches!(
+        plan(None, "command", "/app", None, Multiplexer::None),
+        LaunchPlan::Error(_)
+    ));
+}
+
+#[test]
+fn tmux_placement_wraps_in_sh_c() {
+    assert_eq!(
+        plan(
+            Some("git diff {base}...HEAD"),
+            "new-window",
+            "/app",
+            Some("origin/main"),
+            Multiplexer::Tmux
+        ),
+        argv(&[
+            "tmux",
+            "new-window",
+            "-c",
+            "/app",
+            "sh",
+            "-c",
+            "git diff 'origin/main'...HEAD"
+        ])
+    );
+}
+
+#[test]
+fn tmux_placement_passes_flags_through() {
+    assert_eq!(
+        plan(
+            Some("lazygit"),
+            "split-window -h -t agents",
+            "/app",
+            None,
+            Multiplexer::Tmux
+        ),
+        argv(&[
+            "tmux",
+            "split-window",
+            "-h",
+            "-t",
+            "agents",
+            "-c",
+            "/app",
+            "sh",
+            "-c",
+            "lazygit"
+        ])
+    );
+}
+
+#[test]
+fn tmux_placement_without_tmux_falls_back_to_inline() {
+    assert_eq!(
+        plan(
+            Some("git diff {base}...HEAD | delta"),
+            "new-window",
+            "/app",
+            Some("main"),
+            Multiplexer::None
+        ),
+        LaunchPlan::Inline("git diff 'main'...HEAD | delta".to_string())
+    );
+}
+
+#[test]
+fn base_with_metacharacters_is_quoted() {
+    assert_eq!(
+        plan(
+            Some("git diff {base}...HEAD"),
+            "inline",
+            "/app",
+            Some("a;rm -rf b"),
+            Multiplexer::None
+        ),
+        LaunchPlan::Inline("git diff 'a;rm -rf b'...HEAD".to_string())
+    );
+}
+
+#[test]
+fn ask_is_a_picker_in_tmux_and_inline_without() {
+    assert_eq!(
+        plan(Some("x"), "ask", "/app", None, Multiplexer::Tmux),
+        LaunchPlan::Ask
+    );
+    assert_eq!(
+        plan(Some("x"), "ask", "/app", None, Multiplexer::None),
+        LaunchPlan::Inline("x".to_string())
+    );
+}
+
+#[test]
+fn command_mode_expands_embedded_path_token() {
+    // `{path}` inside a token expands too (one argv element, space-safe).
+    assert_eq!(
+        plan(
+            Some("wezterm cli spawn --cwd={path}"),
+            "command",
+            "/w t/x",
+            None,
+            Multiplexer::None
+        ),
+        argv(&["wezterm", "cli", "spawn", "--cwd=/w t/x"])
+    );
+}
+
+#[test]
+fn command_mode_blank_command_opens_tmux_pane() {
+    // A whitespace-only command counts as empty.
+    assert_eq!(
+        plan(Some("   "), "command", "/repo", None, Multiplexer::Tmux),
+        argv(&["tmux", "split-window", "-c", "/repo"])
+    );
+}
+
+#[test]
+fn shell_mode_quotes_path_token() {
+    // In shell modes, {path} is shell-quoted (it reaches `sh -c`).
+    assert_eq!(
+        plan(
+            Some("cd {path} && git diff"),
+            "inline",
+            "/w t/x",
+            None,
+            Multiplexer::None
+        ),
+        LaunchPlan::Inline("cd '/w t/x' && git diff".to_string())
+    );
+}
+
+#[test]
+fn invalid_placement_is_an_error_plan() {
+    assert!(matches!(
+        plan(Some("x"), "frobnicate", "/app", None, Multiplexer::Tmux),
+        LaunchPlan::Error(_)
+    ));
+}
+
+#[test]
+fn parse_tmux_windows_skips_malformed_lines() {
+    let out = "@0\tmain:0 editor\n@1\t\nno-tab-here\n@2\twork:2 logs\n";
+    assert_eq!(
+        parse_tmux_windows(out),
+        vec![
+            ("main:0 editor".to_string(), "@0".to_string()),
+            ("@1".to_string(), "@1".to_string()), // empty label -> target as label
+            ("work:2 logs".to_string(), "@2".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn placement_choices_use_space_free_window_id_target() {
+    // Even with a spaced label, the placement `-t` target is the window id,
+    // so the whitespace-split placement string stays valid.
+    let windows = vec![("my session:0 editor".to_string(), "@7".to_string())];
+    assert_eq!(
+        placement_choices(&windows),
+        vec![
+            ("New window".to_string(), "new-window".to_string()),
+            (
+                "Right of my session:0 editor".to_string(),
+                "split-window -h -t @7".to_string()
+            ),
+            (
+                "Below my session:0 editor".to_string(),
+                "split-window -v -t @7".to_string()
+            ),
+        ]
+    );
+}
+
+fn herdr_argv(parts: &[&str]) -> LaunchPlan {
+    LaunchPlan::Herdr {
+        create: parts.iter().map(|s| s.to_string()).collect(),
+        command: None,
+    }
+}
+
+#[test]
+fn command_mode_empty_opens_herdr_pane_in_herdr() {
+    assert_eq!(
+        plan(None, "command", "/app", None, Multiplexer::Herdr),
+        herdr_argv(&[
+            "herdr",
+            "pane",
+            "split",
+            "--current",
+            "--direction",
+            "right",
+            "--cwd",
+            "/app",
+            "--no-focus",
+            "--right-click",
+            "pane",
+        ])
+    );
+}
+
+#[test]
+fn herdr_split_placement_honors_h_v_and_pane_target() {
+    // `-h` -> right, `-v` -> down, `-t <pane-id>` -> `--pane`.
+    assert_eq!(
+        plan(
+            Some("lazygit"),
+            "split-window -h",
+            "/app",
+            None,
+            Multiplexer::Herdr
+        ),
+        LaunchPlan::Herdr {
+            create: vec![
+                "herdr",
+                "pane",
+                "split",
+                "--current",
+                "--direction",
+                "right",
+                "--cwd",
+                "/app",
+                "--no-focus",
+                "--right-click",
+                "pane",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+            command: Some("lazygit".to_string()),
+        }
+    );
+    let down = plan(
+        Some("x"),
+        "split-window -v",
+        "/app",
+        None,
+        Multiplexer::Herdr,
+    );
+    assert!(matches!(
+        down,
+        LaunchPlan::Herdr {
+            create: ref c,
+            ..
+        } if c.contains(&"down".to_string())
+    ));
+    let targeted = plan(
+        Some("x"),
+        "split-window -h -t w1:p3",
+        "/app",
+        None,
+        Multiplexer::Herdr,
+    );
+    assert!(matches!(
+        targeted,
+        LaunchPlan::Herdr {
+            create: ref c,
+            ..
+        } if c.contains(&"--pane".to_string()) && c.contains(&"w1:p3".to_string())
+    ));
+}
+
+#[test]
+fn herdr_new_window_creates_a_tab() {
+    // review's default `new-window` placement -> `herdr tab create`; the
+    // command runs in the tab's root pane via `herdr pane run`.
+    assert_eq!(
+        plan(
+            Some("git diff {base}...HEAD"),
+            "new-window",
+            "/app",
+            Some("origin/main"),
+            Multiplexer::Herdr,
+        ),
+        LaunchPlan::Herdr {
+            create: vec!["herdr", "tab", "create", "--cwd", "/app", "--no-focus",]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+            command: Some("git diff 'origin/main'...HEAD".to_string()),
+        }
+    );
+}
+
+#[test]
+fn herdr_rejects_unknown_and_tmux_only_flags() {
+    // Unknown flags and `new-window` flags must not silently mis-launch.
+    assert!(matches!(
+        plan(
+            Some("x"),
+            "split-window -l 20",
+            "/app",
+            None,
+            Multiplexer::Herdr
+        ),
+        LaunchPlan::Error(_)
+    ));
+    assert!(matches!(
+        plan(
+            Some("x"),
+            "new-window -t work",
+            "/app",
+            None,
+            Multiplexer::Herdr
+        ),
+        LaunchPlan::Error(_)
+    ));
+    assert!(matches!(
+        plan(
+            Some("x"),
+            "split-window -t",
+            "/app",
+            None,
+            Multiplexer::Herdr
+        ),
+        LaunchPlan::Error(_)
+    ));
+}
+
+#[test]
+fn ask_is_a_picker_under_herdr() {
+    assert_eq!(
+        plan(Some("x"), "ask", "/app", None, Multiplexer::Herdr),
+        LaunchPlan::Ask
+    );
+}
+
+#[test]
+fn herdr_placement_choices_offer_tab_and_splits() {
+    assert_eq!(
+        herdr_placement_choices(),
+        vec![
+            ("New tab".to_string(), "new-window".to_string()),
+            (
+                "Right of current pane".to_string(),
+                "split-window -h".to_string(),
+            ),
+            (
+                "Below current pane".to_string(),
+                "split-window -v".to_string(),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn parse_herdr_pane_id_reads_split_and_tab_responses() {
+    let split = "{\"id\":\"cli:pane:split\",\"result\":{\"pane\":{\"pane_id\":\"w1:p3\"}}}";
+    assert_eq!(parse_herdr_pane_id(split), Some("w1:p3".to_string()));
+    let tab = "{\"result\":{\"tab\":{\"tab_id\":\"w1:t2\"},\"root_pane\":{\"pane_id\":\"w1:p7\"}}}";
+    assert_eq!(parse_herdr_pane_id(tab), Some("w1:p7".to_string()));
+    assert_eq!(parse_herdr_pane_id("not json"), None);
+}

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -16,6 +16,60 @@ pub(crate) struct RepoWatcher {
     _debouncer: Debouncer<RecommendedWatcher, NoCache>,
 }
 
+/// The worktree owns its HEAD/index; refs and packed-refs belong to every
+/// tracked worktree sharing the common directory. Resolve through git2 so
+/// gitdir pointer files, symlinks, and bare repositories use the same routing.
+#[derive(Debug)]
+struct RepoMetadata {
+    owner: PathBuf,
+    git_dir: PathBuf,
+    common_dir: PathBuf,
+}
+
+impl RepoMetadata {
+    fn resolve(owner: &Path) -> Option<Self> {
+        let repo = git2::Repository::open(owner).ok()?;
+        Some(Self {
+            owner: owner.to_path_buf(),
+            git_dir: repo.path().canonicalize().ok()?,
+            common_dir: repo.commondir().canonicalize().ok()?,
+        })
+    }
+}
+
+fn is_shared_metadata(relative: &Path) -> bool {
+    relative == Path::new("packed-refs") || relative.starts_with("refs")
+}
+
+fn is_private_metadata(relative: &Path) -> bool {
+    matches!(
+        relative.to_str(),
+        Some("HEAD" | "index" | "MERGE_HEAD" | "REBASE_HEAD" | "COMMIT_EDITMSG")
+    ) || is_shared_metadata(relative)
+}
+
+/// `Some` claims the event even when the owner set is empty: object/log noise
+/// inside a real git directory must not fall through as a working-tree edit.
+fn metadata_owners(changed: &Path, metadata: &[RepoMetadata]) -> Option<HashSet<PathBuf>> {
+    let mut inside_metadata = false;
+    let mut owners = HashSet::new();
+    for repo in metadata {
+        if let Ok(relative) = changed.strip_prefix(&repo.git_dir) {
+            inside_metadata = true;
+            if is_private_metadata(relative) {
+                owners.insert(repo.owner.clone());
+            }
+        }
+        if let Ok(relative) = changed.strip_prefix(&repo.common_dir) {
+            inside_metadata = true;
+            if is_shared_metadata(relative) {
+                owners.insert(repo.owner.clone());
+            }
+        }
+    }
+    inside_metadata.then_some(owners)
+}
+
 /// How a single filesystem event is attributed.
 #[derive(Debug, PartialEq, Eq)]
 enum Classification {
@@ -150,8 +204,8 @@ fn watch_dirs(root: &Path, exclude_set: &HashSet<String>) -> Vec<PathBuf> {
 }
 
 /// Install a non-recursive notify watch on each gitignore-aware working-tree
-/// directory, then re-add the `.git` metadata watches the change classifier
-/// depends on. We do the walk ourselves (rather than asking notify for
+/// directory. Git metadata is watched separately at its resolved location.
+/// We do the walk ourselves (rather than asking notify for
 /// `RecursiveMode::Recursive`) so we never descend into symlinks that point at
 /// restricted system paths, and so ignored / build dirs never hit inotify.
 fn install_filtered_watches(
@@ -190,9 +244,6 @@ fn install_filtered_watches(
             }
         }
     }
-
-    // The working-tree walk prunes `.git`; re-add the watches we depend on.
-    watch_git_metadata(debouncer, &root.join(".git"));
 }
 
 /// Re-install the small set of `.git` watches the change classifier depends on.
@@ -201,8 +252,8 @@ fn install_filtered_watches(
 /// meaningful — that is how commits, checkouts, merges, and branch updates
 /// trigger a refresh. We watch `.git` itself (its top-level files) plus every
 /// directory under `.git/refs`, and deliberately skip `.git/objects` (huge and
-/// never classified as meaningful). The scanner only admits repos whose `.git`
-/// is a real directory, so a missing/file `.git` here is a no-op.
+/// never classified as meaningful). `git_dir` is a resolved private or shared
+/// metadata directory, including the target of a worktree's gitdir file.
 fn watch_git_metadata(debouncer: &mut Debouncer<RecommendedWatcher, NoCache>, git_dir: &Path) {
     if !git_dir.is_dir() {
         return;
@@ -238,6 +289,14 @@ impl RepoWatcher {
     ) -> color_eyre::Result<Self> {
         let owned_repo_paths: Vec<PathBuf> = repo_paths.to_vec();
         let owned_root_dirs: Vec<PathBuf> = root_dirs.to_vec();
+        let metadata: Vec<RepoMetadata> = repo_paths
+            .iter()
+            .filter_map(|path| RepoMetadata::resolve(path))
+            .collect();
+        let metadata_dirs: HashSet<PathBuf> = metadata
+            .iter()
+            .flat_map(|repo| [repo.git_dir.clone(), repo.common_dir.clone()])
+            .collect();
 
         // Bridge channel: notify callback (OS thread) -> tokio task
         let (bridge_tx, mut bridge_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<PathBuf>>();
@@ -253,6 +312,12 @@ impl RepoWatcher {
                 let mut roots_changed = false;
 
                 for changed_path in &changed_paths {
+                    // A linked worktree's metadata can live beneath another
+                    // tracked repo. Resolve ownership before lexical routing.
+                    if let Some(owners) = metadata_owners(changed_path, &metadata) {
+                        affected_repos.extend(owners);
+                        continue;
+                    }
                     match classify(
                         changed_path,
                         &repos_for_routing,
@@ -308,6 +373,9 @@ impl RepoWatcher {
             }
             install_filtered_watches(&mut debouncer, path, &exclude_set, watch_worktree_dirs);
         }
+        for git_dir in metadata_dirs {
+            watch_git_metadata(&mut debouncer, &git_dir);
+        }
 
         // Watch each configured root non-recursively so we notice top-level
         // children appearing or disappearing (new clones, deleted repos).
@@ -330,6 +398,144 @@ impl RepoWatcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn commit_empty(repo: &git2::Repository, message: &str) -> git2::Oid {
+        let sig = git2::Signature::now("Test", "test@example.test").unwrap();
+        let tree_id = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
+        repo.commit(
+            Some("HEAD"),
+            &sig,
+            &sig,
+            message,
+            &tree,
+            &parent.iter().collect::<Vec<_>>(),
+        )
+        .unwrap()
+    }
+
+    fn linked_repos() -> (tempfile::TempDir, git2::Repository, git2::Repository) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let main = git2::Repository::init(root.join("main")).unwrap();
+        commit_empty(&main, "Initial");
+        let linked_path = root.join("linked");
+        main.worktree("linked", &linked_path, None).unwrap();
+        let linked = git2::Repository::open(linked_path).unwrap();
+        (tmp, main, linked)
+    }
+
+    #[test]
+    fn worktree_private_metadata_refreshes_its_owner() {
+        let (_tmp, main, linked) = linked_repos();
+        let main_path = main.workdir().unwrap().to_path_buf();
+        let linked_path = linked.workdir().unwrap().to_path_buf();
+        let metadata = vec![
+            RepoMetadata::resolve(&main_path).unwrap(),
+            RepoMetadata::resolve(&linked_path).unwrap(),
+        ];
+        for name in ["HEAD", "index", "MERGE_HEAD", "refs/worktree/private"] {
+            assert_eq!(
+                metadata_owners(&linked.path().join(name), &metadata),
+                Some(HashSet::from([linked_path.clone()])),
+                "private {name} must refresh the linked worktree"
+            );
+        }
+        assert_eq!(
+            metadata_owners(&main.path().join("HEAD"), &metadata),
+            Some(HashSet::from([main_path]))
+        );
+    }
+
+    #[test]
+    fn shared_refs_refresh_every_tracked_worktree() {
+        let (_tmp, main, linked) = linked_repos();
+        let paths = [main.workdir().unwrap(), linked.workdir().unwrap()];
+        let metadata: Vec<_> = paths
+            .iter()
+            .map(|path| RepoMetadata::resolve(path).unwrap())
+            .collect();
+        let expected: HashSet<_> = paths.iter().map(|path| path.to_path_buf()).collect();
+        for name in ["refs/heads/main", "refs/tags/v1", "packed-refs"] {
+            assert_eq!(
+                metadata_owners(&main.commondir().join(name), &metadata),
+                Some(expected.clone()),
+                "shared {name} must refresh all owners"
+            );
+        }
+        for name in ["objects/ab/object", "logs/HEAD", "index.lock"] {
+            assert_eq!(
+                metadata_owners(&main.commondir().join(name), &metadata),
+                Some(HashSet::new()),
+                "metadata noise {name} must not become a worktree edit"
+            );
+        }
+        assert_eq!(
+            metadata_owners(&paths[0].join("source.rs"), &metadata),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn pinned_worktree_refreshes_after_private_head_and_shared_ref_changes() {
+        let (_tmp, main, linked) = linked_repos();
+        let first = main.head().unwrap().target().unwrap();
+        let second = commit_empty(&main, "Second");
+        let main_path = main.workdir().unwrap().to_path_buf();
+        let linked_path = linked.workdir().unwrap().to_path_buf();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let watcher =
+            RepoWatcher::new(std::slice::from_ref(&linked_path), &[], 20, tx, &[], false).unwrap();
+
+        // Repeat only metadata writes while awaiting an OS event. This gives
+        // the watcher time to become ready without assuming a fixed delay or
+        // producing worktree-file events that could mask missing gitdir watches.
+        tokio::time::timeout(Duration::from_secs(10), async {
+            let mut writes = tokio::time::interval(Duration::from_millis(100));
+            let mut target = first;
+            loop {
+                tokio::select! {
+                    _ = writes.tick() => {
+                        target = if target == first { second } else { first };
+                        linked.set_head_detached(target).unwrap();
+                    }
+                    event = rx.recv() => {
+                        if matches!(event, Some(Event::RepoChanged(path)) if path == linked_path) {
+                            break;
+                        }
+                    }
+                }
+            }
+        })
+        .await
+        .expect("a pinned worktree must refresh after its private HEAD moves");
+        drop(watcher);
+
+        let paths = [main_path, linked_path];
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let _watcher = RepoWatcher::new(&paths, &[], 20, tx, &[], false).unwrap();
+        let mut remaining: HashSet<_> = paths.into_iter().collect();
+        tokio::time::timeout(Duration::from_secs(10), async {
+            let mut writes = tokio::time::interval(Duration::from_millis(100));
+            let mut target = first;
+            while !remaining.is_empty() {
+                tokio::select! {
+                    _ = writes.tick() => {
+                        target = if target == first { second } else { first };
+                        main.reference("refs/heads/shared", target, true, "update").unwrap();
+                    }
+                    event = rx.recv() => {
+                        if let Some(Event::RepoChanged(path)) = event {
+                            remaining.remove(&path);
+                        }
+                    }
+                }
+            }
+        })
+        .await
+        .expect("a shared branch update must refresh every tracked worktree");
+    }
 
     fn s(p: &str) -> PathBuf {
         PathBuf::from(p)

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -51,16 +51,18 @@ fn is_private_metadata(relative: &Path) -> bool {
 /// `Some` claims the event even when the owner set is empty: object/log noise
 /// inside a real git directory must not fall through as a working-tree edit.
 fn metadata_owners(changed: &Path, metadata: &[RepoMetadata]) -> Option<HashSet<PathBuf>> {
+    let changed = crate::repo_id::boundary_path(changed);
     let mut inside_metadata = false;
     let mut owners = HashSet::new();
     for repo in metadata {
-        if let Ok(relative) = changed.strip_prefix(&repo.git_dir) {
+        if let Ok(relative) = changed.strip_prefix(crate::repo_id::boundary_path(&repo.git_dir)) {
             inside_metadata = true;
             if is_private_metadata(relative) {
                 owners.insert(repo.owner.clone());
             }
         }
-        if let Ok(relative) = changed.strip_prefix(&repo.common_dir) {
+        if let Ok(relative) = changed.strip_prefix(crate::repo_id::boundary_path(&repo.common_dir))
+        {
             inside_metadata = true;
             if is_shared_metadata(relative) {
                 owners.insert(repo.owner.clone());
@@ -90,6 +92,7 @@ fn classify(
     root_dirs: &[PathBuf],
     exclude_set: &HashSet<String>,
 ) -> Classification {
+    let changed_path = crate::repo_id::boundary_path(changed_path);
     // Skip events from excluded directories (node_modules, target, etc.).
     if changed_path
         .components()
@@ -105,14 +108,16 @@ fn classify(
             .file_name()
             .map(|n| n.to_string_lossy())
             .unwrap_or_default();
-        let path_str = changed_path.to_string_lossy();
         let is_meaningful = name == "HEAD"
             || name == "index"
             || name == "MERGE_HEAD"
             || name == "REBASE_HEAD"
             || name == "COMMIT_EDITMSG"
             || name == "packed-refs"
-            || path_str.contains(".git/refs/");
+            || changed_path
+                .components()
+                .zip(changed_path.components().skip(1))
+                .any(|(a, b)| a.as_os_str() == ".git" && b.as_os_str() == "refs");
         if !is_meaningful {
             return Classification::Ignore;
         }
@@ -120,7 +125,7 @@ fn classify(
 
     // Inside a known repo? Route the change to it.
     for repo_path in repo_paths {
-        if changed_path.starts_with(repo_path) {
+        if changed_path.starts_with(crate::repo_id::boundary_path(repo_path)) {
             return Classification::Repo(repo_path.clone());
         }
     }
@@ -132,7 +137,7 @@ fn classify(
     // actually find the new repo.
     for root in root_dirs {
         if let Some(parent) = changed_path.parent()
-            && parent == root.as_path()
+            && parent == crate::repo_id::boundary_path(root).as_ref()
         {
             return Classification::RootDir;
         }
@@ -398,6 +403,42 @@ impl RepoWatcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn ordinary_windows_events_keep_canonical_repository_identity() {
+        let owner = PathBuf::from(r"\\?\C:\repos\project");
+        let metadata = vec![RepoMetadata {
+            owner: owner.clone(),
+            git_dir: owner.join(".git"),
+            common_dir: owner.join(".git"),
+        }];
+        assert_eq!(
+            metadata_owners(
+                Path::new("C:/repos/project/.git/refs/heads/main"),
+                &metadata
+            ),
+            Some(HashSet::from([owner.clone()]))
+        );
+        assert_eq!(
+            classify(
+                Path::new("C:/repos/project/source.rs"),
+                std::slice::from_ref(&owner),
+                &[],
+                &HashSet::new()
+            ),
+            Classification::Repo(owner)
+        );
+        assert_eq!(
+            classify(
+                Path::new(r"\\?\C:\repos\new-repo"),
+                &[],
+                &[PathBuf::from("C:/repos")],
+                &HashSet::new()
+            ),
+            Classification::RootDir
+        );
+    }
 
     fn commit_empty(repo: &git2::Repository, message: &str) -> git2::Oid {
         let sig = git2::Signature::now("Test", "test@example.test").unwrap();


### PR DESCRIPTION
Closes #73

## In simple terms

Fix the verified project audit findings before the next release. File actions preserve unrelated work, delayed responses stay with the correct view, and small terminals and Unicode errors no longer crash the app.

## Problem

Discarding a file literally named `*.txt` could also discard edits in other matching files. Renames targeted only one path, and restoring both paths could overwrite a file recreated at the original location. Commit previews also expanded filename patterns.

Graph and GitHub requests could complete after a repository, filter, or detail view changed, showing stale content or losing refreshes. The audit also reproduced status failures for bare repositories and type changes, missing linked-worktree watches, broken file-editor launches and review substitutions, and repository removal hiding namesakes.

Release builds had no tag/version consistency gate and could publish with missing release notes.

## Fix

- Use literal file paths for operations and previews. Resolve rename endpoints and refuse discard when the original path has been recreated.
- Track request identity and filter state, invalidate closed details, rebuild graph search matches, and preserve queued refreshes.
- Handle tiny layouts and Unicode truncation safely; report type changes and bare repository status.
- Watch resolved worktree metadata, separate launcher targets from working directories, expand review placeholders once, and exclude removed repositories by exact path.
- Normalize extended Windows paths at launcher and watcher boundaries while preserving repository identity. Keep temporary Git fixtures independent of automatic CRLF conversion.
- Validate the release tag against Cargo.toml, Cargo.lock, and a nonempty changelog section before builds or publishing. Use locked Cargo commands.
- Split test and launcher modules to preserve the repository's file-size limits.

## Test

- `just ci`: 575 passed, one existing ignored test; formatting, clippy, and rustdoc pass.
- Eight release metadata CLI tests pass with Python 3.11.
- Rust 1.88 compatibility check, dependency audit, and package verification pass.
- Regressions use temporary Git repositories, rendered buffers, delayed responses, and actual filesystem events. Original-code counterchecks confirmed the reported failures.
- Fresh Astra reviews covered the implementation, including the rename collision guard.
- Cross-platform GitHub checks run on this PR.

No version bump or release tag is included.
