### PR TITLE
fix: isolate Git commands and tests from caller environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
-      - name: Test release metadata validation
+      - name: Test CI scripts
         # Ubuntu provides Python 3.11+ for the stdlib tomllib parser.
-        run: python3 -B -m unittest discover -s scripts -p 'test_release_metadata.py'
+        run: python3 -B -m unittest discover -s scripts -p 'test_*.py'
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -77,8 +77,15 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      - name: Require Git for full integration coverage
+        run: git --version
+
       - name: Run tests
         run: cargo test --all-targets --all-features
+
+      - name: Run tests without Git
+        if: runner.os != 'Windows'
+        run: python3 scripts/check_test_environment.py
 
       - name: Build release binary
         run: cargo build --release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,9 @@ map in [README.md#architecture](README.md#architecture). Key areas:
   caller performs the I/O (see `src/session/launcher/mod.rs`).
 - Validate or quote any user input that reaches a shell. argv launches avoid the
   shell entirely; `sh -c` paths quote every substituted value.
+- Use `crate::git::process::git_command(path)` for repository-scoped Git
+  subprocesses, including test fixtures. It clears inherited hook variables
+  so commands cannot target the calling repository instead of `path`.
 
 ## Pull requests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ human-facing overview, see [README.md](README.md).
 
 - Rust edition 2024, MSRV **1.88.0**. Install a matching toolchain (rustup recommended).
 - No services or network access are needed to build, run, or test.
+- Full integration coverage requires `git` on PATH, plus `sh` and `sleep` on
+  Unix. CLI tests use `crate::git::git_test_available()` to skip only missing
+  Git, with a reason visible under `--nocapture`; broken Git must fail tests.
 - Optional tooling for the full local suite: `cargo install cargo-audit cargo-llvm-cov`,
   plus [`just`](https://github.com/casey/just) for the task recipes below.
 
@@ -33,6 +36,11 @@ CI runs the same checks and treats every warning as an error, so `just ci` must
 pass before you push. Tests are inline `#[cfg(test)]` modules in the binary
 target, so a plain `cargo test --lib` finds nothing. Use `just test` or
 `cargo test --bin gitpane`.
+
+For changes to tests or subprocess dependencies, also run
+`python3 scripts/check_test_environment.py` on Linux or macOS. This runs every
+test harness with only `sh` and `sleep` on its PATH. Missing-Git skips count as
+passed in Rust's summary, so the normal suite with Git remains required.
 
 ## Pre-commit hooks (required)
 

--- a/README.md
+++ b/README.md
@@ -637,6 +637,19 @@ CI runs formatting, clippy, MSRV checks, docs, tests, and release builds across
 Linux, macOS, and Windows. Security and coverage run as separate workflows so
 their README badges map to real checks.
 
+Install Git on PATH for full integration coverage. On Unix, the process tests
+also require `sh` and `sleep`. If Git is missing, CLI integration tests return
+early and print a skip reason with `cargo test -- --nocapture`. Rust counts
+these early returns as passed, so this is partial coverage. A Git executable
+that fails or cannot be executed causes the tests to fail.
+
+Linux and macOS CI also run `python3 scripts/check_test_environment.py`, which
+builds the tests and runs them with only `sh` and `sleep` on the child PATH.
+This catches accidental Git dependencies in environments such as Nix builds.
+The normal CI test run requires Git and exercises the CLI integration tests.
+For full coverage in a Nix package, include `git` in the package arguments and
+set `nativeCheckInputs = [ git ];`.
+
 Install the local hooks before contributing:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -650,6 +650,10 @@ The normal CI test run requires Git and exercises the CLI integration tests.
 For full coverage in a Nix package, include `git` in the package arguments and
 set `nativeCheckInputs = [ git ];`.
 
+Repository-scoped Git commands clear inherited hook variables such as
+`GIT_DIR` and `GIT_INDEX_FILE`. Tests also verify that running under a Git hook
+cannot redirect operations into the calling checkout.
+
 Install the local hooks before contributing:
 
 ```bash

--- a/scripts/check_test_environment.py
+++ b/scripts/check_test_environment.py
@@ -1,0 +1,54 @@
+"""Run the Rust test suite without Git on PATH (Linux and macOS)."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+def main():
+    if os.name != "posix":
+        raise SystemExit("This check requires a Unix environment")
+
+    build = subprocess.run(
+        ["cargo", "test", "--locked", "--all-targets", "--all-features",
+         "--no-run", "--message-format=json-render-diagnostics"],
+        stdout=subprocess.PIPE, text=True, check=True,
+    )
+    artifacts = [json.loads(line) for line in build.stdout.splitlines() if line.strip()]
+    tests = [
+        item for item in artifacts
+        if item.get("reason") == "compiler-artifact"
+        and item.get("profile", {}).get("test")
+        and item.get("executable")
+    ]
+    # A library-only run succeeds with zero tests in this project.
+    if not any(item["target"]["name"] == "gitpane"
+               and item["target"]["kind"] == ["bin"] for item in tests):
+        raise SystemExit("Cargo did not produce the gitpane binary test harness")
+
+    with tempfile.TemporaryDirectory(prefix="gitpane-test-path-") as directory:
+        # Process-group tests still need a shell and a sleeping grandchild.
+        for name in ("sh", "sleep"):
+            executable = shutil.which(name)
+            if executable is None:
+                raise SystemExit(f"Required test utility missing: {name}")
+            Path(directory, name).symlink_to(Path(executable).resolve())
+        env = dict(os.environ, PATH=directory)
+        if shutil.which("git", path=directory) is not None:
+            raise SystemExit("Git must be absent from the restricted test PATH")
+
+        for item in tests:
+            executable = item["executable"]
+            print(f"Testing without Git: {executable}", flush=True)
+            # Change only the child's PATH. Cargo and the caller keep theirs.
+            subprocess.run([executable, "--nocapture"], env=env, check=True)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as error:
+        raise SystemExit(error.returncode) from error

--- a/scripts/test_check_test_environment.py
+++ b/scripts/test_check_test_environment.py
@@ -1,0 +1,102 @@
+"""Exercise the restricted-PATH runner using stand-ins at process boundaries."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("check_test_environment.py")
+
+
+@unittest.skipUnless(os.name == "posix", "restricted PATH check requires Unix")
+class TestEnvironmentTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        for name in ("sh", "sleep"):
+            (self.bin / name).symlink_to(shutil.which(name))
+        self.executable("bin/git", "raise SystemExit(0)")
+        self.observed = self.root / "observed.json"
+
+    def executable(self, name, source):
+        path = self.root / name
+        path.write_text(f"#!{sys.executable}\n{source}\n", encoding="utf-8")
+        path.chmod(0o755)
+        return path
+
+    def cargo(self, kinds=("lib", "bin"), test_exit=0, build_exit=0):
+        artifacts = []
+        for kind in kinds:
+            test = self.executable(
+                f"test-{kind}",
+                "import json, shutil\n"
+                "from pathlib import Path\n"
+                f"observed = Path({str(self.observed)!r})\n"
+                "data = json.loads(observed.read_text()) if observed.exists() else {}\n"
+                f"data[{kind!r}] = {{name: shutil.which(name) "
+                "for name in ('git', 'sh', 'sleep', 'cargo')}\n"
+                "observed.write_text(json.dumps(data))\n"
+                f"raise SystemExit({test_exit})",
+            )
+            artifacts.append({
+                "reason": "compiler-artifact", "profile": {"test": True},
+                "target": {"name": "gitpane", "kind": [kind]},
+                "executable": str(test),
+            })
+        messages = "\n".join(json.dumps(item) for item in artifacts)
+        self.executable(
+            "bin/cargo", f"print({messages!r})\nraise SystemExit({build_exit})"
+        )
+
+    def run_check(self):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            env=dict(os.environ, PATH=str(self.bin)),
+            capture_output=True, text=True, check=False,
+        )
+
+    def test_runs_binary_and_library_with_git_removed_from_child_path(self):
+        self.cargo()
+        result = self.run_check()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        observed = json.loads(self.observed.read_text())
+        self.assertEqual(set(observed), {"bin", "lib"})
+        for commands in observed.values():
+            self.assertIsNone(commands["git"])
+            self.assertIsNone(commands["cargo"])
+            self.assertIsNotNone(commands["sh"])
+            self.assertIsNotNone(commands["sleep"])
+        self.assertIsNotNone(shutil.which("git", path=str(self.bin)))
+
+    def test_rejects_builds_without_the_binary_test_harness(self):
+        for kinds in ((), ("lib",)):
+            with self.subTest(kinds=kinds):
+                self.cargo(kinds=kinds)
+                result = self.run_check()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("binary test harness", result.stderr)
+                self.assertFalse(self.observed.exists())
+
+    def test_propagates_test_failure(self):
+        self.cargo(kinds=("bin",), test_exit=37)
+        result = self.run_check()
+        self.assertEqual(result.returncode, 37, result.stdout + result.stderr)
+        self.assertTrue(self.observed.exists())
+
+    def test_does_not_run_tests_after_build_failure(self):
+        self.cargo(build_exit=23)
+        result = self.run_check()
+        self.assertEqual(result.returncode, 23, result.stdout + result.stderr)
+        self.assertFalse(self.observed.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -463,9 +463,7 @@ impl App {
                                     label,
                                     "─".repeat(40),
                                 );
-                                let output = std::process::Command::new("git")
-                                    .arg("-C")
-                                    .arg(&submodule_abs)
+                                let output = crate::git::process::git_command(&submodule_abs)
                                     .args(["diff", "HEAD"])
                                     .output();
                                 let body = match output {
@@ -473,15 +471,15 @@ impl App {
                                         let text = String::from_utf8_lossy(&o.stdout).to_string();
                                         if text.is_empty() {
                                             // Fallback: show status
-                                            let status_out = std::process::Command::new("git")
-                                                .arg("-C")
-                                                .arg(&submodule_abs)
-                                                .args(["status", "--short"])
-                                                .output()
-                                                .map(|o| {
-                                                    String::from_utf8_lossy(&o.stdout).to_string()
-                                                })
-                                                .unwrap_or_default();
+                                            let status_out =
+                                                crate::git::process::git_command(&submodule_abs)
+                                                    .args(["status", "--short"])
+                                                    .output()
+                                                    .map(|o| {
+                                                        String::from_utf8_lossy(&o.stdout)
+                                                            .to_string()
+                                                    })
+                                                    .unwrap_or_default();
                                             if status_out.is_empty() {
                                                 "(no changes detected)".to_string()
                                             } else {
@@ -511,9 +509,7 @@ impl App {
                                     "─".repeat(40),
                                 );
                                 let range = format!("{}..{}", old_oid, new_oid);
-                                let output = std::process::Command::new("git")
-                                    .arg("-C")
-                                    .arg(&submodule_abs)
+                                let output = crate::git::process::git_command(&submodule_abs)
                                     .args(["log", "--oneline", "--graph", &range])
                                     .output();
                                 let body = match output {

--- a/src/app/launch.rs
+++ b/src/app/launch.rs
@@ -811,7 +811,9 @@ mod tests {
         let crate::session::launcher::LaunchPlan::Spawn(argv) = plan else {
             panic!("expected an argv launch")
         };
-        let output = std::process::Command::new(&argv[0])
+        let mut command = std::process::Command::new(&argv[0]);
+        crate::git::process::clear_inherited_git_env(&mut command);
+        let output = command
             .args(&argv[1..])
             .current_dir(&request.dir)
             .output()

--- a/src/app/launch.rs
+++ b/src/app/launch.rs
@@ -833,6 +833,9 @@ mod tests {
 
     #[test]
     fn configured_file_open_passes_file_to_editor_with_directory_cwd() {
+        if !crate::git::git_test_available() {
+            return;
+        }
         let (_temp, app, id, file) = file_open_app();
         let request = app
             .file_open_request(&id, std::path::Path::new("source file.rs"))
@@ -842,6 +845,9 @@ mod tests {
 
     #[test]
     fn placement_picker_preserves_file_target_and_directory_cwd() {
+        if !crate::git::git_test_available() {
+            return;
+        }
         let (_temp, mut app, id, file) = file_open_app();
         // Herdr choices are local data, so no real multiplexer is needed.
         app.mux = crate::session::env::Multiplexer::Herdr;

--- a/src/git/file_ops.rs
+++ b/src/git/file_ops.rs
@@ -69,8 +69,8 @@ pub(crate) fn arguments(
 pub(crate) fn diff(repo_path: &Path, selected: &Path) -> color_eyre::Result<String> {
     let repo = git2::Repository::open(repo_path)?;
     let untracked = repo.status_file(selected)?.is_wt_new();
-    let mut command = std::process::Command::new("git");
-    command.arg("-C").arg(repo_path).current_dir(repo_path);
+    let mut command = super::process::git_command(repo_path);
+    command.current_dir(repo_path);
     if untracked {
         command
             .args(["diff", "--no-index", "--", "/dev/null"])

--- a/src/git/file_ops/tests.rs
+++ b/src/git/file_ops/tests.rs
@@ -56,6 +56,9 @@ fn apply(path: &Path, name: &str, operation: FileOperation) {
 #[cfg(unix)]
 #[test]
 fn selected_pattern_filename_does_not_change_other_files_or_index_entries() {
+    if !crate::git::git_test_available() {
+        return;
+    }
     for selected in ["*.txt", ":(glob)*.txt", "[ab].txt"] {
         let (tmp, repo) = fixture(&[selected, "a.txt"]);
         for name in [selected, "a.txt"] {
@@ -106,6 +109,9 @@ fn selected_pattern_filename_does_not_change_other_files_or_index_entries() {
 #[cfg(unix)]
 #[test]
 fn deleting_untracked_pattern_filename_preserves_other_files() {
+    if !crate::git::git_test_available() {
+        return;
+    }
     let (tmp, _) = fixture(&["tracked"]);
     for name in ["*.draft", "important.draft"] {
         std::fs::write(tmp.path().join(name), "draft").unwrap();
@@ -117,6 +123,9 @@ fn deleting_untracked_pattern_filename_preserves_other_files() {
 
 #[test]
 fn rename_actions_update_both_paths_and_preserve_other_staged_changes() {
+    if !crate::git::git_test_available() {
+        return;
+    }
     for operation in [
         FileOperation::Stage,
         FileOperation::Unstage,
@@ -164,6 +173,9 @@ fn rename_actions_update_both_paths_and_preserve_other_staged_changes() {
 #[cfg(unix)]
 #[test]
 fn selected_diff_excludes_other_pattern_matches_in_worktree_and_commit() {
+    if !crate::git::git_test_available() {
+        return;
+    }
     let (tmp, repo) = fixture(&["*.txt", "other.txt"]);
     for (name, text) in [("*.txt", "SELECTED"), ("other.txt", "UNRELATED")] {
         std::fs::write(tmp.path().join(name), text).unwrap();
@@ -179,6 +191,9 @@ fn selected_diff_excludes_other_pattern_matches_in_worktree_and_commit() {
 
 #[test]
 fn untracked_diff_reads_from_selected_repository() {
+    if !crate::git::git_test_available() {
+        return;
+    }
     let (tmp, _) = fixture(&["tracked"]);
     std::fs::write(tmp.path().join("untracked"), "NEW CONTENT").unwrap();
     assert!(
@@ -190,6 +205,9 @@ fn untracked_diff_reads_from_selected_repository() {
 
 #[test]
 fn staging_rename_does_not_stage_a_recreated_source_file() {
+    if !crate::git::git_test_available() {
+        return;
+    }
     let (tmp, repo) = fixture(&["old"]);
     git(tmp.path(), &["mv", "old", "new"]);
     std::fs::write(tmp.path().join("old"), "unrelated replacement").unwrap();
@@ -201,6 +219,9 @@ fn staging_rename_does_not_stage_a_recreated_source_file() {
 
 #[test]
 fn discarding_rename_refuses_to_overwrite_a_recreated_source() {
+    if !crate::git::git_test_available() {
+        return;
+    }
     let (tmp, repo) = fixture(&["old"]);
     git(tmp.path(), &["mv", "old", "new"]);
     std::fs::write(tmp.path().join("old"), "unrelated replacement").unwrap();
@@ -224,6 +245,9 @@ fn discarding_rename_refuses_to_overwrite_a_recreated_source() {
 #[cfg(unix)]
 #[test]
 fn discarding_rename_preserves_a_recreated_dangling_symlink() {
+    if !crate::git::git_test_available() {
+        return;
+    }
     let (tmp, repo) = fixture(&["old"]);
     git(tmp.path(), &["mv", "old", "new"]);
     std::os::unix::fs::symlink("missing-target", tmp.path().join("old")).unwrap();

--- a/src/git/file_ops/tests.rs
+++ b/src/git/file_ops/tests.rs
@@ -2,9 +2,7 @@ use super::*;
 use git2::Repository;
 
 fn git(path: &Path, args: &[&str]) {
-    let out = std::process::Command::new("git")
-        .arg("-C")
-        .arg(path)
+    let out = crate::git::process::git_command(path)
         .args(args)
         .output()
         .unwrap();
@@ -39,9 +37,7 @@ fn fixture(names: &[&str]) -> (tempfile::TempDir, Repository) {
 
 fn apply(path: &Path, name: &str, operation: FileOperation) {
     let args = arguments(path, Path::new(name), operation).unwrap();
-    let out = std::process::Command::new("git")
-        .arg("-C")
-        .arg(path)
+    let out = crate::git::process::git_command(path)
         .args(&args)
         .output()
         .unwrap();

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -178,6 +178,75 @@ mod tests {
         assert_git_dependency_failure(directory.path(), "cannot execute git --version");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn hook_environment_cannot_redirect_repository_operations() {
+        if !git_test_available() {
+            return;
+        }
+        let directory = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(directory.path()).unwrap();
+        repo.index().unwrap().write().unwrap();
+        std::fs::write(directory.path().join("sentinel"), "preserve this checkout").unwrap();
+        let snapshot = || {
+            walkdir::WalkDir::new(directory.path())
+                .into_iter()
+                .map(Result::unwrap)
+                .filter(|entry| entry.file_type().is_file())
+                .map(|entry| {
+                    let path = entry.into_path();
+                    let contents = std::fs::read(&path).unwrap();
+                    (path, contents)
+                })
+                .collect::<std::collections::BTreeMap<_, _>>()
+        };
+        let before = snapshot();
+        let tests = [
+            "git::file_ops::tests::selected_pattern_filename_does_not_change_other_files_or_index_entries",
+            "git::file_ops::tests::deleting_untracked_pattern_filename_preserves_other_files",
+            "git::file_ops::tests::rename_actions_update_both_paths_and_preserve_other_staged_changes",
+            "git::file_ops::tests::selected_diff_excludes_other_pattern_matches_in_worktree_and_commit",
+            "git::file_ops::tests::untracked_diff_reads_from_selected_repository",
+            "git::file_ops::tests::staging_rename_does_not_stage_a_recreated_source_file",
+            "git::file_ops::tests::discarding_rename_refuses_to_overwrite_a_recreated_source",
+            "git::file_ops::tests::discarding_rename_preserves_a_recreated_dangling_symlink",
+            "app::launch::tests::configured_file_open_passes_file_to_editor_with_directory_cwd",
+            "app::launch::tests::placement_picker_preserves_file_target_and_directory_cwd",
+            "git::process::tests::run_git_op_capturing_registers_and_unregisters",
+            "git::status::tests_refs::query_status_detects_commit_in_linked_worktree",
+            "watcher::tests::watch_dirs_respects_gitignore",
+        ];
+        // Every injected path refers to this sacrificial repository. Even a
+        // regression must never direct a test operation at the real checkout.
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .args(tests)
+            .current_dir(directory.path())
+            .env("GIT_DIR", repo.path())
+            .env("GIT_WORK_TREE", directory.path())
+            .env("GIT_INDEX_FILE", repo.path().join("index"))
+            .env("GIT_COMMON_DIR", repo.path())
+            .env("GIT_OBJECT_DIRECTORY", repo.path().join("objects"))
+            .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+            .env_remove("GIT_PREFIX")
+            .env_remove("GIT_NAMESPACE")
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            snapshot() == before,
+            "test operations modified the inherited repository\n{stdout}\n{stderr}"
+        );
+        assert!(output.status.success(), "{stdout}\n{stderr}");
+        for name in tests {
+            assert!(
+                stdout.contains(&format!("test {name} ... ok")),
+                "expected integration test did not pass: {name}\n{stdout}\n{stderr}"
+            );
+        }
+    }
+
     #[test]
     fn describe_spawn_error_flags_missing_git() {
         let err = io::Error::new(io::ErrorKind::NotFound, "No such file or directory");

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -41,6 +41,37 @@ pub(crate) fn git_available() -> bool {
     })
 }
 
+/// Skip CLI integration tests only when Git is missing. A broken installation
+/// must fail the test instead of silently reducing coverage.
+#[cfg(test)]
+pub(crate) fn git_test_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    let available = *AVAILABLE.get_or_init(|| {
+        match std::process::Command::new("git").arg("--version").output() {
+            Ok(output) => {
+                assert!(
+                    output.status.success(),
+                    "git --version failed ({}): {}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                true
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+            Err(error) => panic!("cannot execute git --version: {error}"),
+        }
+    });
+    if !available {
+        eprintln!(
+            "skipping {}: git is not on PATH; install Git to run this integration test",
+            std::thread::current()
+                .name()
+                .unwrap_or("Git integration test")
+        );
+    }
+    available
+}
+
 /// The remote gitpane should treat as canonical for `repo` when nothing more
 /// specific is configured: `origin` if present, else the lexicographically
 /// first remote (stable even when config order is not). Gerrit and mirror
@@ -105,6 +136,47 @@ pub(crate) fn resolve_sync_remote(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    fn assert_git_dependency_failure(directory: &std::path::Path, message: &str) {
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "git::file_ops::tests::untracked_diff_reads_from_selected_repository",
+                "--nocapture",
+            ])
+            .env("PATH", directory)
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(101));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains(message), "{stderr}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn git_integration_tests_fail_when_git_exits_unsuccessfully() {
+        let directory = tempfile::tempdir().unwrap();
+        // The test harness rejects `--version`, providing an executable that
+        // exits unsuccessfully without needing a shell or a Git installation.
+        std::os::unix::fs::symlink(
+            std::env::current_exe().unwrap(),
+            directory.path().join("git"),
+        )
+        .unwrap();
+        assert_git_dependency_failure(directory.path(), "git --version failed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn git_integration_tests_fail_when_git_is_not_executable() {
+        use std::os::unix::fs::PermissionsExt;
+        let directory = tempfile::tempdir().unwrap();
+        let git = directory.path().join("git");
+        std::fs::write(&git, "").unwrap();
+        std::fs::set_permissions(&git, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_git_dependency_failure(directory.path(), "cannot execute git --version");
+    }
 
     #[test]
     fn describe_spawn_error_flags_missing_git() {

--- a/src/git/process.rs
+++ b/src/git/process.rs
@@ -12,6 +12,31 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
 
+/// Keep explicit repository selection independent of the Git hook that may
+/// have launched gitpane or its tests. Preserve authentication and user config.
+pub(crate) fn clear_inherited_git_env(cmd: &mut std::process::Command) {
+    for var in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_PREFIX",
+        "GIT_COMMON_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_NAMESPACE",
+    ] {
+        cmd.env_remove(var);
+    }
+}
+
+/// Construct a Git command scoped to `path`, even when called from a hook.
+pub(crate) fn git_command(path: &Path) -> std::process::Command {
+    let mut cmd = std::process::Command::new("git");
+    clear_inherited_git_env(&mut cmd);
+    cmd.arg("-C").arg(path);
+    cmd
+}
+
 /// Seconds a user-initiated mutating git op (pull/push/submodule, and the file
 /// and worktree ops) may run before it is killed as a process group. Long
 /// enough to let a large transfer finish, but bounded so a stalled connection
@@ -122,12 +147,8 @@ pub(crate) fn run_git_op_capturing(
     args: &[String],
 ) -> std::io::Result<std::process::Output> {
     use std::process::Stdio;
-    let mut cmd = std::process::Command::new("git");
-    cmd.arg("-C")
-        .arg(path)
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    let mut cmd = git_command(path);
+    cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
     let mut child = spawn_killable(&mut cmd)?;
     let pid = child.id() as i32;
     let result = capture_with_timeout(&mut child, MUTATING_OP_TIMEOUT);
@@ -145,12 +166,8 @@ pub(crate) fn run_git_op_capturing(
     args: &[String],
 ) -> std::io::Result<std::process::Output> {
     use std::process::Stdio;
-    let mut cmd = std::process::Command::new("git");
-    cmd.arg("-C")
-        .arg(path)
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    let mut cmd = git_command(path);
+    cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
     cmd.output()
 }
 

--- a/src/git/process/tests.rs
+++ b/src/git/process/tests.rs
@@ -258,9 +258,8 @@ fn run_git_op_capturing_registers_and_unregisters() {
 
     let tmp = tempfile::TempDir::new().unwrap();
     let path = tmp.path().to_path_buf();
-    let init = std::process::Command::new("git")
+    let init = super::git_command(&path)
         .arg("init")
-        .arg(&path)
         .status()
         .expect("run git init");
     assert!(init.success(), "git init failed: {init}");

--- a/src/git/process/tests.rs
+++ b/src/git/process/tests.rs
@@ -248,6 +248,9 @@ fn capture_with_timeout_success_does_not_kill_descendant() {
 #[test]
 fn run_git_op_capturing_registers_and_unregisters() {
     use std::time::Duration;
+    if !crate::git::git_test_available() {
+        return;
+    }
     let _lock = super::TEST_KILL_LOCK
         .lock()
         .unwrap_or_else(|e| e.into_inner());
@@ -258,12 +261,9 @@ fn run_git_op_capturing_registers_and_unregisters() {
     let init = std::process::Command::new("git")
         .arg("init")
         .arg(&path)
-        .status();
-    // Skip (don't panic) when git is unavailable, matching the repo's pattern.
-    if !matches!(init, Ok(s) if s.success()) {
-        eprintln!("skipping run_git_op_capturing test: 'git init' failed");
-        return;
-    }
+        .status()
+        .expect("run git init");
+    assert!(init.success(), "git init failed: {init}");
 
     // The alias records the sleep pid in a file once the whole git -> sh ->
     // sleep tree is up; waiting on that (rather than on registration alone)

--- a/src/git/status/tests_refs.rs
+++ b/src/git/status/tests_refs.rs
@@ -3,24 +3,6 @@ use super::*;
 use std::{fs, path::Path};
 use tempfile::TempDir;
 
-/// Strip the git environment a hook injects (`GIT_DIR`, `GIT_INDEX_FILE`, …).
-/// This suite runs under the pre-push hook, whose env would otherwise redirect
-/// a spawned `git` at the outer repo instead of the test's temp repo.
-fn clear_inherited_git_env(cmd: &mut std::process::Command) {
-    for var in [
-        "GIT_DIR",
-        "GIT_WORK_TREE",
-        "GIT_INDEX_FILE",
-        "GIT_PREFIX",
-        "GIT_COMMON_DIR",
-        "GIT_OBJECT_DIRECTORY",
-        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-        "GIT_NAMESPACE",
-    ] {
-        cmd.env_remove(var);
-    }
-}
-
 #[test]
 fn test_ahead_count_when_no_upstream_with_remote_ref() {
     // Local branch with no configured upstream but with a remote-tracking
@@ -206,16 +188,13 @@ fn query_status_detects_commit_in_linked_worktree() {
     fs::create_dir_all(&root).unwrap();
 
     let git = |args: &[&str], cwd: &Path| -> bool {
-        let mut cmd = std::process::Command::new("git");
+        let mut cmd = crate::git::process::git_command(cwd);
         cmd.args(args)
             .current_dir(cwd)
             .env("GIT_AUTHOR_NAME", "Test")
             .env("GIT_AUTHOR_EMAIL", "t@t")
             .env("GIT_COMMITTER_NAME", "Test")
             .env("GIT_COMMITTER_EMAIL", "t@t");
-        // Clear the git env a hook injects (this suite runs under the pre-push
-        // hook), so operations target `cwd`'s repo and not the outer one.
-        clear_inherited_git_env(&mut cmd);
         cmd.status().map(|s| s.success()).unwrap_or(false)
     };
 

--- a/src/git/status/tests_refs.rs
+++ b/src/git/status/tests_refs.rs
@@ -193,6 +193,9 @@ fn fingerprint_buckets_remote_separately_from_local() {
 
 #[test]
 fn query_status_detects_commit_in_linked_worktree() {
+    if !crate::git::git_test_available() {
+        return;
+    }
     // End-to-end through the public entry point with a real linked worktree:
     // a commit made inside the worktree (on its own branch) must change the
     // root's `refs` fingerprint while leaving the root's checked-out HEAD
@@ -216,10 +219,7 @@ fn query_status_detects_commit_in_linked_worktree() {
         cmd.status().map(|s| s.success()).unwrap_or(false)
     };
 
-    if !git(&["init", "-q"], &root) {
-        eprintln!("skipping query_status_detects_commit_in_linked_worktree: git unavailable");
-        return;
-    }
+    assert!(git(&["init", "-q"], &root), "git init failed");
     assert!(git(&["commit", "-q", "--allow-empty", "-m", "init"], &root));
     // Linked worktree checked out on its own branch (shares root refs/heads).
     assert!(git(

--- a/src/git/status/worktree.rs
+++ b/src/git/status/worktree.rs
@@ -81,10 +81,8 @@ pub(super) fn collect_worktree_info(
 pub(super) fn fetch_remote_silent(path: &Path) -> bool {
     use wait_timeout::ChildExt;
 
-    let mut cmd = std::process::Command::new("git");
-    cmd.arg("-C")
-        .arg(path)
-        .arg("fetch")
+    let mut cmd = crate::git::process::git_command(path);
+    cmd.arg("fetch")
         .arg("--quiet")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -762,25 +762,10 @@ mod tests {
         // defaults to true), so we actually `git init` rather than fake `.git`.
         let tmp = tempfile::TempDir::new().unwrap();
         let root = tmp.path();
-        let mut init_cmd = std::process::Command::new("git");
-        init_cmd.args(["init", "-q"]).current_dir(root);
-        // This suite can run under the pre-push hook, whose injected git env
-        // (GIT_DIR, GIT_INDEX_FILE, …) would make `git init` target the outer
-        // repo instead of the temp dir, leaving it a non-repo where `ignore`
-        // then skips .gitignore. Strip that env.
-        for var in [
-            "GIT_DIR",
-            "GIT_WORK_TREE",
-            "GIT_INDEX_FILE",
-            "GIT_PREFIX",
-            "GIT_COMMON_DIR",
-            "GIT_OBJECT_DIRECTORY",
-            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-            "GIT_NAMESPACE",
-        ] {
-            init_cmd.env_remove(var);
-        }
-        let initialized = init_cmd.status().expect("run git init");
+        let initialized = crate::git::process::git_command(root)
+            .args(["init", "-q"])
+            .status()
+            .expect("run git init");
         assert!(initialized.success(), "git init failed: {initialized}");
 
         std::fs::write(root.join(".gitignore"), "data/\n").unwrap();

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -755,6 +755,9 @@ mod tests {
 
     #[test]
     fn watch_dirs_respects_gitignore() {
+        if !crate::git::git_test_available() {
+            return;
+        }
         // `ignore` only applies .gitignore inside a real git repo (require_git
         // defaults to true), so we actually `git init` rather than fake `.git`.
         let tmp = tempfile::TempDir::new().unwrap();
@@ -777,11 +780,8 @@ mod tests {
         ] {
             init_cmd.env_remove(var);
         }
-        let initialized = init_cmd.status().map(|s| s.success()).unwrap_or(false);
-        if !initialized {
-            eprintln!("skipping watch_dirs_respects_gitignore: git is not available");
-            return;
-        }
+        let initialized = init_cmd.status().expect("run git init");
+        assert!(initialized.success(), "git init failed: {initialized}");
 
         std::fs::write(root.join(".gitignore"), "data/\n").unwrap();
         std::fs::create_dir(root.join("src")).unwrap();


### PR DESCRIPTION
Refs #77

## Type

- [x] Bug fix

## In simple terms

Tests no longer crash when Git is missing. Git commands also stay scoped to the selected repository when launched from a Git hook.

## Problem

Ten tests added in 0.16.0 invoked Git without checking its availability, breaking isolated builds. CI runners already had Git installed, so they missed the failure. Pre-push verification also exposed inherited hook variables redirecting test operations into the calling checkout.

## Fix

- Skip CLI integration tests only when Git is missing, with explicit diagnostics. Broken or non-executable Git fails the tests.
- Require Git in normal CI and add Linux/macOS runs with only sh and sleep on the test PATH.
- Share repository-scoped command construction that clears inherited Git routing variables.
- Add regressions for broken Git, runner failures, and hook isolation. The hook test verifies all selected tests ran and the calling repository stayed unchanged.
- Document partial coverage without Git and Nix test prerequisites.

## Test

- [x] just ci: 578 passed, 1 ignored.
- [x] Restricted-PATH suite passed, with 14 explicit dependency skips counted as passed by Rust.
- [x] All 12 Python CI-script tests passed using Python 3.14.
- [x] Pre-commit and pre-push hooks passed, including audit and coverage.
- [x] Tests and documentation updated.

The Nix build itself has not been run locally.

## Review assistance

- [x] No preference.
