### PR TITLE
fix: address release audit findings and gate publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_call:
   push:
     branches: [main]
     tags: ["v*"]
@@ -80,12 +81,20 @@ jobs:
       - name: Require Git for full integration coverage
         run: git --version
 
+      - name: Install Python for package validation
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
       - name: Run tests
-        run: cargo test --all-targets --all-features
+        run: cargo test --locked --all-targets --all-features
 
       - name: Run tests without Git
         if: runner.os != 'Windows'
         run: python3 scripts/check_test_environment.py
 
       - name: Build release binary
-        run: cargo build --release
+        run: cargo build --locked --release
+
+      - name: Test distributed source package
+        run: python3 scripts/check_source_package.py

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,7 @@
 name: Coverage
 
 on:
+  workflow_call:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 name: Docs
 
 on:
+  workflow_call:
   push:
     branches: [main]
     tags: ["v*"]

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -2,6 +2,7 @@ name: Gitleaks
 
 # Scan the repository for committed secrets and keys on every push and PR.
 on:
+  workflow_call:
   push:
   pull_request:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,31 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
+
+  docs:
+    uses: ./.github/workflows/docs.yml
+    permissions:
+      contents: read
+
+  security:
+    uses: ./.github/workflows/security.yml
+    permissions:
+      contents: read
+
+  coverage:
+    uses: ./.github/workflows/coverage.yml
+    permissions:
+      contents: read
+
+  gitleaks:
+    uses: ./.github/workflows/gitleaks.yml
+    permissions:
+      contents: read
+
   validate:
     name: Validate release metadata
     runs-on: ubuntu-latest
@@ -98,7 +123,7 @@ jobs:
 
   release:
     name: Upload Assets
-    needs: build
+    needs: [build, ci, docs, security, coverage, gitleaks]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -106,6 +131,7 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
+          pattern: gitpane-*
           path: artifacts
           merge-multiple: true
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,7 @@
 name: Security
 
 on:
