### PR TITLE
chore: prepare v0.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to gitpane are documented here.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-09-08
+
+### Added
+- Resize the commit message, changed files, and diff panes by dragging their borders. ([#68](https://github.com/affromero/gitpane/pull/68), closes [#67](https://github.com/affromero/gitpane/issues/67)) Thanks @expoli.
+- Search incrementally in graph filters, the Changes pane, and a commit's changed files. Matching rows stay selected as results change, with Unicode-aware highlighting. ([#70](https://github.com/affromero/gitpane/pull/70), closes [#69](https://github.com/affromero/gitpane/issues/69)) Thanks @expoli.
+
+### Fixed
+- Bound libgit2 pack windows and object caches to keep large repositories from consuming excessive memory. ([#66](https://github.com/affromero/gitpane/pull/66), closes [#65](https://github.com/affromero/gitpane/issues/65)) Thanks @expoli for the report and fix.
+- Repository additions and removals now synchronize across running instances without overwriting concurrent config changes. ([#72](https://github.com/affromero/gitpane/pull/72), closes [#71](https://github.com/affromero/gitpane/issues/71))
+- File actions and diff previews treat filenames literally. Rename operations handle both paths, and discard refuses to overwrite a file recreated at the original path. ([#74](https://github.com/affromero/gitpane/pull/74), closes [#73](https://github.com/affromero/gitpane/issues/73))
+- Late graph and GitHub responses cannot reopen closed details or show content from another repository or filter. Graph refreshes preserve pending updates and rebuild search matches. ([#74](https://github.com/affromero/gitpane/pull/74))
+- Small terminal layouts and long Unicode error messages no longer crash the app. Commit messages remain readable in narrow layouts. ([#74](https://github.com/affromero/gitpane/pull/74))
+- Status includes file-type changes and supports bare repositories. Pinned linked worktrees receive Git metadata updates. ([#74](https://github.com/affromero/gitpane/pull/74))
+- Configured file openers use a directory as their working directory, review commands expand their base ref, and Windows launcher and watcher paths use compatible spellings. Removing one repository preserves others with the same name. ([#74](https://github.com/affromero/gitpane/pull/74))
+
+### Changed
+- Release builds validate the tag, Cargo versions, and matching release notes before building or publishing. ([#74](https://github.com/affromero/gitpane/pull/74))
+
 ## [0.15.1] - 2026-09-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "gitpane"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "arboard",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitpane"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Multi-repo Git workspace dashboard TUI"


### PR DESCRIPTION
Closes #75

## In simple terms

Prepare v0.16.0 with resizable commit-view panels, incremental search, and the reviewed project fixes.

## Problem

The merged features and audit fixes are still labelled v0.15.1 and have no release notes. The release workflow requires the tag, manifest, lockfile, and changelog to agree.

## Fix

Bump gitpane to 0.16.0 in Cargo.toml and Cargo.lock. Add release notes covering #66, #68, #70, #72, and #74, with contributor credits and links. Dependency versions stay unchanged.

## Test

- `just ci`: 575 passed, one existing ignored test; formatting, clippy, and rustdoc pass.
- Release metadata validation and package verification pass.
- Fresh release-file review found no blockers.
- Platform CI must pass before merge and tagging.

After merge, the v0.16.0 tag triggers the existing workflow to build six platform archives, create the GitHub Release with these notes, and publish to crates.io.