+  workflow_call:
   push:
     branches: [main]
     tags: ["v*"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,11 @@ For changes to tests or subprocess dependencies, also run
 test harness with only `sh` and `sleep` on its PATH. Missing-Git skips count as
 passed in Rust's summary, so the normal suite with Git remains required.
 
+Before a release, also run `python3.14 scripts/check_source_package.py`. It
+extracts the Cargo source archive into a temporary directory and runs its tests
+with a fresh build target, including the no-Git check on Unix. CI runs this on
+Linux, macOS, and Windows, and publication requires all release checks to pass.
+
 ## Pre-commit hooks (required)
 
 Install them before contributing:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,7 @@ dependencies = [
  "ureq",
  "wait-timeout",
  "walkdir",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,8 @@ arboard = { version = "3", default-features = false, features = ["wayland-data-c
 fs2 = "0.4"
 tempfile = "3"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_System_Com", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
+
 [dev-dependencies]
 tokio = { version = "1.23.1", features = ["full", "test-util"] }

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ command = "tmux new-window -c {path}"   # new tmux window instead of a pane
 # command = "cursor {path}"             # or your editor: code, zed, nvim wrapper, ...
 ```
 
-The template is split on whitespace and run directly (no shell), so `{path}` is safe even with spaces, but other template arguments cannot contain spaces. Need a pipe or quoting? Wrap it: `command = "sh -c 'code {path}'"`.
+With `placement = "command"`, the template is split on whitespace and run directly, so `{path}` remains one argument even with spaces. Other template arguments cannot contain spaces. For shell quoting or pipes, use `placement = "inline"` with a command such as `command = 'code "{path}"'`. Use `split-window` or `new-window` to run the shell command in a multiplexer pane or window.
 
 **Example launchers** (set as `[open] command`):
 
@@ -401,7 +401,7 @@ command = "git diff {base}...HEAD | delta --side-by-side"
 # placement = "split-window -h"  # beside gitpane instead of a new window (default)
 ```
 
-The command runs via `sh -c` in the target directory, so pipes work; `{base}` and `{path}` are shell-quoted before substitution. `[review] placement` uses the same vocabulary as `[open] placement` (default `new-window`), so the same `split-window -h -t <named>` recipes direct the review window wherever you like. Viewers worth a look:
+The command runs via `sh -c` in the target directory, so pipes work. `{base}` and `{path}` preserve their literal argument values whether unquoted, single-quoted, or double-quoted in the template. Templates with placeholders reject nested shell substitutions, heredocs, and escaped placeholders. Put complex shell logic in a wrapper script that receives placeholders as quoted arguments, such as `review-script "{path}" "{base}"`. Do not pass them as code to `eval`, `sh -c`, or another interpreter. `[review] placement` uses the same vocabulary as `[open] placement` (default `new-window`), so the same `split-window -h -t <named>` recipes direct the review window wherever you like. Viewers worth a look:
 
 | Tool | What it gives |
 |------|---------------|

--- a/scripts/check_source_package.py
+++ b/scripts/check_source_package.py
@@ -1,0 +1,55 @@
+"""Test the distributed Cargo source archive, isolated from checkout artifacts."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+
+def main():
+    root = Path.cwd()
+    metadata = subprocess.run(
+        ["cargo", "metadata", "--locked", "--no-deps", "--format-version=1"],
+        capture_output=True, text=True, check=True,
+    )
+    packages = json.loads(metadata.stdout)["packages"]
+    package = next(item for item in packages
+                   if Path(item["manifest_path"]).resolve() == root / "Cargo.toml")
+    name = f"{package['name']}-{package['version']}"
+    with tempfile.TemporaryDirectory(prefix="gitpane-source-package-") as directory:
+        temporary = Path(directory)
+        target = temporary / "target"
+        # A fresh target prevents a checkout's test executable from being reused.
+        env = dict(os.environ, CARGO_TARGET_DIR=str(target))
+        subprocess.run(
+            ["cargo", "package", "--locked", "--no-verify", "--allow-dirty"],
+            env=env, check=True,
+        )
+        with tarfile.open(target / "package" / f"{name}.crate", "r:gz") as archive:
+            archive.extractall(temporary / "source", filter="data")
+        source = temporary / "source" / name
+        if not (source / "Cargo.toml").is_file() or (source / ".git").exists():
+            raise SystemExit("Package must contain Cargo.toml and no Git checkout")
+        subprocess.run(
+            ["cargo", "test", "--locked", "--all-targets", "--all-features"],
+            cwd=source, env=env, check=True,
+        )
+        if os.name == "posix":
+            subprocess.run(
+                [sys.executable, str(root / "scripts/check_test_environment.py")],
+                cwd=source, env=env, check=True,
+            )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as error:
+        if error.stdout:
+            print(error.stdout, file=sys.stderr)
+        if error.stderr:
+            print(error.stderr, file=sys.stderr)
+        raise SystemExit(error.returncode) from error

--- a/scripts/test_check_source_package.py
+++ b/scripts/test_check_source_package.py
@@ -1,0 +1,110 @@
+"""Exercise source-package testing with Cargo as the process boundary."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("check_source_package.py").resolve()
+
+
+@unittest.skipUnless(os.name == "posix", "executable Cargo stand-in requires Unix")
+class SourcePackageTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.checkout = self.root / "checkout"
+        self.checkout.mkdir()
+        (self.checkout / "Cargo.toml").write_text("checkout only")
+        (self.checkout / "scripts").mkdir()
+        shutil.copy(SCRIPT.with_name("check_test_environment.py"),
+                    self.checkout / "scripts/check_test_environment.py")
+        self.observed = self.root / "observed.json"
+        for name in ("sh", "sleep", "git"):
+            (self.bin / name).symlink_to(shutil.which(name))
+
+    def cargo(self, fail_stage="", exit_code=0):
+        source = f'''#!{sys.executable}
+import io, json, os, pathlib, sys, tarfile
+stage = sys.argv[1]
+if stage == "test" and "--no-run" in sys.argv:
+    stage = "restricted"
+if stage == {fail_stage!r}:
+    print("deliberate Cargo failure", file=sys.stderr)
+    raise SystemExit({exit_code})
+root = pathlib.Path.cwd()
+observed = pathlib.Path({str(self.observed)!r})
+if stage == "metadata":
+    print(json.dumps({{"packages": [{{"name": "gitpane", "version": "1.2.3",
+          "manifest_path": str(root / "Cargo.toml")}}]}}))
+elif stage == "package":
+    target = pathlib.Path(os.environ["CARGO_TARGET_DIR"])
+    (target / "package").mkdir(parents=True)
+    with tarfile.open(target / "package/gitpane-1.2.3.crate", "w:gz") as archive:
+        data = b"packaged source"
+        info = tarfile.TarInfo("gitpane-1.2.3/Cargo.toml")
+        info.size = len(data)
+        archive.addfile(info, io.BytesIO(data))
+elif stage == "test":
+    assert (root / "Cargo.toml").read_text() == "packaged source"
+    assert not (root / ".git").exists()
+    observed.write_text(json.dumps({{"source": str(root),
+        "target": os.environ["CARGO_TARGET_DIR"], "normal": True}}))
+elif stage == "restricted":
+    harness = pathlib.Path(os.environ["CARGO_TARGET_DIR"]) / "package-test"
+    harness.write_text({('#!' + sys.executable + chr(10))!r} +
+        "import json, pathlib, shutil\\n" +
+        "p = pathlib.Path(" + repr(str(observed)) + ")\\n" +
+        "data = json.loads(p.read_text())\\n" +
+        "data['restricted'] = shutil.which('git') is None\\n" +
+        "p.write_text(json.dumps(data))\\n")
+    harness.chmod(0o755)
+    print(json.dumps({{"reason": "compiler-artifact", "profile": {{"test": True}},
+        "target": {{"name": "gitpane", "kind": ["bin"]}},
+        "executable": str(harness)}}))
+'''
+        executable = self.bin / "cargo"
+        executable.write_text(source)
+        executable.chmod(0o755)
+
+    def run_check(self):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT)], cwd=self.checkout,
+            env=dict(os.environ, PATH=str(self.bin),
+                     CARGO_TARGET_DIR=str(self.checkout / "target")),
+            capture_output=True, text=True, check=False,
+        )
+
+    def test_runs_packaged_source_with_and_without_git_in_fresh_target(self):
+        self.cargo()
+        result = self.run_check()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        observed = json.loads(self.observed.read_text())
+        self.assertTrue(observed["normal"])
+        self.assertTrue(observed["restricted"])
+        self.assertFalse(Path(observed["source"]).is_relative_to(self.checkout))
+        self.assertFalse(Path(observed["target"]).is_relative_to(self.checkout))
+        self.assertFalse((self.checkout / "target").exists())
+
+    def test_package_and_test_failures_stop_validation(self):
+        for stage in ("metadata", "package", "test", "restricted"):
+            with self.subTest(stage=stage):
+                self.observed.unlink(missing_ok=True)
+                self.cargo(fail_stage=stage, exit_code=37)
+                result = self.run_check()
+                self.assertEqual(result.returncode, 37, result.stdout + result.stderr)
+                self.assertIn("deliberate Cargo failure", result.stderr)
+                if self.observed.exists():
+                    self.assertNotIn("restricted", json.loads(self.observed.read_text()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -660,13 +660,19 @@ impl App {
                 self.github_fetched(repo_id, generation, result);
             }
             Action::OpenUrl(ref url) => {
-                let opener = if cfg!(target_os = "macos") {
-                    "open"
-                } else {
-                    "xdg-open"
-                };
-                let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/"));
-                self.os_open(vec![opener.to_string(), url.clone()], cwd, "github");
+                #[cfg(windows)]
+                self.os_open_windows(std::path::PathBuf::from(url), "github");
+                #[cfg(not(windows))]
+                {
+                    let opener = if cfg!(target_os = "macos") {
+                        "open"
+                    } else {
+                        "xdg-open"
+                    };
+                    let cwd =
+                        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/"));
+                    self.os_open(vec![opener.to_string(), url.clone()], cwd, "github");
+                }
             }
             Action::ShowGithubItem {
                 url,

--- a/src/app/actions_extra.rs
+++ b/src/app/actions_extra.rs
@@ -262,16 +262,7 @@ impl App {
                         // remote) or the repo has no remote. `"HEAD"` is the
                         // git2 shorthand for a detached HEAD — no branch to
                         // sync, so run bare and let git report it.
-                        let mut git_args = git_op;
-                        if !branch.is_empty()
-                            && branch != "(no branch)"
-                            && branch != "HEAD"
-                            && let Some(remote) =
-                                crate::git::resolve_sync_remote(&path, &branch, is_push)
-                        {
-                            git_args.push(remote);
-                            git_args.push(branch);
-                        }
+                        let git_args = crate::git::sync_arguments(&path, &branch, is_push, git_op);
                         let output = crate::git::process::run_git_op_capturing(&path, &git_args);
                         match output {
                             Ok(o) if o.status.success() => {
@@ -466,20 +457,23 @@ impl App {
                                 let output = crate::git::process::git_command(&submodule_abs)
                                     .args(["diff", "HEAD"])
                                     .output();
-                                let body = match output {
-                                    Ok(o) => {
-                                        let text = String::from_utf8_lossy(&o.stdout).to_string();
+                                let body = match crate::git::process::output_text(output) {
+                                    Ok(text) => {
                                         if text.is_empty() {
                                             // Fallback: show status
-                                            let status_out =
+                                            let status_out = crate::git::process::output_text(
                                                 crate::git::process::git_command(&submodule_abs)
                                                     .args(["status", "--short"])
-                                                    .output()
-                                                    .map(|o| {
-                                                        String::from_utf8_lossy(&o.stdout)
-                                                            .to_string()
-                                                    })
-                                                    .unwrap_or_default();
+                                                    .output(),
+                                            );
+                                            let status_out = match status_out {
+                                                Ok(text) => text,
+                                                Err(error) => {
+                                                    let _ =
+                                                        tx.send(Action::Error(error.to_string()));
+                                                    return;
+                                                }
+                                            };
                                             if status_out.is_empty() {
                                                 "(no changes detected)".to_string()
                                             } else {
@@ -490,10 +484,10 @@ impl App {
                                         }
                                     }
                                     Err(e) => {
-                                        format!(
-                                            "Failed to get submodule diff: {}",
-                                            crate::git::describe_spawn_error(&e)
-                                        )
+                                        let _ = tx.send(Action::Error(format!(
+                                            "Failed to get submodule diff: {e}"
+                                        )));
+                                        return;
                                     }
                                 };
                                 let _ = tx.send(Action::DiffLoaded {
@@ -512,19 +506,20 @@ impl App {
                                 let output = crate::git::process::git_command(&submodule_abs)
                                     .args(["log", "--oneline", "--graph", &range])
                                     .output();
-                                let body = match output {
-                                    Ok(o) => {
-                                        let text = String::from_utf8_lossy(&o.stdout).to_string();
+                                let body = match crate::git::process::output_text(output) {
+                                    Ok(text) => {
                                         if text.is_empty() {
                                             "(no commits in range)".to_string()
                                         } else {
                                             text
                                         }
                                     }
-                                    Err(e) => format!(
-                                        "Failed to get submodule log: {}",
-                                        crate::git::describe_spawn_error(&e)
-                                    ),
+                                    Err(e) => {
+                                        let _ = tx.send(Action::Error(format!(
+                                            "Failed to get submodule log: {e}"
+                                        )));
+                                        return;
+                                    }
                                 };
                                 let _ = tx.send(Action::DiffLoaded {
                                     generation: diff_gen,

--- a/src/app/launch.rs
+++ b/src/app/launch.rs
@@ -115,7 +115,7 @@ impl App {
     }
 
     #[cfg(windows)]
-    fn os_open_windows(&self, target: std::path::PathBuf, label: &'static str) {
+    pub(super) fn os_open_windows(&self, target: std::path::PathBuf, label: &'static str) {
         let tx = self.action_tx.clone();
         tokio::task::spawn_blocking(move || {
             if let Err(error) = crate::session::opener::open(&target) {

--- a/src/app/launch.rs
+++ b/src/app/launch.rs
@@ -109,8 +109,19 @@ impl App {
 
     /// Spawn an OS opener (`open` / `xdg-open`) detached. Shares the launch
     /// machinery used by `[open]`/`[review]`, just without a config template.
+    #[cfg(not(windows))]
     pub(super) fn os_open(&self, argv: Vec<String>, cwd: std::path::PathBuf, label: &'static str) {
         spawn_detached(argv, cwd, self.action_tx.clone(), label);
+    }
+
+    #[cfg(windows)]
+    fn os_open_windows(&self, target: std::path::PathBuf, label: &'static str) {
+        let tx = self.action_tx.clone();
+        tokio::task::spawn_blocking(move || {
+            if let Err(error) = crate::session::opener::open(&target) {
+                let _ = tx.send(Action::Error(format!("{label} failed: {error}")));
+            }
+        });
     }
 
     /// Open a changed file: via the configured `[open]` command when set (so
@@ -127,19 +138,24 @@ impl App {
         if request.command.is_some() {
             self.launch_open_request(request, tui)?;
         } else {
-            let opener = if cfg!(target_os = "macos") {
-                "open"
-            } else {
-                "xdg-open"
-            };
-            self.os_open(
-                vec![
-                    opener.to_string(),
-                    request.target.to_string_lossy().into_owned(),
-                ],
-                request.dir,
-                "open",
-            );
+            #[cfg(windows)]
+            self.os_open_windows(request.target, "open");
+            #[cfg(not(windows))]
+            {
+                let opener = if cfg!(target_os = "macos") {
+                    "open"
+                } else {
+                    "xdg-open"
+                };
+                self.os_open(
+                    vec![
+                        opener.to_string(),
+                        request.target.to_string_lossy().into_owned(),
+                    ],
+                    request.dir,
+                    "open",
+                );
+            }
         }
         Ok(())
     }
@@ -161,7 +177,7 @@ impl App {
     }
 
     /// Reveal a changed file in the OS file manager: Finder selects it on macOS
-    /// (`open -R`); elsewhere open the enclosing folder (`xdg-open <dir>`).
+    /// (`open -R`); elsewhere open the enclosing folder with the platform opener.
     pub(super) fn reveal_file_external(&self, id: &RepoId, rel: &std::path::Path) {
         let Some(abs) = self.file_op_dir(id).map(|d| d.join(rel)) else {
             return;
@@ -170,19 +186,24 @@ impl App {
             .parent()
             .map(|p| p.to_path_buf())
             .unwrap_or_else(|| abs.clone());
-        let argv = if cfg!(target_os = "macos") {
-            vec![
-                "open".to_string(),
-                "-R".to_string(),
-                abs.to_string_lossy().into_owned(),
-            ]
-        } else {
-            vec![
-                "xdg-open".to_string(),
-                parent.to_string_lossy().into_owned(),
-            ]
-        };
-        self.os_open(argv, parent, "reveal");
+        #[cfg(windows)]
+        self.os_open_windows(parent, "reveal");
+        #[cfg(not(windows))]
+        {
+            let argv = if cfg!(target_os = "macos") {
+                vec![
+                    "open".to_string(),
+                    "-R".to_string(),
+                    abs.to_string_lossy().into_owned(),
+                ]
+            } else {
+                vec![
+                    "xdg-open".to_string(),
+                    parent.to_string_lossy().into_owned(),
+                ]
+            };
+            self.os_open(argv, parent, "reveal");
+        }
     }
     /// Execute a [`crate::session::launcher::LaunchPlan`] for a verb (`open`/`review`)
     /// targeting `dir`. Needs `tui` so an `Inline` plan can suspend the TUI,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -46,6 +46,30 @@ mod repo_admin;
 #[cfg(test)]
 mod tests;
 
+#[derive(Default)]
+struct WatcherSlot {
+    requested: u64,
+    current: Option<(u64, RepoWatcher)>,
+}
+
+impl WatcherSlot {
+    fn request(&mut self) -> u64 {
+        self.requested = self
+            .requested
+            .checked_add(1)
+            .expect("watcher generation exhausted");
+        self.requested
+    }
+
+    fn install(&mut self, generation: u64, watcher: RepoWatcher) -> bool {
+        if generation != self.requested {
+            return false;
+        }
+        self.current = Some((generation, watcher));
+        true
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FocusPanel {
     Repos,
@@ -252,7 +276,7 @@ pub(crate) struct App {
     /// (which stops the underlying watches) only fires when we deliberately
     /// replace it via `rebuild_watcher`. Shared so the watcher can be built on
     /// a blocking thread and dropped into this slot once ready.
-    watcher: Arc<Mutex<Option<RepoWatcher>>>,
+    watcher: Arc<Mutex<WatcherSlot>>,
     /// Clone of `Tui::event_tx` so `rebuild_watcher` can run outside `run()`.
     tui_event_tx: Option<UnboundedSender<Event>>,
     /// Wall-clock of the last `DiscoverNewRepos` dispatch driven by a
@@ -426,7 +450,7 @@ impl App {
             active_worktree: None,
             liveness_probe_in_flight: false,
             theme,
-            watcher: Arc::new(Mutex::new(None)),
+            watcher: Arc::new(Mutex::new(WatcherSlot::default())),
             tui_event_tx: None,
             last_discovery: None,
             discovery_pending: false,
@@ -536,6 +560,9 @@ impl App {
         let exclude_dirs = self.config.watch.watch_exclude_dirs.clone();
         let watch_worktree_dirs = self.config.watch.watch_worktree_dirs;
         let slot = Arc::clone(&self.watcher);
+        // Request and installation use the same lock, so an older build can
+        // never replace watches requested for a newer membership snapshot.
+        let generation = slot.lock().unwrap().request();
         let repo_count = repo_paths.len();
         tokio::task::spawn_blocking(move || {
             let started = std::time::Instant::now();
@@ -548,7 +575,9 @@ impl App {
                 watch_worktree_dirs,
             ) {
                 Ok(w) => {
-                    *slot.lock().unwrap() = Some(w);
+                    if !slot.lock().unwrap().install(generation, w) {
+                        return;
+                    }
                     tracing::info!(
                         "filesystem watcher ready: {} repos in {:?}",
                         repo_count,

--- a/src/app/repo_admin.rs
+++ b/src/app/repo_admin.rs
@@ -66,6 +66,7 @@ impl App {
                         // SelectRepo below can land on the new row instead of
                         // silently no-op'ing against the stale row model.
                         self.sort_repos();
+                        self.rebuild_watcher();
                         self.action_tx.send(Action::RefreshRepo(repo_id.clone()))?;
                         self.action_tx.send(Action::SelectRepo(repo_id))?;
                     }
@@ -128,6 +129,7 @@ impl App {
                         self.active_worktree = None;
                     }
                     self.repo_list.repos.remove(idx);
+                    self.rebuild_watcher();
                     self.prune_github_cache(std::slice::from_ref(&id.0));
                     // Fix selection
                     if self.repo_list.repos.is_empty() {

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 mod robustness;
+mod watcher_membership;
 use crate::git::status::StashEntry;
 use std::path::Path;
 

--- a/src/app/tests/watcher_membership.rs
+++ b/src/app/tests/watcher_membership.rs
@@ -110,8 +110,8 @@ async fn older_watcher_completion_cannot_replace_newer_membership() {
     let build = |path: &std::path::PathBuf| {
         RepoWatcher::new(std::slice::from_ref(path), &[], 20, tx.clone(), &[], true).unwrap()
     };
-    assert!(slot.install(newer, build(&new_path)));
-    assert!(!slot.install(older, build(&old_path)));
+    slot.install(newer, build(&new_path));
+    slot.install(older, build(&old_path));
     while rx.try_recv().is_ok() {}
     std::fs::write(new_path.join("changed.txt"), "new membership").unwrap();
     changed_repo(&mut rx, &new_path).await;

--- a/src/app/tests/watcher_membership.rs
+++ b/src/app/tests/watcher_membership.rs
@@ -1,0 +1,134 @@
+use super::*;
+
+async fn wait_for_watcher(app: &App) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            {
+                let slot = app.watcher.lock().unwrap();
+                if slot
+                    .current
+                    .as_ref()
+                    .is_some_and(|(generation, _)| *generation == slot.requested)
+                {
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("watcher rebuild did not finish");
+}
+
+async fn changed_repo(rx: &mut UnboundedReceiver<Event>, expected: &Path) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if let Some(Event::RepoChanged(path)) = rx.recv().await
+                && path == expected
+            {
+                return;
+            }
+        }
+    })
+    .await
+    .expect("repository edit did not produce a watcher event");
+}
+
+async fn drain_buffered_events(rx: &mut UnboundedReceiver<Event>) {
+    // A dropped debouncer can leave already-routed events queued. Wait for a
+    // quiet interval before making the edit whose absence we are checking.
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while tokio::time::timeout(Duration::from_millis(200), rx.recv())
+            .await
+            .is_ok()
+        {}
+    })
+    .await
+    .expect("watcher events did not settle");
+}
+
+#[tokio::test]
+async fn manually_added_repo_refreshes_in_doze_and_removal_stops_its_events() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pinned");
+    git2::Repository::init(&path).unwrap();
+    let path = path.canonicalize().unwrap();
+    let mut config = Config {
+        root_dirs: vec![],
+        write_target_override: Some(dir.path().join("config.toml")),
+        ..Config::default()
+    };
+    config.watch.debounce_ms = 20;
+    config.save().unwrap();
+    let mut app = App::new(config);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    app.tui_event_tx = Some(tx);
+    app.rebuild_watcher();
+    wait_for_watcher(&app).await;
+    app.handle_repo_admin(Action::AddRepo(path.clone()))
+        .unwrap();
+    wait_for_watcher(&app).await;
+    app.handle_event(Event::Power(PowerState::Doze)).unwrap();
+    drain_actions(&mut app);
+    while rx.try_recv().is_ok() {}
+    std::fs::write(path.join("changed.txt"), "first edit").unwrap();
+    changed_repo(&mut rx, &path).await;
+    app.handle_event(Event::RepoChanged(path.clone())).unwrap();
+    assert!(
+        drain_actions(&mut app)
+            .iter()
+            .any(|action| { matches!(action, Action::RefreshRepo(id) if id.0 == path) }),
+        "Doze must refresh repositories after a filesystem edit"
+    );
+
+    app.handle_repo_admin(Action::RemoveRepo(RepoId(path.clone())))
+        .unwrap();
+    wait_for_watcher(&app).await;
+    drain_buffered_events(&mut rx).await;
+    std::fs::write(path.join("changed.txt"), "edit after removal").unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(700), rx.recv())
+            .await
+            .is_err(),
+        "removed repository still emits watcher events"
+    );
+}
+
+#[tokio::test]
+async fn older_watcher_completion_cannot_replace_newer_membership() {
+    let dir = tempfile::tempdir().unwrap();
+    let old_path = dir.path().join("old");
+    let new_path = dir.path().join("new");
+    git2::Repository::init(&old_path).unwrap();
+    git2::Repository::init(&new_path).unwrap();
+    let old_path = old_path.canonicalize().unwrap();
+    let new_path = new_path.canonicalize().unwrap();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut slot = WatcherSlot::default();
+    let older = slot.request();
+    let newer = slot.request();
+    let build = |path: &std::path::PathBuf| {
+        RepoWatcher::new(std::slice::from_ref(path), &[], 20, tx.clone(), &[], true).unwrap()
+    };
+    assert!(slot.install(newer, build(&new_path)));
+    assert!(!slot.install(older, build(&old_path)));
+    while rx.try_recv().is_ok() {}
+    std::fs::write(new_path.join("changed.txt"), "new membership").unwrap();
+    changed_repo(&mut rx, &new_path).await;
+    drain_buffered_events(&mut rx).await;
+    std::fs::write(old_path.join("changed.txt"), "stale membership").unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(700), async {
+            loop {
+                if let Some(Event::RepoChanged(path)) = rx.recv().await
+                    && path == old_path
+                {
+                    return;
+                }
+            }
+        })
+        .await
+        .is_err(),
+        "stale watcher remained active"
+    );
+}

--- a/src/git/commit_files.rs
+++ b/src/git/commit_files.rs
@@ -101,7 +101,7 @@ pub(crate) fn batch_diff_stats(
     Ok(results)
 }
 
-fn diff_to_string(diff: &Diff<'_>, output: &mut String) -> color_eyre::Result<()> {
+pub(super) fn diff_to_string(diff: &Diff<'_>, output: &mut String) -> color_eyre::Result<()> {
     diff.print(git2::DiffFormat::Patch, |_delta, _hunk, line| {
         let prefix = match line.origin() {
             '+' => "+",

--- a/src/git/file_ops.rs
+++ b/src/git/file_ops.rs
@@ -14,7 +14,7 @@ pub(crate) fn arguments(
     selected: &Path,
     operation: FileOperation,
 ) -> color_eyre::Result<Vec<String>> {
-    let words = match operation {
+    let mut words = match operation {
         FileOperation::Stage => vec!["add", "-A"],
         FileOperation::Unstage => vec!["reset", "-q"],
         FileOperation::Discard => vec!["restore", "--staged", "--worktree"],
@@ -27,6 +27,20 @@ pub(crate) fn arguments(
         FileOperation::DeleteUntracked | FileOperation::Stage
     ) {
         let repo = git2::Repository::open(repo_path)?;
+        if matches!(operation, FileOperation::Discard) {
+            match repo.head() {
+                Ok(_) => {}
+                Err(error) if error.code() == git2::ErrorCode::UnbornBranch => {
+                    if !repo.status_file(selected)?.is_index_new() {
+                        return Err(color_eyre::eyre::eyre!(
+                            "Cannot discard a path that is not a staged addition before the first commit"
+                        ));
+                    }
+                    words = vec!["rm", "-f"];
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
         let mut options = git2::StatusOptions::new();
         options.include_untracked(true).renames_head_to_index(true);
         let statuses = repo.statuses(Some(&mut options))?;
@@ -68,26 +82,38 @@ pub(crate) fn arguments(
 
 pub(crate) fn diff(repo_path: &Path, selected: &Path) -> color_eyre::Result<String> {
     let repo = git2::Repository::open(repo_path)?;
-    let untracked = repo.status_file(selected)?.is_wt_new();
+    let untracked = repo_path.join(selected).is_dir() || repo.status_file(selected)?.is_wt_new();
+    if untracked {
+        let mut options = git2::DiffOptions::new();
+        options
+            .include_untracked(true)
+            .recurse_untracked_dirs(true)
+            .show_untracked_content(true)
+            .disable_pathspec_match(true)
+            .pathspec(selected);
+        let diff = repo.diff_index_to_workdir(None, Some(&mut options))?;
+        let mut text = String::new();
+        super::commit_files::diff_to_string(&diff, &mut text)?;
+        return Ok(if text.is_empty() {
+            "(no diff available)".into()
+        } else {
+            text
+        });
+    }
     let mut command = super::process::git_command(repo_path);
     command.current_dir(repo_path);
-    if untracked {
-        command
-            .args(["diff", "--no-index", "--", "/dev/null"])
-            .arg(selected);
-    } else {
-        let mut args = arguments(repo_path, selected, FileOperation::Diff)?;
-        if repo.head().is_err() {
+    let mut args = arguments(repo_path, selected, FileOperation::Diff)?;
+    match repo.head() {
+        Ok(_) => {}
+        Err(error) if error.code() == git2::ErrorCode::UnbornBranch => {
             // An unborn branch has an index but no HEAD tree yet.
-            if !repo.is_empty()? {
-                return Err(color_eyre::eyre::eyre!("Cannot resolve repository HEAD"));
-            }
             args[2] = "--cached".to_owned();
         }
-        command.args(args);
+        Err(error) => return Err(error.into()),
     }
+    command.args(args);
     let output = command.output()?;
-    if !(output.status.success() || untracked && output.status.code() == Some(1)) {
+    if !output.status.success() {
         return Err(color_eyre::eyre::eyre!(
             "{}",
             String::from_utf8_lossy(&output.stderr).trim()

--- a/src/git/file_ops/tests.rs
+++ b/src/git/file_ops/tests.rs
@@ -187,15 +187,140 @@ fn selected_diff_excludes_other_pattern_matches_in_worktree_and_commit() {
 
 #[test]
 fn untracked_diff_reads_from_selected_repository() {
-    if !crate::git::git_test_available() {
-        return;
-    }
     let (tmp, _) = fixture(&["tracked"]);
     std::fs::write(tmp.path().join("untracked"), "NEW CONTENT").unwrap();
     assert!(
         diff(tmp.path(), Path::new("untracked"))
             .unwrap()
             .contains("NEW CONTENT")
+    );
+}
+
+#[test]
+fn untracked_directory_diff_includes_nested_files_and_preserves_index() {
+    let (tmp, repo) = fixture(&["tracked"]);
+    std::fs::create_dir_all(tmp.path().join("new/nested")).unwrap();
+    std::fs::write(tmp.path().join("new/first"), "FIRST CONTENT\n").unwrap();
+    std::fs::write(tmp.path().join("new/nested/second"), "NESTED CONTENT\n").unwrap();
+    std::fs::write(tmp.path().join("unrelated"), "EXCLUDED CONTENT\n").unwrap();
+    let index_before = std::fs::read(repo.path().join("index")).unwrap();
+    let text = diff(tmp.path(), Path::new("new/")).unwrap();
+    assert!(text.contains("FIRST CONTENT"));
+    assert!(text.contains("NESTED CONTENT"));
+    assert!(!text.contains("EXCLUDED CONTENT"));
+    assert_eq!(
+        std::fs::read(repo.path().join("index")).unwrap(),
+        index_before
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn untracked_pattern_directory_diff_is_literal_and_does_not_follow_symlinks() {
+    let (tmp, _) = fixture(&["tracked"]);
+    std::fs::create_dir(tmp.path().join("*.draft")).unwrap();
+    std::fs::create_dir(tmp.path().join("other.draft")).unwrap();
+    std::fs::write(tmp.path().join("*.draft/file"), "SELECTED CONTENT\n").unwrap();
+    std::fs::write(tmp.path().join("other.draft/file"), "UNRELATED CONTENT\n").unwrap();
+    std::os::unix::fs::symlink("../other.draft/file", tmp.path().join("*.draft/link")).unwrap();
+    let text = diff(tmp.path(), Path::new("*.draft/")).unwrap();
+    assert!(text.contains("SELECTED CONTENT"));
+    assert!(text.contains("../other.draft/file"));
+    assert!(!text.contains("UNRELATED CONTENT"));
+}
+
+#[test]
+fn untracked_binary_diff_reports_binary_content() {
+    let (tmp, _) = fixture(&["tracked"]);
+    std::fs::write(tmp.path().join("binary"), b"\0\x01\x02").unwrap();
+    let text = diff(tmp.path(), Path::new("binary")).unwrap();
+    assert!(text.contains("binary"));
+    assert!(text.contains("Binary"));
+}
+
+#[test]
+fn tracked_diff_includes_staged_and_unstaged_content_only_for_selected_file() {
+    if !crate::git::git_test_available() {
+        return;
+    }
+    let (tmp, repo) = fixture(&["selected", "other"]);
+    std::fs::write(tmp.path().join("selected"), "STAGED CONTENT\n").unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("selected")).unwrap();
+    index.write().unwrap();
+    std::fs::write(
+        tmp.path().join("selected"),
+        "STAGED CONTENT\nUNSTAGED CONTENT\n",
+    )
+    .unwrap();
+    std::fs::write(tmp.path().join("other"), "UNRELATED CONTENT\n").unwrap();
+    let text = diff(tmp.path(), Path::new("selected")).unwrap();
+    assert!(text.contains("STAGED CONTENT"));
+    assert!(text.contains("UNSTAGED CONTENT"));
+    assert!(!text.contains("UNRELATED CONTENT"));
+}
+
+#[test]
+fn discarding_staged_addition_before_first_commit_preserves_other_changes() {
+    if !crate::git::git_test_available() {
+        return;
+    }
+    let tmp = tempfile::TempDir::new().unwrap();
+    let repo = Repository::init(tmp.path()).unwrap();
+    for name in ["selected", "other"] {
+        std::fs::write(tmp.path().join(name), format!("{name} content\n")).unwrap();
+    }
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("selected")).unwrap();
+    index.add_path(Path::new("other")).unwrap();
+    index.write().unwrap();
+    std::fs::write(tmp.path().join("untracked"), "untracked content\n").unwrap();
+    std::fs::write(tmp.path().join("selected"), "edited staged addition\n").unwrap();
+    apply(tmp.path(), "selected", FileOperation::Discard);
+    let repo = Repository::open(tmp.path()).unwrap();
+    assert!(!tmp.path().join("selected").exists());
+    assert!(
+        repo.index()
+            .unwrap()
+            .get_path(Path::new("selected"), 0)
+            .is_none()
+    );
+    assert!(repo.status_file(Path::new("other")).unwrap().is_index_new());
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("other")).unwrap(),
+        "other content\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("untracked")).unwrap(),
+        "untracked content\n"
+    );
+}
+
+#[test]
+fn unborn_discard_refuses_untracked_paths_and_directories() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let repo = Repository::init(tmp.path()).unwrap();
+    std::fs::create_dir(tmp.path().join("directory")).unwrap();
+    std::fs::write(tmp.path().join("directory/staged"), "staged content").unwrap();
+    std::fs::write(tmp.path().join("untracked"), "untracked content").unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("directory/staged")).unwrap();
+    index.write().unwrap();
+    let index_before = std::fs::read(repo.path().join("index")).unwrap();
+    for selected in ["untracked", "directory/"] {
+        assert!(arguments(tmp.path(), Path::new(selected), FileOperation::Discard).is_err());
+    }
+    assert_eq!(
+        std::fs::read(repo.path().join("index")).unwrap(),
+        index_before
+    );
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("directory/staged")).unwrap(),
+        "staged content"
+    );
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("untracked")).unwrap(),
+        "untracked content"
     );
 }
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -133,6 +133,23 @@ pub(crate) fn resolve_sync_remote(
     preferred_remote(&repo)
 }
 
+/// Keep repository and branch operands literal when selecting a sync remote.
+pub(crate) fn sync_arguments(
+    path: &std::path::Path,
+    branch: &str,
+    push: bool,
+    mut args: Vec<String>,
+) -> Vec<String> {
+    if !branch.is_empty()
+        && branch != "(no branch)"
+        && branch != "HEAD"
+        && let Some(remote) = resolve_sync_remote(path, branch, push)
+    {
+        args.extend(["--".into(), remote, branch.into()]);
+    }
+    args
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -142,7 +159,7 @@ mod tests {
         let output = std::process::Command::new(std::env::current_exe().unwrap())
             .args([
                 "--exact",
-                "git::file_ops::tests::untracked_diff_reads_from_selected_repository",
+                "git::file_ops::tests::tracked_diff_includes_staged_and_unstaged_content_only_for_selected_file",
                 "--nocapture",
             ])
             .env("PATH", directory)
@@ -207,6 +224,9 @@ mod tests {
             "git::file_ops::tests::rename_actions_update_both_paths_and_preserve_other_staged_changes",
             "git::file_ops::tests::selected_diff_excludes_other_pattern_matches_in_worktree_and_commit",
             "git::file_ops::tests::untracked_diff_reads_from_selected_repository",
+            "git::file_ops::tests::tracked_diff_includes_staged_and_unstaged_content_only_for_selected_file",
+            "git::file_ops::tests::discarding_staged_addition_before_first_commit_preserves_other_changes",
+            "git::tests::pushing_to_a_flag_named_remote_cannot_force_divergent_history",
             "git::file_ops::tests::staging_rename_does_not_stage_a_recreated_source_file",
             "git::file_ops::tests::discarding_rename_refuses_to_overwrite_a_recreated_source",
             "git::file_ops::tests::discarding_rename_preserves_a_recreated_dangling_symlink",
@@ -281,6 +301,76 @@ mod tests {
             resolve_sync_remote(tmp.path(), "main", false).as_deref(),
             Some("origin")
         );
+    }
+
+    #[test]
+    fn pushing_to_a_flag_named_remote_cannot_force_divergent_history() {
+        if !git_test_available() {
+            return;
+        }
+        let tmp = tempfile::TempDir::new().unwrap();
+        let local_path = tmp.path().join("local");
+        let remote_path = tmp.path().join("remote");
+        let repo = git2::Repository::init(&local_path).unwrap();
+        let remote = git2::Repository::init_bare(&remote_path).unwrap();
+        repo.set_head("refs/heads/main").unwrap();
+        repo.config()
+            .unwrap()
+            .set_str("push.default", "current")
+            .unwrap();
+        for name in ["--force", "main"] {
+            repo.remote(name, remote_path.to_str().unwrap()).unwrap();
+        }
+        let commit = |text: &str| {
+            std::fs::write(local_path.join("file"), text).unwrap();
+            let mut index = repo.index().unwrap();
+            index.add_path(std::path::Path::new("file")).unwrap();
+            index.write().unwrap();
+            let tree = repo.find_tree(index.write_tree().unwrap()).unwrap();
+            let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+            let parents: Vec<_> = repo
+                .head()
+                .ok()
+                .map(|head| head.peel_to_commit().unwrap())
+                .into_iter()
+                .collect();
+            repo.commit(
+                Some("HEAD"),
+                &sig,
+                &sig,
+                text,
+                &tree,
+                &parents.iter().collect::<Vec<_>>(),
+            )
+            .unwrap()
+        };
+        let first = commit("first");
+        let remote_tip = commit("remote change");
+        let initial_push = process::git_command(&local_path)
+            .args(["push", "--", "--force", "main"])
+            .output()
+            .unwrap();
+        assert!(
+            initial_push.status.success(),
+            "{}",
+            String::from_utf8_lossy(&initial_push.stderr)
+        );
+        repo.reset(
+            &repo.find_object(first, None).unwrap(),
+            git2::ResetType::Hard,
+            None,
+        )
+        .unwrap();
+        let local_tip = commit("divergent local change");
+        let args = sync_arguments(&local_path, "main", true, vec!["push".into()]);
+        let output = process::git_command(&local_path)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("rejected"));
+        assert_eq!(remote.refname_to_id("refs/heads/main").unwrap(), remote_tip);
+        assert_eq!(repo.head().unwrap().target(), Some(local_tip));
     }
 
     #[test]

--- a/src/git/process.rs
+++ b/src/git/process.rs
@@ -37,6 +37,23 @@ pub(crate) fn git_command(path: &Path) -> std::process::Command {
     cmd
 }
 
+/// Decode Git output only after checking both spawn and command failures.
+pub(crate) fn output_text(
+    output: std::io::Result<std::process::Output>,
+) -> color_eyre::Result<String> {
+    let output = output
+        .map_err(|error| color_eyre::eyre::eyre!("{}", super::describe_spawn_error(&error)))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(color_eyre::eyre::eyre!(
+            "Git command failed ({}): {}",
+            output.status,
+            stderr.trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
 /// Seconds a user-initiated mutating git op (pull/push/submodule, and the file
 /// and worktree ops) may run before it is killed as a process group. Long
 /// enough to let a large transfer finish, but bounded so a stalled connection

--- a/src/git/process/tests.rs
+++ b/src/git/process/tests.rs
@@ -331,3 +331,21 @@ fn run_git_op_capturing_registers_and_unregisters() {
         "killable registry not empty after run_git_op_capturing"
     );
 }
+#[test]
+fn failed_git_queries_report_stderr_instead_of_empty_content() {
+    if !crate::git::git_test_available() {
+        return;
+    }
+    let tmp = tempfile::TempDir::new().unwrap();
+    git2::Repository::init(tmp.path()).unwrap();
+    let output = super::git_command(tmp.path())
+        .args(["log", "missing-reference"])
+        .output();
+    let error = super::output_text(output).unwrap_err().to_string();
+    assert!(error.contains("missing-reference"));
+    assert!(error.contains("failed"));
+    let output = super::git_command(tmp.path())
+        .args(["status", "--short"])
+        .output();
+    assert!(super::output_text(output).unwrap().is_empty());
+}

--- a/src/session/launcher/mod.rs
+++ b/src/session/launcher/mod.rs
@@ -10,6 +10,8 @@
 
 use crate::session::env::Multiplexer;
 
+mod shell;
+
 /// How a verb places the command it runs.
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum Placement {
@@ -81,14 +83,6 @@ fn substitute_argv(template: &str, dir: &str, base: Option<&str>) -> Vec<String>
         .split_whitespace()
         .map(|tok| substitute_placeholders(tok, dir, base))
         .collect()
-}
-
-/// Substitute `{path}` and `{base}` into a template destined for `sh -c`,
-/// shell-quoting each value so a path with spaces or a ref with shell
-/// metacharacters cannot break out of the command.
-fn substitute_shell(template: &str, dir: &str, base: Option<&str>) -> String {
-    let base = base.map(shell_single_quote);
-    substitute_placeholders(template, &shell_single_quote(dir), base.as_deref())
 }
 
 /// Parse a placement string. `command`/`inline`/`ask` are keywords; anything
@@ -171,6 +165,14 @@ pub(crate) fn plan_with_target(
         Err(e) => return LaunchPlan::Error(e),
     };
     let cmd = command.filter(|c| !c.trim().is_empty());
+    let shell = if matches!(placement, Placement::Command) {
+        None
+    } else {
+        match cmd.map(|c| shell::substitute(c, target, base)).transpose() {
+            Ok(command) => command,
+            Err(error) => return LaunchPlan::Error(error),
+        }
+    };
     match placement {
         Placement::Command => match cmd {
             Some(c) => LaunchPlan::Spawn(substitute_argv(c, target, base)),
@@ -190,39 +192,32 @@ pub(crate) fn plan_with_target(
                 }
             },
         },
-        Placement::Tmux(flags) => {
-            let shell = cmd.map(|c| substitute_shell(c, target, base));
-            match mux {
-                Multiplexer::Tmux => {
-                    LaunchPlan::Spawn(build_tmux_argv(&flags, dir, shell.as_deref()))
-                }
-                Multiplexer::Herdr => match herdr_create_argv(&flags, dir) {
-                    Ok(create) => LaunchPlan::Herdr {
-                        create,
-                        command: shell,
-                    },
-                    Err(e) => LaunchPlan::Error(e),
+        Placement::Tmux(flags) => match mux {
+            Multiplexer::Tmux => LaunchPlan::Spawn(build_tmux_argv(&flags, dir, shell.as_deref())),
+            Multiplexer::Herdr => match herdr_create_argv(&flags, dir) {
+                Ok(create) => LaunchPlan::Herdr {
+                    create,
+                    command: shell,
                 },
-                Multiplexer::None => {
-                    if let Some(s) = shell {
-                        LaunchPlan::Inline(s)
-                    } else {
-                        LaunchPlan::Error(
-                            "run gitpane inside tmux or herdr for this placement".into(),
-                        )
-                    }
+                Err(e) => LaunchPlan::Error(e),
+            },
+            Multiplexer::None => {
+                if let Some(s) = shell {
+                    LaunchPlan::Inline(s)
+                } else {
+                    LaunchPlan::Error("run gitpane inside tmux or herdr for this placement".into())
                 }
             }
-        }
-        Placement::Inline => match cmd {
-            Some(c) => LaunchPlan::Inline(substitute_shell(c, target, base)),
+        },
+        Placement::Inline => match shell {
+            Some(command) => LaunchPlan::Inline(command),
             None => LaunchPlan::Error("inline placement needs a command".to_string()),
         },
         Placement::Ask => match mux {
             Multiplexer::Tmux | Multiplexer::Herdr => LaunchPlan::Ask,
             Multiplexer::None => {
-                if let Some(c) = cmd {
-                    LaunchPlan::Inline(substitute_shell(c, target, base))
+                if let Some(command) = shell {
+                    LaunchPlan::Inline(command)
                 } else {
                     LaunchPlan::Error("run gitpane inside tmux or herdr for this placement".into())
                 }
@@ -480,3 +475,6 @@ pub(crate) fn forward_right_click_in_herdr() {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(all(test, unix))]
+mod tests_shell;

--- a/src/session/launcher/shell.rs
+++ b/src/session/launcher/shell.rs
@@ -1,0 +1,95 @@
+use super::shell_single_quote;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Quote {
+    None,
+    Single,
+    Double,
+}
+
+/// Values enter a separate shell through its environment, never as script text.
+/// Support ordinary shell words and quoting; reject syntax whose nested parsing
+/// would require a full shell parser to identify placeholder quote contexts.
+pub(super) fn substitute(template: &str, path: &str, base: Option<&str>) -> Result<String, String> {
+    if !template.contains("{path}") && !template.contains("{base}") {
+        return Ok(template.to_string());
+    }
+    let mut script = String::new();
+    let mut quote = Quote::None;
+    let mut rest = template;
+    while !rest.is_empty() {
+        let placeholder = if rest.starts_with("{path}") {
+            Some(("{path}", "GITPANE_LAUNCH_PATH"))
+        } else if rest.starts_with("{base}") {
+            if base.is_none() {
+                return Err("command uses {base} but no review base is available".into());
+            }
+            Some(("{base}", "GITPANE_LAUNCH_BASE"))
+        } else {
+            None
+        };
+        if let Some((token, variable)) = placeholder {
+            let expansion = format!("${{{variable}}}");
+            match quote {
+                Quote::None => script.push_str(&format!("\"{expansion}\"")),
+                Quote::Double => script.push_str(&expansion),
+                Quote::Single => script.push_str(&format!("'\"{expansion}\"'")),
+            }
+            rest = &rest[token.len()..];
+            continue;
+        }
+        let ch = rest.chars().next().expect("nonempty template remainder");
+        if quote == Quote::None
+            && ch == '#'
+            && script
+                .chars()
+                .last()
+                .is_none_or(|c| c.is_whitespace() || ";|&()".contains(c))
+        {
+            let end = rest.find('\n').unwrap_or(rest.len());
+            script.push_str(&rest[..end]);
+            rest = &rest[end..];
+            continue;
+        }
+        if quote != Quote::Single {
+            if rest.starts_with("$(")
+                || rest.starts_with("${")
+                || ch == '`'
+                || quote == Quote::None && rest.starts_with("<<")
+                || quote == Quote::None && (rest.starts_with("$'") || rest.starts_with("$\""))
+            {
+                return Err("commands with placeholders do not support nested shell substitutions, heredocs, or extended quoting; use a wrapper script".into());
+            }
+            if ch == '\\' {
+                let escaped = &rest[1..];
+                if escaped.starts_with("{path}") || escaped.starts_with("{base}") {
+                    return Err("command placeholders cannot be backslash-escaped".into());
+                }
+                let Some(next) = escaped.chars().next() else {
+                    return Err("command ends with an incomplete shell escape".into());
+                };
+                script.push(ch);
+                script.push(next);
+                rest = &escaped[next.len_utf8()..];
+                continue;
+            }
+        }
+        quote = match (quote, ch) {
+            (Quote::None, '\'') => Quote::Single,
+            (Quote::None, '"') => Quote::Double,
+            (Quote::Single, '\'') | (Quote::Double, '"') => Quote::None,
+            (current, _) => current,
+        };
+        script.push(ch);
+        rest = &rest[ch.len_utf8()..];
+    }
+    if quote != Quote::None {
+        return Err("command has an unterminated shell quote".into());
+    }
+    Ok(format!(
+        "GITPANE_LAUNCH_PATH={} GITPANE_LAUNCH_BASE={} sh -c {}",
+        shell_single_quote(path),
+        shell_single_quote(base.unwrap_or_default()),
+        shell_single_quote(&script),
+    ))
+}

--- a/src/session/launcher/tests.rs
+++ b/src/session/launcher/tests.rs
@@ -75,38 +75,17 @@ fn command_mode_runs_detached_argv() {
 fn file_launches_keep_the_parent_directory_separate_from_the_file_target() {
     let dir = "/code/my repo";
     let target = "/code/my repo/source.rs";
-    let command = "viewer '/code/my repo/source.rs'";
-    let cases = [
-        ("command", Multiplexer::None, argv(&["viewer", target])),
-        (
-            "inline",
-            Multiplexer::None,
-            LaunchPlan::Inline(command.into()),
+    assert_eq!(
+        plan_with_target(
+            Some("viewer {path}"),
+            "command",
+            dir,
+            target,
+            None,
+            Multiplexer::None
         ),
-        (
-            "split-window",
-            Multiplexer::Tmux,
-            argv(&["tmux", "split-window", "-c", dir, "sh", "-c", command]),
-        ),
-        (
-            "new-window",
-            Multiplexer::Herdr,
-            LaunchPlan::Herdr {
-                create: ["herdr", "tab", "create", "--cwd", dir, "--no-focus"]
-                    .into_iter()
-                    .map(String::from)
-                    .collect(),
-                command: Some(command.into()),
-            },
-        ),
-    ];
-    for (placement, mux, expected) in cases {
-        assert_eq!(
-            plan_with_target(Some("viewer {path}"), placement, dir, target, None, mux),
-            expected,
-            "file launch with {placement} placement"
-        );
-    }
+        argv(&["viewer", target]),
+    );
 }
 
 #[test]
@@ -189,7 +168,7 @@ fn command_mode_empty_without_tmux_errors() {
 fn tmux_placement_wraps_in_sh_c() {
     assert_eq!(
         plan(
-            Some("git diff {base}...HEAD"),
+            Some("git diff origin/main...HEAD"),
             "new-window",
             "/app",
             Some("origin/main"),
@@ -202,7 +181,7 @@ fn tmux_placement_wraps_in_sh_c() {
             "/app",
             "sh",
             "-c",
-            "git diff 'origin/main'...HEAD"
+            "git diff origin/main...HEAD"
         ])
     );
 }
@@ -236,27 +215,13 @@ fn tmux_placement_passes_flags_through() {
 fn tmux_placement_without_tmux_falls_back_to_inline() {
     assert_eq!(
         plan(
-            Some("git diff {base}...HEAD | delta"),
+            Some("git diff main...HEAD | delta"),
             "new-window",
             "/app",
             Some("main"),
             Multiplexer::None
         ),
-        LaunchPlan::Inline("git diff 'main'...HEAD | delta".to_string())
-    );
-}
-
-#[test]
-fn base_with_metacharacters_is_quoted() {
-    assert_eq!(
-        plan(
-            Some("git diff {base}...HEAD"),
-            "inline",
-            "/app",
-            Some("a;rm -rf b"),
-            Multiplexer::None
-        ),
-        LaunchPlan::Inline("git diff 'a;rm -rf b'...HEAD".to_string())
+        LaunchPlan::Inline("git diff main...HEAD | delta".to_string())
     );
 }
 
@@ -293,21 +258,6 @@ fn command_mode_blank_command_opens_tmux_pane() {
     assert_eq!(
         plan(Some("   "), "command", "/repo", None, Multiplexer::Tmux),
         argv(&["tmux", "split-window", "-c", "/repo"])
-    );
-}
-
-#[test]
-fn shell_mode_quotes_path_token() {
-    // In shell modes, {path} is shell-quoted (it reaches `sh -c`).
-    assert_eq!(
-        plan(
-            Some("cd {path} && git diff"),
-            "inline",
-            "/w t/x",
-            None,
-            Multiplexer::None
-        ),
-        LaunchPlan::Inline("cd '/w t/x' && git diff".to_string())
     );
 }
 
@@ -447,7 +397,7 @@ fn herdr_new_window_creates_a_tab() {
     // command runs in the tab's root pane via `herdr pane run`.
     assert_eq!(
         plan(
-            Some("git diff {base}...HEAD"),
+            Some("git diff origin/main...HEAD"),
             "new-window",
             "/app",
             Some("origin/main"),
@@ -458,7 +408,7 @@ fn herdr_new_window_creates_a_tab() {
                 .into_iter()
                 .map(String::from)
                 .collect(),
-            command: Some("git diff 'origin/main'...HEAD".to_string()),
+            command: Some("git diff origin/main...HEAD".to_string()),
         }
     );
 }

--- a/src/session/launcher/tests_shell.rs
+++ b/src/session/launcher/tests_shell.rs
@@ -1,0 +1,153 @@
+use super::*;
+
+fn run(command: &str, directory: &std::path::Path) -> String {
+    let output = std::process::Command::new("sh")
+        .args(["-c", command])
+        .current_dir(directory)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn shell_launches_preserve_values_in_each_quote_context_without_executing_them() {
+    let directory = tempfile::tempdir().unwrap();
+    let target = "source café ' \" $(touch INJECTED) `touch INJECTED` {base}\nfile.rs";
+    let base = "branch'\";touch INJECTED;${HOME} {path}";
+    for template in [
+        "printf '%s\\n' {path} {base}",
+        "printf '%s\\n' \"{path}\" \"{base}\"",
+        "printf '%s\\n' '{path}' '{base}'",
+        "# ignored '\" {path} ${HOME}\nprintf '%s\\n' {path} {base}",
+        "printf '%s\\n' pre{path}post 'pre{base}post'",
+    ] {
+        for (placement, mux) in [
+            ("inline", Multiplexer::None),
+            ("new-window", Multiplexer::None),
+            ("split-window", Multiplexer::Tmux),
+            ("new-window", Multiplexer::Herdr),
+        ] {
+            let dir = directory.path().to_str().unwrap();
+            let launch = plan_with_target(Some(template), placement, dir, target, Some(base), mux);
+            let command = match launch {
+                LaunchPlan::Inline(command) => command,
+                LaunchPlan::Spawn(argv) => {
+                    assert_eq!(&argv[..4], ["tmux", "split-window", "-c", dir]);
+                    assert_eq!(&argv[4..6], ["sh", "-c"]);
+                    argv[6].clone()
+                }
+                LaunchPlan::Herdr { create, command } => {
+                    assert_eq!(
+                        create,
+                        ["herdr", "tab", "create", "--cwd", dir, "--no-focus"]
+                    );
+                    command.expect("configured command")
+                }
+                other => panic!("unexpected launch: {other:?}"),
+            };
+            let expected = if template.contains("pre{path}") {
+                format!("pre{target}post\npre{base}post\n")
+            } else {
+                format!("{target}\n{base}\n")
+            };
+            assert_eq!(
+                run(&command, directory.path()),
+                expected,
+                "{template} / {placement}"
+            );
+            assert!(!directory.path().join("INJECTED").exists());
+        }
+    }
+}
+
+#[test]
+fn shell_launches_keep_working_directory_and_pipes() {
+    let directory = tempfile::tempdir().unwrap();
+    let target = directory.path().join("space ' directory");
+    std::fs::create_dir(&target).unwrap();
+    let LaunchPlan::Inline(command) = plan(
+        Some(
+            "cd \"{path}\" && printf '%s\\n' \"$PWD\" | while IFS= read -r line; do printf '%s\\n' \"$line\"; done",
+        ),
+        "inline",
+        target.to_str().unwrap(),
+        None,
+        Multiplexer::None,
+    ) else {
+        panic!("expected inline command");
+    };
+    assert_eq!(
+        run(&command, directory.path()).trim(),
+        target.to_str().unwrap()
+    );
+}
+
+#[test]
+fn shell_launches_preserve_existing_environment_and_positional_parameters() {
+    let LaunchPlan::Inline(command) = plan(
+        Some("printf '%s\\n' \"$GITPANE_TEST_VALUE\" \"$1\" \"{path}\""),
+        "inline",
+        "/tmp/repo",
+        None,
+        Multiplexer::None,
+    ) else {
+        panic!("expected inline command");
+    };
+    let output = std::process::Command::new("sh")
+        .args(["-c", &command])
+        .env("GITPANE_TEST_VALUE", "preserved")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "preserved\n\n/tmp/repo\n"
+    );
+}
+
+#[test]
+fn shell_launches_reject_ambiguous_or_incomplete_placeholder_templates() {
+    for template in [
+        "printf '%s' \\{path}",
+        "printf '%s' \"{path}",
+        "printf '%s' '{path}",
+        "printf '%s' {path} \\",
+        "printf '%s' $(printf '%s' {path})",
+        "printf '%s' `printf '%s' {path}`",
+        "printf '%s' ${HOME:-{path}}",
+        "printf '%s' $'{path}'",
+        "printf '%s' $\"{path}\"",
+        "cat <<EOF\n{path}\nEOF",
+    ] {
+        for placement in ["inline", "split-window", "ask"] {
+            assert!(
+                matches!(
+                    plan(
+                        Some(template),
+                        placement,
+                        "/tmp/repo",
+                        None,
+                        Multiplexer::Tmux
+                    ),
+                    LaunchPlan::Error(_)
+                ),
+                "accepted {template:?} with {placement}"
+            );
+        }
+    }
+    assert!(matches!(
+        plan(
+            Some("printf '%s' {base}"),
+            "inline",
+            "/tmp/repo",
+            None,
+            Multiplexer::None
+        ),
+        LaunchPlan::Error(_)
+    ));
+}

--- a/src/session/launcher/tests_shell.rs
+++ b/src/session/launcher/tests_shell.rs
@@ -17,50 +17,58 @@ fn run(command: &str, directory: &std::path::Path) -> String {
 #[test]
 fn shell_launches_preserve_values_in_each_quote_context_without_executing_them() {
     let directory = tempfile::tempdir().unwrap();
-    let target = "source café ' \" $(touch INJECTED) `touch INJECTED` {base}\nfile.rs";
-    let base = "branch'\";touch INJECTED;${HOME} {path}";
-    for template in [
-        "printf '%s\\n' {path} {base}",
-        "printf '%s\\n' \"{path}\" \"{base}\"",
-        "printf '%s\\n' '{path}' '{base}'",
-        "# ignored '\" {path} ${HOME}\nprintf '%s\\n' {path} {base}",
-        "printf '%s\\n' pre{path}post 'pre{base}post'",
+    for (target, base) in [
+        ("source$(touch INJECTED).rs", "main"),
+        ("source.rs", "base$(touch INJECTED)"),
+        (
+            "source café ' \" $(touch INJECTED) `touch INJECTED` {base}\nfile.rs",
+            "branch'\";touch INJECTED;${HOME} {path}",
+        ),
     ] {
-        for (placement, mux) in [
-            ("inline", Multiplexer::None),
-            ("new-window", Multiplexer::None),
-            ("split-window", Multiplexer::Tmux),
-            ("new-window", Multiplexer::Herdr),
+        for template in [
+            "printf '%s\\n' {path} {base}",
+            "printf '%s\\n' \"{path}\" \"{base}\"",
+            "printf '%s\\n' '{path}' '{base}'",
+            "# ignored '\" {path} ${HOME}\nprintf '%s\\n' {path} {base}",
+            "printf '%s\\n' pre{path}post 'pre{base}post'",
         ] {
-            let dir = directory.path().to_str().unwrap();
-            let launch = plan_with_target(Some(template), placement, dir, target, Some(base), mux);
-            let command = match launch {
-                LaunchPlan::Inline(command) => command,
-                LaunchPlan::Spawn(argv) => {
-                    assert_eq!(&argv[..4], ["tmux", "split-window", "-c", dir]);
-                    assert_eq!(&argv[4..6], ["sh", "-c"]);
-                    argv[6].clone()
-                }
-                LaunchPlan::Herdr { create, command } => {
-                    assert_eq!(
-                        create,
-                        ["herdr", "tab", "create", "--cwd", dir, "--no-focus"]
-                    );
-                    command.expect("configured command")
-                }
-                other => panic!("unexpected launch: {other:?}"),
-            };
-            let expected = if template.contains("pre{path}") {
-                format!("pre{target}post\npre{base}post\n")
-            } else {
-                format!("{target}\n{base}\n")
-            };
-            assert_eq!(
-                run(&command, directory.path()),
-                expected,
-                "{template} / {placement}"
-            );
-            assert!(!directory.path().join("INJECTED").exists());
+            for (placement, mux) in [
+                ("inline", Multiplexer::None),
+                ("new-window", Multiplexer::None),
+                ("split-window", Multiplexer::Tmux),
+                ("new-window", Multiplexer::Herdr),
+            ] {
+                let dir = directory.path().to_str().unwrap();
+                let launch =
+                    plan_with_target(Some(template), placement, dir, target, Some(base), mux);
+                let command = match launch {
+                    LaunchPlan::Inline(command) => command,
+                    LaunchPlan::Spawn(argv) => {
+                        assert_eq!(&argv[..4], ["tmux", "split-window", "-c", dir]);
+                        assert_eq!(&argv[4..6], ["sh", "-c"]);
+                        argv[6].clone()
+                    }
+                    LaunchPlan::Herdr { create, command } => {
+                        assert_eq!(
+                            create,
+                            ["herdr", "tab", "create", "--cwd", dir, "--no-focus"]
+                        );
+                        command.expect("configured command")
+                    }
+                    other => panic!("unexpected launch: {other:?}"),
+                };
+                let expected = if template.contains("pre{path}") {
+                    format!("pre{target}post\npre{base}post\n")
+                } else {
+                    format!("{target}\n{base}\n")
+                };
+                let output = run(&command, directory.path());
+                assert!(
+                    !directory.path().join("INJECTED").exists(),
+                    "placeholder executed shell code: {template}"
+                );
+                assert_eq!(output, expected, "{template} / {placement}");
+            }
         }
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,4 +1,6 @@
 pub(crate) mod env;
 pub(crate) mod launcher;
 pub(crate) mod liveness;
+#[cfg(windows)]
+pub(crate) mod opener;
 pub(crate) mod visibility;

--- a/src/session/opener.rs
+++ b/src/session/opener.rs
@@ -1,4 +1,4 @@
-//! Windows file associations. Paths go directly to the platform API as data.
+//! Windows file and URL associations. Targets reach the platform API as data.
 
 use std::os::windows::ffi::OsStrExt;
 use std::path::Path;
@@ -79,6 +79,19 @@ fn open_with(path: &Path, execute: impl FnOnce(&[u16]) -> isize) -> std::io::Res
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn web_links_reach_the_default_browser_with_query_parameters_intact() {
+        let url = "https://github.com/affromero/gitpane/issues/77?name=space%20here&value=%25";
+        open_with(Path::new(url), |target| {
+            assert_eq!(
+                String::from_utf16(&target[..target.len() - 1]).unwrap(),
+                url
+            );
+            33
+        })
+        .unwrap();
+    }
 
     #[test]
     fn file_association_receives_literal_unicode_and_shell_characters() {

--- a/src/session/opener.rs
+++ b/src/session/opener.rs
@@ -1,0 +1,111 @@
+//! Windows file associations. Paths go directly to the platform API as data.
+
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+use windows_sys::Win32::System::Com::{
+    COINIT_APARTMENTTHREADED, COINIT_DISABLE_OLE1DDE, CoInitializeEx, CoUninitialize,
+};
+use windows_sys::Win32::UI::Shell::ShellExecuteW;
+use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
+pub(crate) fn open(path: &Path) -> std::io::Result<()> {
+    let _apartment = ComApartment::initialize()?;
+    open_with(path, |file| {
+        // SAFETY: file is NUL-terminated and lives through the call. All
+        // optional pointers are null. No command-line parameters are passed.
+        unsafe {
+            ShellExecuteW(
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                file.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+                SW_SHOWNORMAL,
+            ) as isize
+        }
+    })
+}
+
+struct ComApartment;
+
+impl ComApartment {
+    fn initialize() -> std::io::Result<Self> {
+        // SAFETY: the reserved pointer is null. The guard balances every
+        // successful initialization on this same blocking worker thread.
+        let result = unsafe {
+            CoInitializeEx(
+                std::ptr::null(),
+                (COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE) as u32,
+            )
+        };
+        if result < 0 {
+            return Err(std::io::Error::other(format!(
+                "Windows opener COM initialization failed (HRESULT {result:#x})"
+            )));
+        }
+        Ok(Self)
+    }
+}
+
+impl Drop for ComApartment {
+    fn drop(&mut self) {
+        // SAFETY: this guard exists only after successful CoInitializeEx and
+        // never leaves the thread that owns the shell operation.
+        unsafe { CoUninitialize() };
+    }
+}
+
+fn open_with(path: &Path, execute: impl FnOnce(&[u16]) -> isize) -> std::io::Result<()> {
+    let path = crate::repo_id::boundary_path(path);
+    let mut file: Vec<u16> = path.as_os_str().encode_wide().collect();
+    if file.contains(&0) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "file path contains NUL",
+        ));
+    }
+    file.push(0);
+    let result = execute(&file);
+    if result > 32 {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!(
+            "Windows could not open {} (ShellExecute error {result})",
+            path.display()
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_association_receives_literal_unicode_and_shell_characters() {
+        let path = Path::new(r"C:\repo\日本語 & %PATH% $(echo injected).txt");
+        open_with(path, |file| {
+            assert_eq!(file.last(), Some(&0));
+            assert_eq!(
+                String::from_utf16(&file[..file.len() - 1]).unwrap(),
+                path.to_str().unwrap()
+            );
+            33
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn platform_launch_failure_is_reported() {
+        let error = open_with(Path::new(r"C:\missing.txt"), |_| 2).unwrap_err();
+        assert!(error.to_string().contains("ShellExecute error 2"));
+    }
+
+    #[test]
+    fn embedded_nul_is_rejected_before_launch() {
+        let error = open_with(Path::new("bad\0path"), |_| {
+            panic!("invalid path reached Windows")
+        })
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
+}


### PR DESCRIPTION
Refs #81 and #77

## In simple terms

Fix the safety and reliability defects found during the release audit, and require successful checks before publishing a release.

## Problem

Remote names and quoted command placeholders could change command behavior. Watcher membership could become stale, several file operations failed in valid repositories, Windows used the wrong opener, and release publication did not depend on passing checks.

## Fix

- Separate Git options from remote and branch operands. Pass shell placeholder values as data and reject unsupported template syntax.
- Rebuild watches after manual membership changes and reject outdated watcher builds.
- Use Windows file and URL associations with COM initialization for default opening, revealing, and GitHub links.
- Render nested untracked diffs, safely discard selected staged additions before the first commit, and surface failed submodule queries.
- Correct the editor configuration example and document wrapper-script argument handling.
- Test extracted Cargo source packages with fresh build targets. Require CI, documentation, security, coverage, and secret scanning before release publication.

## Test

- `just ci`: 590 passed, 1 ignored.
- Extracted source package: 590 passed, 1 ignored, both with Git and without Git.
- 14 Python tests passed; dependency audit and workflow validation passed.
- Final CI passed on Linux, macOS, and Windows, including extracted source packages. Windows ran 569 tests successfully, including the native opener boundary tests.
- Added behavioral regressions for the reported failures and expanded hook-environment isolation coverage.
- In disposable source copies with separate build artifacts, removing each of eight runtime fixes caused its regression to fail. Seven deliberately broken release dependency graphs were also rejected.
- Actual Nix builds and desktop application launches were not exercised.

Issue references are informational. Neither issue should close automatically.
